### PR TITLE
Fixed invalid torrent titles in dlna

### DIFF
--- a/server/dlna/list.go
+++ b/server/dlna/list.go
@@ -55,7 +55,7 @@ func getTorrents() (ret []interface{}) {
 			ID:          "%2F" + t.TorrentSpec.InfoHash.HexString(),
 			ParentID:    "%2FTR",
 			Restricted:  1,
-			Title:       t.Title,
+			Title:       strings.ReplaceAll(t.Title, "/", "|"),
 			Class:       "object.container.storageFolder",
 			Icon:        t.Poster,
 			AlbumArtURI: t.Poster,


### PR DESCRIPTION
Many devices doesn't support `/` in the title of objects.
In this cases, slashes are parsed as a directory separator and the file tree is broken