### PR TITLE
Move `wipe` to server side. Add UI unsafe buttons

### DIFF
--- a/server/web/api/torrents.go
+++ b/server/web/api/torrents.go
@@ -72,6 +72,10 @@ func torrents(c *gin.Context) {
 		{
 			dropTorrent(req, c)
 		}
+	case "wipe":
+		{
+			wipeTorrents(req, c)
+		}
 	}
 }
 
@@ -182,5 +186,18 @@ func dropTorrent(req torrReqJS, c *gin.Context) {
 		return
 	}
 	torr.DropTorrent(req.Hash)
+	c.Status(200)
+}
+
+func wipeTorrents(req torrReqJS, c *gin.Context) {
+	torrents := torr.ListTorrent()
+	for _, t := range torrents {
+		torr.RemTorrent(t.TorrentSpec.InfoHash.HexString())
+	}
+	// TODO: remove (copied todo from remTorrent())
+	if set.BTsets.EnableDLNA {
+		dlna.Stop()
+		dlna.Start()
+	}
 	c.Status(200)
 }

--- a/web/src/components/CloseServer.jsx
+++ b/web/src/components/CloseServer.jsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
 import { Button, DialogActions, DialogTitle, ListItemIcon, ListItemText } from '@material-ui/core'
 import { StyledDialog, StyledMenuButtonWrapper } from 'style/CustomMaterialUiStyles'
-import { PowerSettingsNew as PowerSettingsNewIcon } from '@material-ui/icons'
+import { PowerSettingsNew as PowerSettingsNewIcon, PowerOff as PowerOffIcon } from '@material-ui/icons'
 import { shutdownHost } from 'utils/Hosts'
 import { useTranslation } from 'react-i18next'
 import { isStandaloneApp } from 'utils/Utils'
 import useOnStandaloneAppOutsideClick from 'utils/useOnStandaloneAppOutsideClick'
+import UnsafeButton from './UnsafeButton'
 
 export default function CloseServer({ isOffline, isLoading }) {
   const { t } = useTranslation()
@@ -41,7 +42,9 @@ export default function CloseServer({ isOffline, isLoading }) {
             {t('Cancel')}
           </Button>
 
-          <Button
+          <UnsafeButton
+            timeout={5}
+            startIcon={<PowerOffIcon />}
             variant='contained'
             onClick={() => {
               fetch(shutdownHost())
@@ -51,7 +54,7 @@ export default function CloseServer({ isOffline, isLoading }) {
             autoFocus
           >
             {t('TurnOff')}
-          </Button>
+          </UnsafeButton>
         </DialogActions>
       </StyledDialog>
     </>

--- a/web/src/components/RemoveAll.jsx
+++ b/web/src/components/RemoveAll.jsx
@@ -10,25 +10,12 @@ import { useTranslation } from 'react-i18next'
 const fnRemoveAll = () => {
   fetch(torrentsHost(), {
     method: 'post',
-    body: JSON.stringify({ action: 'list' }),
+    body: JSON.stringify({ action: 'wipe' }),
     headers: {
       Accept: 'application/json, text/plain, */*',
       'Content-Type': 'application/json',
     },
   })
-    .then(res => res.json())
-    .then(json => {
-      json.forEach(torr => {
-        fetch(torrentsHost(), {
-          method: 'post',
-          body: JSON.stringify({ action: 'rem', hash: torr.hash }),
-          headers: {
-            Accept: 'application/json, text/plain, */*',
-            'Content-Type': 'application/json',
-          },
-        })
-      })
-    })
 }
 
 export default function RemoveAll({ isOffline, isLoading }) {

--- a/web/src/components/RemoveAll.jsx
+++ b/web/src/components/RemoveAll.jsx
@@ -6,6 +6,7 @@ import DeleteIcon from '@material-ui/icons/Delete'
 import { useState } from 'react'
 import { torrentsHost } from 'utils/Hosts'
 import { useTranslation } from 'react-i18next'
+import UnsafeButton from './UnsafeButton'
 
 const fnRemoveAll = () => {
   fetch(torrentsHost(), {
@@ -41,7 +42,9 @@ export default function RemoveAll({ isOffline, isLoading }) {
             {t('Cancel')}
           </Button>
 
-          <Button
+          <UnsafeButton
+            timeout={5}
+            startIcon={<DeleteIcon />}
             variant='contained'
             onClick={() => {
               fnRemoveAll()
@@ -51,7 +54,7 @@ export default function RemoveAll({ isOffline, isLoading }) {
             autoFocus
           >
             {t('OK')}
-          </Button>
+          </UnsafeButton>
         </DialogActions>
       </Dialog>
     </>

--- a/web/src/components/UnsafeButton.jsx
+++ b/web/src/components/UnsafeButton.jsx
@@ -1,0 +1,26 @@
+import { Button } from '@material-ui/core';
+import { useEffect, useRef, useState } from 'react';
+
+export default function UnsafeButton({ timeout, children, disabled, ...props }) {
+    const [timeLeft, setTimeLeft] = useState(timeout || 7)
+    const [buttonDisabled, setButtonDisabled] = useState(disabled || timeLeft > 0)
+    const handleTimerTick = () => {
+        const newTimeLeft = timeLeft - 1
+        setTimeLeft(newTimeLeft)
+        if (newTimeLeft <= 0) {
+            setButtonDisabled(disabled)
+        }
+    }
+    const getTimerText = () => !disabled && timeLeft > 0 ? ` (${timeLeft})` : ''
+    useEffect(() => {
+        if (disabled || !timeLeft) { return }
+        const intervalId = setInterval(handleTimerTick, 1000)
+        return () => clearInterval(intervalId)
+    }, [timeLeft])
+
+    return (
+        <Button disabled={buttonDisabled} {...props}>
+            {children} {getTimerText()}
+        </Button>
+    )
+}


### PR DESCRIPTION
* WebUI & API: Moved _**Remove All**_ functionality to server side from WebUI. 
  * New API action for `/torrents`, payload: `{"action":"wipe"}`, extra parameters: none
  * Removed list and loop logic from `RemoveAll` WebUI component
* WebUI: Added icons to main button for _**Remove All_** and _**Turn Off**_ confirmation dialogs
* WebUI: Added a 5-second button activation delay for destructive action confirmation dialogs:
   * _**Remove All**_ (_Delete all torrents?_ confirmation dialog)
   * _**Turn Off**_ action (_Do you want to turn off server?_ confirmation dialog)

![unsafeButtonCountdown](https://github.com/YouROK/TorrServer/assets/2893566/f2aa76c6-280a-4e88-bad9-c1dc03b47af7)
