### PR TITLE
[install] omit chown on plist created by the current user

### DIFF
--- a/installTorrServerMac.sh
+++ b/installTorrServerMac.sh
@@ -179,7 +179,6 @@ EOF
     sysPath="${HOME}/Library/LaunchAgents"
     [[ ! -d "$sysPath" ]] && mkdir -p ${sysPath}
     cp "$dirInstall/$serviceName.plist" $sysPath
-    sudo chown $user "$sysPath/$serviceName.plist"
     chmod 0644 "$sysPath/$serviceName.plist"
     launchctl load -w "$sysPath/$serviceName.plist" 1>/dev/null 2>&1
   else


### PR DESCRIPTION
`$serviceName.plist` is created under current user, `chown` would basically do nothing when installing only for current user