### PR TITLE
subtitles m3u fix for future VLC update

### DIFF
--- a/server/web/api/m3u.go
+++ b/server/web/api/m3u.go
@@ -101,7 +101,7 @@ func getM3uList(tor *state.TorrentStatus, host string, fromLast bool) string {
 				subs := findSubs(tor.FileStats, f)
 				if subs != nil {
 					sname := filepath.Base(subs.Path)
-					m3u += "#EXTVLCOPT:sub-file=" + host + "/stream/" + url.PathEscape(sname) + "?link=" + tor.Hash + "&index=" + fmt.Sprint(subs.Id) + "&play\n"
+					m3u += "#EXTVLCOPT:input-slave=" + host + "/stream/" + url.PathEscape(sname) + "?link=" + tor.Hash + "&index=" + fmt.Sprint(subs.Id) + "&play\n"
 				}
 				name := filepath.Base(f.Path)
 				m3u += host + "/stream/" + url.PathEscape(name) + "?link=" + tor.Hash + "&index=" + fmt.Sprint(f.Id) + "&play\n"


### PR DESCRIPTION
`sub-file` dont support HTTP sourse.
`input-slave` support `.mks`. With `.srt` and `.ass` problem, but they'll fix it eventually.
https://code.videolan.org/videolan/vlc/-/issues/25549#note_256112