### PR TITLE
Use auto theme by default

### DIFF
--- a/web/src/style/materialUISetup.js
+++ b/web/src/style/materialUISetup.js
@@ -28,7 +28,7 @@ export const useMaterialUITheme = () => {
   const savedThemeMode = localStorage.getItem('themeMode')
   const isSystemModeDark = useMediaQuery('(prefers-color-scheme: dark)')
   const [isDarkMode, setIsDarkMode] = useState(savedThemeMode === 'dark' || isSystemModeDark)
-  const [currentThemeMode, setCurrentThemeMode] = useState(savedThemeMode || THEME_MODES.LIGHT)
+  const [currentThemeMode, setCurrentThemeMode] = useState(savedThemeMode || THEME_MODES.AUTO)
 
   const updateThemeMode = mode => {
     setCurrentThemeMode(mode)


### PR DESCRIPTION
I think it's better to use auto theme by default to avoid flashbangs when opening up TorrServer web ui for the first time while using an all dark theme

Makes sense to me, but may be there is another reason to force light mode