### PR TITLE
fix: mixed-content error on loading tmdb posters with https

### DIFF
--- a/web/src/components/Add/helpers.js
+++ b/web/src/components/Add/helpers.js
@@ -3,8 +3,8 @@ import parseTorrent from 'parse-torrent'
 import ptt from 'parse-torrent-title'
 
 export const getMoviePosters = (movieName, language = 'en') => {
-  const url = 'http://api.themoviedb.org/3/search/multi'
-  const imgHost = language === 'ru' ? 'http://imagetmdb.com' : 'http://image.tmdb.org' // https:
+  const url = `${window.location.protocol}//api.themoviedb.org/3/search/multi`
+  const imgHost = `${window.location.protocol}//${language === 'ru' ? 'imagetmdb.com' : 'image.tmdb.org'}`
 
   return axios
     .get(url, {


### PR DESCRIPTION
TMDB URLs now dynamically use the protocol from window.location.protocol to prevent mixed-content error when using https for torrserver.

Tested locally:

http
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/fbe0a3cc-b918-4b8d-a0af-0604c70477f7" />

https
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/632e290d-7010-46c8-92e2-8a9a8f6c793b" />

