### PR TITLE
change the watchTDir function

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/anacrolix/publicip v0.3.1
 	github.com/anacrolix/torrent v1.58.1
 	github.com/dustin/go-humanize v1.0.1
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gin-contrib/cors v1.7.5
 	github.com/gin-contrib/location v1.0.3
 	github.com/gin-gonic/gin v1.10.1

--- a/server/go.sum
+++ b/server/go.sum
@@ -223,6 +223,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
so that it uses the Linux kernel inotify mechanism 

### Advantages of the inotify approach
**Reactivity instead of polling:**
Instant response to changes (milliseconds instead of 5+ seconds of delay)
No delays between change detection
**Resource efficiency:**
No periodic scanning of the entire directory
Minimal CPU usage (especially important for large directories)
No I/O load when there are no changes
**Processing accuracy:**
Only changed files are processed
Possibility of filtering by event types (creation, modification, etc.)
**Scalability:**
Works equally efficiently with any number of files in a directory
Does not depend on the processing time of individual files

### Disadvantages of the inotify approach
**Complexity of event processing:**
Files can be created in parts (a delay is needed for a full write)
Events can be generated multiple times for one file
Not all file system operations are detected correctly (e.g., moving)
**Kernel limitations:**
Limit on the number of watched descriptors (/proc/sys/fs/inotify/max_user_watches)
Possible loss buffer overflow events
**File system features:**
Some network FS may not work correctly
Events for symbolic links require separate processing
**Subdirectory tracking:**
Requires recursive installation of watchers
Does not automatically track new subdirectories

tested and working on Ubuntu 25.04, cant test on android