### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ docker run --rm -d --name torrserver -p 8090:8090 ghcr.io/yourok/torrserver:late
 For running in persistence mode, just mount volume to container by adding `-v ~/ts:/opt/ts`, where `~/ts` folder path is just example, but you could use it anyway... Result example command:
 
 ```bash
-docker run --rm -d --name torrserver -v ~/ts:/opt/ts -p 8090:8090 ghcr.io/yourok/torrserver:latest
+docker run --rm -d --name torrserver -v ~/ts:/opt/ts -e TS_PATH=/opt/ts -p 8090:8090 ghcr.io/yourok/torrserver:latest
 ```
 
 #### Environments
@@ -127,7 +127,7 @@ docker run --rm -d --name torrserver -v ~/ts:/opt/ts -p 8090:8090 ghcr.io/yourok
 - `TS_RDB` - if 1, then the enabling `--rdb` flag
 - `TS_DONTKILL` - if 1, then the enabling `--dontkill` flag
 - `TS_PORT` - for changind default port to **5555** (example), also u need to change `-p 8090:8090` to `-p 5555:5555` (example)
-- `TS_CONF_PATH` - for overriding torrserver config path inside container. Example `/opt/tsss`
+- `TS_PATH` - for overriding torrserver database and config dir path path inside container. Example `/opt/tsss`
 - `TS_TORR_DIR` - for overriding torrents directory. Example `/opt/torr_files`
 - `TS_LOG_PATH` - for overriding log path. Example `/opt/torrserver.log`
 

--- a/README.md
+++ b/README.md
@@ -124,12 +124,12 @@ docker run --rm -d --name torrserver -v ~/ts:/opt/ts -e TS_PATH=/opt/ts -p 8090:
 #### Environments
 
 - `TS_HTTPAUTH` - 1, and place auth file into `~/ts/config` folder for enabling basic auth
-- `TS_RDB` - if 1, then the enabling `--rdb` flag
-- `TS_DONTKILL` - if 1, then the enabling `--dontkill` flag
-- `TS_PORT` - for changind default port to **5555** (example), also u need to change `-p 8090:8090` to `-p 5555:5555` (example)
-- `TS_PATH` - for overriding torrserver database and config dir path path inside container. Example `/opt/tsss`
-- `TS_TORR_DIR` - for overriding torrents directory. Example `/opt/torr_files`
-- `TS_LOG_PATH` - for overriding log path. Example `/opt/torrserver.log`
+- `TS_RDB` - if 1, then the `--rdb` flag is enabled
+- `TS_DONTKILL` - if 1, then the `--dontkill` flag is enabled
+- `TS_PORT` - to change the default port to **5555** (example), you also need to change `-p 8090:8090` to `-p 5555:5555` (example)
+- `TS_CONF_PATH` - for overriding torrserver database and config dir path inside container. Example `/opt/ts`
+- `TS_TORR_DIR` - for overriding torrents watch directory. Example `/opt/torr_files`
+- `TS_LOG_PATH` - for overriding log file path. Example `/opt/torrserver.log`
 
 Example with full overrided command (on default values):
 


### PR DESCRIPTION
**TS_CONF_PATH** - is not present in start.sh for docker run, but it has the **TS_PATH** to override default config dir (default config dir is `/opt/torrserver` and for run with persistent volume like` /opt/ts` you should set `TS_PATH=/opt/ts`)
