### PR TITLE
fix ERROR: failed to build

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -18,12 +18,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -42,7 +36,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REG_REPO }}
             ghcr.io/${{ env.REG_REPO }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,59 @@
+name: Release Docker multi arch
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: set lower case owner name
+        run: |
+          echo "REG_REPO=${REPO,,}" >>${GITHUB_ENV}
+        env:
+          REPO: '${{ github.repository }}'
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REG_REPO }}
+            ghcr.io/${{ env.REG_REPO }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,16 +39,16 @@ RUN apk add --update g++ \
 && cd server \
 && go mod tidy \
 && go clean -i -r -cache \
-&& go build -ldflags '-w -s' --o "torrserver" ./cmd 
+&& go build -ldflags '-w -s' --o "torrserver" ./cmd
 ### BUILD TORRSERVER MULTIARCH END ###
 
 
 ### UPX COMPRESSING START ###
-FROM debian:buster-slim AS compressed
+FROM ubuntu AS compressed
 
 COPY --from=builder /opt/src/server/torrserver ./torrserver
 
-RUN apt-get update && apt-get install -y upx-ucl && upx --best --lzma ./torrserver
+RUN apt update && apt install -y upx-ucl && upx --best --lzma ./torrserver
 # Compress torrserver only for amd64 and arm64 no variant platforms
 # ARG TARGETARCH
 # ARG TARGETVARIANT


### PR DESCRIPTION
Замена debian:buster-slim на debian:stable-slim или ubuntu решила проблему сборки:
`ERROR: failed to build: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y upx-ucl && upx --best --lzma ./torrserver" did not complete successfully: exit code: 100`
Причина ошибки: Пакет недоступен в этом комплекте

<img width="950" height="704" alt="image" src="https://github.com/user-attachments/assets/7cae931e-734d-44e4-b34b-72aae444dd46" />


Так же добавил GHA workflow сборки latest образа для коммитов в master.

_Возможный сценарий использования:_
Можно убрать фильтр ветки и тогда образ будет создаваться для любой ветки с соответствующим тегом.
Так, например, можно завести canary/beta ветку, при сборке которой в реестре всегда будет самый свежий билд. В master ветку же направлять проверенный на работоспособность код.