### PR TITLE
correctly recognizes .mkv on Panasonic TV 2019

### DIFF
--- a/server/mimetype/mimetype.go
+++ b/server/mimetype/mimetype.go
@@ -105,7 +105,7 @@ func MimeTypeByPath(filePath string) (ret mimeType, err error) {
 	if ret == "video/mp2t" {
 		ret = "video/mpeg"
 	} else if ret == "video/x-matroska" {
-		ret = "video/mpeg"
+		ret = "video/x-matroska"
 	} else if ret == "video/x-msvideo" {
 		ret = "video/avi"
 	} else if ret == "" {


### PR DESCRIPTION
or so, but it probably doesn't make sense

else if ret == "video/x-matroska" {
		ret = "video/x-matroska"
	}