### PR TITLE
Add lock file to docker copy to avoid accidental upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REACT_APP_SERVER_HOST=$REACT_APP_SERVER_HOST
 ENV REACT_APP_TMDB_API_KEY=$REACT_APP_TMDB_API_KEY
 ENV PUBLIC_URL=$PUBLIC_URL
 
-COPY ./web/package.json .
+COPY ./web/package.json ./web/yarn.lock ./
 RUN yarn install
 
 # Build front once upon multiarch build


### PR DESCRIPTION
Recently, manual builds have been failing for me since lock file wasn't sent to docker build context and it created auto-upgrades of certain dependencies which resulted in a failed build. I do not know what are the packages that need manual upgrade and currently I do not care to know.

**Previous error**
<img width="1493" alt="Screenshot 2025-02-09 at 11 14 33 PM" src="https://github.com/user-attachments/assets/f9c9816b-927c-4b58-a728-b51d8524c7f0" />
