### PR TITLE
web: disable multiple .torrent file selection in Add new torrent dialog

### DIFF
--- a/web/src/components/Add/LeftSideComponent.jsx
+++ b/web/src/components/Add/LeftSideComponent.jsx
@@ -39,7 +39,11 @@ export default function LeftSideComponent({
   }
 
   const [isTorrentSourceActive, setIsTorrentSourceActive] = useState(false)
-  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop: handleCapture, accept: '.torrent' })
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop: handleCapture,
+    accept: '.torrent',
+    multiple: false,
+  })
 
   const handleTorrentSourceChange = ({ target: { value } }) => setTorrentSource(value)
 


### PR DESCRIPTION
Disable multiple .torrent file selection in Add new torrent dialog