### PR TITLE
fix AddExpiredTime function

### DIFF
--- a/server/torr/torrent.go
+++ b/server/torr/torrent.go
@@ -143,7 +143,10 @@ func (t *Torrent) GotInfo() bool {
 }
 
 func (t *Torrent) AddExpiredTime(duration time.Duration) {
-	t.expiredTime = time.Now().Add(duration)
+	newExpiredTime := time.Now().Add(duration)
+	if t.expiredTime.Before(newExpiredTime) {
+		t.expiredTime = newExpiredTime
+	}
 }
 
 func (t *Torrent) watch() {


### PR DESCRIPTION
Поймал бесячий баг, когда таймаут отключения торрента больше 1 минуты. В чем суть:
1. В функции `GetTorrent` (`server/torr/apihelper.go:88`) захардкожен вызов `AddExpiredTime` с 1 минутой
2. На `Preload` (`server/torr/preload.go:67`) и `CloseReader` (`server/torr/torrent.go:255`) `AddExpiredTime` вызывается со значением из конфига.

В итоге получается, когда вызовы из пункта 1 и пункта 2 идут в произвольном порядке во времени (из-за поллингов на клиентах это легко воспроизвести даже при работе с 1 устройства, еще легче с нескольких устройств), то может возникнуть ситуация, когда торрент закроется через минуту, даже если таймаут выставлен, например, 30 минут. То есть, последним оказался вызов на `GetTorrent`.

Фикс получился простой и вроде логичный. Вряд ли ожидается, что `AddExpiredTime` может сократить время жизни торрента.