### PR TITLE
Added Torznab integration and Rutor search support in UI

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -589,6 +589,38 @@ const docTemplate = `{
                 }
             }
         },
+        "/torznab/search": {
+            "get": {
+                "description": "Makes a torznab search.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API"
+                ],
+                "summary": "Makes a torznab search",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Torznab query",
+                        "name": "query",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Torznab torrent search result(s)",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TorrentDetails"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/viewed": {
             "post": {
                 "description": "Allow to set, list or remove viewed torrents from server.",
@@ -827,6 +859,10 @@ const docTemplate = `{
                     "description": "Rutor",
                     "type": "boolean"
                 },
+                "enableTorznabSearch": {
+                    "description": "Torznab",
+                    "type": "boolean"
+                },
                 "forceEncrypt": {
                     "description": "Torrent",
                     "type": "boolean"
@@ -877,6 +913,12 @@ const docTemplate = `{
                 "torrentsSavePath": {
                     "type": "string"
                 },
+                "torznabUrls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/settings.TorznabConfig"
+                    }
+                },
                 "uploadRateLimit": {
                     "description": "in kb, 0 - inf",
                     "type": "integer"
@@ -884,6 +926,20 @@ const docTemplate = `{
                 "useDisk": {
                     "description": "Disk",
                     "type": "boolean"
+                }
+            }
+        },
+        "settings.TorznabConfig": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -582,6 +582,38 @@
                 }
             }
         },
+        "/torznab/search": {
+            "get": {
+                "description": "Makes a torznab search.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API"
+                ],
+                "summary": "Makes a torznab search",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Torznab query",
+                        "name": "query",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Torznab torrent search result(s)",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TorrentDetails"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/viewed": {
             "post": {
                 "description": "Allow to set, list or remove viewed torrents from server.",
@@ -820,6 +852,10 @@
                     "description": "Rutor",
                     "type": "boolean"
                 },
+                "enableTorznabSearch": {
+                    "description": "Torznab",
+                    "type": "boolean"
+                },
                 "forceEncrypt": {
                     "description": "Torrent",
                     "type": "boolean"
@@ -870,6 +906,12 @@
                 "torrentsSavePath": {
                     "type": "string"
                 },
+                "torznabUrls": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/settings.TorznabConfig"
+                    }
+                },
                 "uploadRateLimit": {
                     "description": "in kb, 0 - inf",
                     "type": "integer"
@@ -877,6 +919,20 @@
                 "useDisk": {
                     "description": "Disk",
                     "type": "boolean"
+                }
+            }
+        },
+        "settings.TorznabConfig": {
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -133,6 +133,9 @@ definitions:
       enableRutorSearch:
         description: Rutor
         type: boolean
+      enableTorznabSearch:
+        description: Torznab
+        type: boolean
       forceEncrypt:
         description: Torrent
         type: boolean
@@ -170,12 +173,25 @@ definitions:
         type: integer
       torrentsSavePath:
         type: string
+      torznabUrls:
+        items:
+          $ref: '#/definitions/settings.TorznabConfig'
+        type: array
       uploadRateLimit:
         description: in kb, 0 - inf
         type: integer
       useDisk:
         description: Disk
         type: boolean
+    type: object
+  settings.TorznabConfig:
+    properties:
+      host:
+        type: string
+      key:
+        type: string
+      name:
+        type: string
     type: object
   settings.Viewed:
     properties:
@@ -718,6 +734,27 @@ paths:
         "200":
           description: OK
       summary: Handle torrents informations
+      tags:
+      - API
+  /torznab/search:
+    get:
+      description: Makes a torznab search.
+      parameters:
+      - description: Torznab query
+        in: query
+        name: query
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Torznab torrent search result(s)
+          schema:
+            items:
+              $ref: '#/definitions/models.TorrentDetails'
+            type: array
+      summary: Makes a torznab search
       tags:
       - API
   /viewed:

--- a/server/settings/btsets.go
+++ b/server/settings/btsets.go
@@ -10,6 +10,12 @@ import (
 	"server/log"
 )
 
+type TorznabConfig struct {
+	Host string
+	Key  string
+	Name string
+}
+
 type BTSets struct {
 	// Cache
 	CacheSize       int64 // in byte, def 64 MB
@@ -33,6 +39,10 @@ type BTSets struct {
 
 	// Rutor
 	EnableRutorSearch bool
+
+	// Torznab
+	EnableTorznabSearch bool
+	TorznabUrls         []TorznabConfig
 
 	// BT Config
 	EnableIPv6        bool

--- a/server/torznab/README.md
+++ b/server/torznab/README.md
@@ -1,0 +1,32 @@
+# Torznab Support for TorrServer
+
+This package implements Torznab support for TorrServer, allowing integration with indexer managers like Jackett and Prowlarr.
+
+## Features
+
+- **Search Integration**: Search for torrents directly from supported Torznab indexers.
+- **Aggregated Search**: Search across multiple configured indexers simultaneously.
+
+## Configuration
+
+Torznab settings can be configured via the Web UI under `Settings > Torznab`.
+
+### Parameters
+
+Each Torznab indexer requires the following:
+
+- **Host URL**: The full URL to the Torznab API endpoint.
+  - Example: `http://192.168.1.10:9117/api/v2.0/indexers/all/results/torznab/` (Jackett)
+  - Example: `http://localhost:9696/1/api` (Prowlarr)
+  - *Note*: Ensure the URL ends with `/` or `/api` as appropriate for your indexer manager, though the server attempts to handle pathing intelligently.
+- **API Key**: The API key provided by your Torznab indexer manager.
+
+### enabling support
+
+To enable Torznab search:
+1. Go to **Settings**.
+2. Navigate to the **Torznab** tab.
+3. Toggle **Enable Torznab Search**.
+4. Add your indexers using the "Host URL" and "API Key" fields.
+5. Click **Add Server**.
+6. **Save** your settings.

--- a/server/torznab/torznab.go
+++ b/server/torznab/torznab.go
@@ -1,0 +1,241 @@
+package torznab
+
+import (
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"server/log"
+	"server/rutor/models"
+	"server/settings"
+)
+
+type TorznabAttribute struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type TorznabEnclosure struct {
+	URL    string `xml:"url,attr"`
+	Length int64  `xml:"length,attr"`
+	Type   string `xml:"type,attr"`
+}
+
+type TorznabItem struct {
+	Title       string             `xml:"title"`
+	Link        string             `xml:"link"`
+	Description string             `xml:"description"`
+	PubDate     string             `xml:"pubDate"`
+	Size        int64              `xml:"size"`
+	Enclosure   []TorznabEnclosure `xml:"enclosure"`
+	Attributes  []TorznabAttribute `xml:"attr"`
+}
+
+type TorznabChannel struct {
+	Items []TorznabItem `xml:"item"`
+}
+
+type TorznabResponse struct {
+	Channel TorznabChannel `xml:"channel"`
+}
+
+func Search(query string, index int) []*models.TorrentDetails {
+	if !settings.BTsets.EnableTorznabSearch || len(settings.BTsets.TorznabUrls) == 0 {
+		return nil
+	}
+
+	var allResults []*models.TorrentDetails
+	if index >= 0 && index < len(settings.BTsets.TorznabUrls) {
+		config := settings.BTsets.TorznabUrls[index]
+		if config.Host != "" && config.Key != "" {
+			return searchOne(config.Host, config.Key, query)
+		}
+		return nil
+	}
+
+	for _, config := range settings.BTsets.TorznabUrls {
+		if config.Host == "" || config.Key == "" {
+			continue
+		}
+		results := searchOne(config.Host, config.Key, query)
+		if results != nil {
+			allResults = append(allResults, results...)
+		}
+	}
+	return allResults
+}
+
+func searchOne(host, key, query string) []*models.TorrentDetails {
+	if !strings.HasSuffix(host, "/") {
+		host += "/"
+	}
+
+	u, err := url.Parse(host + "api")
+	if err != nil {
+		log.TLogln("Error parsing Torznab host:", err)
+		return nil
+	}
+
+	q := u.Query()
+	q.Set("apikey", key)
+	q.Set("t", "search")
+	q.Set("q", query)
+	q.Set("cat", "5000,2000") // Movies and TV
+	u.RawQuery = q.Encode()
+
+	resp, err := http.Get(u.String())
+	if err != nil {
+		log.TLogln("Error connecting to Torznab:", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.TLogln("Torznab returned status:", resp.Status)
+		return nil
+	}
+
+	var torznabResp TorznabResponse
+	if err := xml.NewDecoder(resp.Body).Decode(&torznabResp); err != nil {
+		log.TLogln("Error decoding Torznab response:", err)
+		return nil
+	}
+
+	var results []*models.TorrentDetails
+	for _, item := range torznabResp.Channel.Items {
+		detail := &models.TorrentDetails{
+			Title:      item.Title,
+			Name:       item.Title, // Use Title as Name for now
+			Link:       item.Link,
+			CreateDate: parseDate(item.PubDate),
+		}
+
+		if len(item.Enclosure) > 0 {
+			detail.Link = item.Enclosure[0].URL
+			detail.Size = formatSize(item.Enclosure[0].Length)
+		} else {
+			detail.Size = formatSize(item.Size)
+		}
+
+		for _, attr := range item.Attributes {
+			if attr.Name == "magneturl" {
+				detail.Magnet = attr.Value
+				detail.Hash = extractHash(detail.Magnet)
+			}
+			if attr.Name == "seeders" {
+				detail.Seed, _ = strconv.Atoi(attr.Value)
+			}
+			if attr.Name == "peers" {
+				detail.Peer, _ = strconv.Atoi(attr.Value)
+			}
+		}
+
+		// Fallback if magnet not in attributes but link is a magnet
+		if detail.Magnet == "" && strings.HasPrefix(detail.Link, "magnet:") {
+			detail.Magnet = detail.Link
+			detail.Hash = extractHash(detail.Magnet)
+		}
+
+		results = append(results, detail)
+	}
+
+	return results
+}
+
+
+
+func Test(host, key string) error {
+	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
+		host = "http://" + host
+	}
+	if !strings.HasSuffix(host, "/") {
+		host += "/"
+	}
+
+	u, err := url.Parse(host + "api")
+	if err != nil {
+		return err
+	}
+
+	q := u.Query()
+	q.Set("apikey", key)
+	q.Set("t", "caps")
+	u.RawQuery = q.Encode()
+
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("status: %s", resp.Status)
+	}
+
+	var probe struct {
+		XMLName     xml.Name
+		Code        string `xml:"code,attr"`
+		Description string `xml:"description,attr"`
+	}
+
+	if err := xml.NewDecoder(resp.Body).Decode(&probe); err != nil {
+		return fmt.Errorf("invalid xml response: %v", err)
+	}
+
+	if probe.XMLName.Local == "error" {
+		msg := probe.Description
+		if msg == "" {
+			msg = probe.Code
+		}
+		return fmt.Errorf("api error: %s", msg)
+	}
+
+	if probe.XMLName.Local != "caps" {
+		return fmt.Errorf("unexpected xml root: %s", probe.XMLName.Local)
+	}
+
+	return nil
+}
+
+func parseDate(dateStr string) time.Time {
+	// RFC1123 is common in RSS
+	t, err := time.Parse(time.RFC1123, dateStr)
+	if err != nil {
+		// Try RFC1123Z
+		t, err = time.Parse(time.RFC1123Z, dateStr)
+		if err != nil {
+			return time.Now()
+		}
+	}
+	return t
+}
+
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cCiB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+func extractHash(magnet string) string {
+	if strings.HasPrefix(magnet, "magnet:?") {
+		u, err := url.Parse(magnet)
+		if err == nil {
+			xt := u.Query().Get("xt")
+			if strings.HasPrefix(xt, "urn:btih:") {
+				return strings.TrimPrefix(xt, "urn:btih:")
+			}
+		}
+	}
+	return ""
+}

--- a/server/web/api/route.go
+++ b/server/web/api/route.go
@@ -18,6 +18,7 @@ func SetupRoute(route gin.IRouter) {
 	authorized.GET("/shutdown/*reason", shutdown)
 
 	authorized.POST("/settings", settings)
+	authorized.POST("/torznab/test", torznabTest)
 
 	authorized.POST("/torrents", torrents)
 
@@ -47,6 +48,12 @@ func SetupRoute(route gin.IRouter) {
 		route.GET("/search/*query", rutorSearch)
 	} else {
 		authorized.GET("/search/*query", rutorSearch)
+	}
+
+	if config.SearchWA {
+		route.GET("/torznab/search/*query", torznabSearch)
+	} else {
+		authorized.GET("/torznab/search/*query", torznabSearch)
 	}
 
 	authorized.GET("/ffp/:hash/:id", ffp)

--- a/server/web/api/torznab.go
+++ b/server/web/api/torznab.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"server/rutor/models"
+	sets "server/settings"
+	"server/torznab"
+)
+
+// torznabSearch godoc
+//
+//	@Summary		Makes a torznab search
+//	@Description	Makes a torznab search.
+//
+//	@Tags			API
+//
+//	@Param			query	query	string	true	"Torznab query"
+//
+//	@Produce		json
+//	@Success		200	{array}	models.TorrentDetails	"Torznab torrent search result(s)"
+//	@Router			/torznab/search [get]
+func torznabSearch(c *gin.Context) {
+	if !sets.BTsets.EnableTorznabSearch {
+		c.JSON(http.StatusBadRequest, []string{})
+		return
+	}
+	query := c.Query("query")
+	indexStr := c.DefaultQuery("index", "-1")
+	index := -1
+	if i, err := strconv.Atoi(indexStr); err == nil {
+		index = i
+	}
+
+	query, _ = url.QueryUnescape(query)
+	list := torznab.Search(query, index)
+	if list == nil {
+		list = []*models.TorrentDetails{}
+	}
+	c.JSON(200, list)
+}
+
+type torznabTestReq struct {
+	Host string `json:"host"`
+	Key  string `json:"key"`
+}
+
+func torznabTest(c *gin.Context) {
+	var req torznabTestReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	if err := torznab.Test(req.Host, req.Key); err != nil {
+		c.JSON(200, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+	c.JSON(200, gin.H{"success": true})
+}

--- a/web/src/components/Add/TorznabSearch.jsx
+++ b/web/src/components/Add/TorznabSearch.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react'
+import { TextField, Button, List, ListItem, ListItemText, CircularProgress, Typography, Divider, ListItemSecondaryAction, IconButton } from '@material-ui/core'
+import { useTranslation } from 'react-i18next'
+import axios from 'axios'
+import { torznabSearchHost } from 'utils/Hosts'
+import { AddCircleOutline as AddIcon } from '@material-ui/icons'
+
+export default function TorznabSearch({ onSelect }) {
+    const { t } = useTranslation()
+    const [query, setQuery] = useState('')
+    const [results, setResults] = useState([])
+    const [loading, setLoading] = useState(false)
+    const [searched, setSearched] = useState(false)
+
+    const handleSearch = async () => {
+        if (!query) return
+        setLoading(true)
+        setSearched(true)
+        try {
+            const { data } = await axios.get(torznabSearchHost(), { params: { query } })
+            setResults(data || [])
+        } catch (error) {
+            console.error(error)
+            setResults([])
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            handleSearch()
+        }
+    }
+
+    return (
+        <div style={{ marginTop: '1.5em' }}>
+            <div style={{ display: 'flex', gap: '8px' }}>
+                <TextField
+                    label={t('Search Torznab')}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    variant="outlined"
+                    size="small"
+                    fullWidth
+                    placeholder={t('Search movies, shows...')}
+                />
+                <Button variant="contained" color="primary" onClick={handleSearch} disabled={loading} style={{ minWidth: '80px' }}>
+                    {loading ? <CircularProgress size={24} color="inherit" /> : t('Search')}
+                </Button>
+            </div>
+            {searched && (
+                <div style={{ maxHeight: '200px', overflowY: 'auto', marginTop: '8px', border: '1px solid rgba(0,0,0,0.12)', borderRadius: '4px' }}>
+                    {results.length === 0 ? (
+                        <div style={{ padding: '8px', textAlign: 'center' }}>
+                            <Typography variant="body2">{loading ? t('Searching...') : t('No results found')}</Typography>
+                        </div>
+                    ) : (
+                        <List dense>
+                            {results.map((item, index) => (
+                                <React.Fragment key={item.Hash || item.Link || index}>
+                                    <ListItem button onClick={() => onSelect(item.Magnet || item.Link)}>
+                                        <ListItemText
+                                            primary={item.Title}
+                                            secondary={`${item.Size} • S:${item.Seed} P:${item.Peer}`}
+                                            primaryTypographyProps={{ noWrap: true, style: { fontSize: '0.9rem' } }}
+                                        />
+                                        <ListItemSecondaryAction>
+                                            <IconButton edge="end" aria-label="add" onClick={() => onSelect(item.Magnet || item.Link)}>
+                                                <AddIcon />
+                                            </IconButton>
+                                        </ListItemSecondaryAction>
+                                    </ListItem>
+                                    <Divider />
+                                </React.Fragment>
+                            ))}
+                        </List>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/web/src/components/App/Sidebar.jsx
+++ b/web/src/components/App/Sidebar.jsx
@@ -10,6 +10,7 @@ import SettingsDialog from 'components/Settings'
 import RemoveAll from 'components/RemoveAll'
 import AboutDialog from 'components/About'
 import CloseServer from 'components/CloseServer'
+import SearchDialogButton from 'components/Search'
 import { memo } from 'react'
 import CheckIcon from '@material-ui/icons/Check'
 import ClearIcon from '@material-ui/icons/Clear'
@@ -25,6 +26,7 @@ const Sidebar = ({ isDrawerOpen, setIsDonationDialogOpen, isOffline, isLoading, 
     <AppSidebarStyle isDrawerOpen={isDrawerOpen}>
       <List>
         <AddDialogButton isOffline={isOffline} isLoading={isLoading} />
+        <SearchDialogButton isOffline={isOffline} isLoading={isLoading} />
 
         <RemoveAll isOffline={isOffline} isLoading={isLoading} />
       </List>

--- a/web/src/components/Search/SearchDialog.jsx
+++ b/web/src/components/Search/SearchDialog.jsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect } from 'react'
+import {
+    TextField,
+    Button,
+    List,
+    ListItem,
+    ListItemText,
+    CircularProgress,
+    Typography,
+    Divider,
+    ListItemSecondaryAction,
+    IconButton,
+    Snackbar,
+    useMediaQuery,
+    Select,
+    MenuItem,
+    FormControl,
+    InputLabel
+} from '@material-ui/core'
+import { useTranslation } from 'react-i18next'
+import axios from 'axios'
+import { torznabSearchHost, torrentsHost, settingsHost } from 'utils/Hosts'
+import { AddCircleOutline as AddIcon, CloudDownload as DownloadIcon } from '@material-ui/icons'
+import { StyledDialog, StyledHeader } from 'style/CustomMaterialUiStyles'
+import { Content } from './style'
+import useOnStandaloneAppOutsideClick from 'utils/useOnStandaloneAppOutsideClick'
+
+export default function SearchDialog({ handleClose }) {
+    const { t } = useTranslation()
+    const [query, setQuery] = useState('')
+    const [results, setResults] = useState([])
+    const [loading, setLoading] = useState(false)
+    const [searched, setSearched] = useState(false)
+    const [adding, setAdding] = useState(false)
+    const [successMsg, setSuccessMsg] = useState('')
+    const [errorMsg, setErrorMsg] = useState('')
+    const [trackers, setTrackers] = useState([])
+    const [selectedTracker, setSelectedTracker] = useState(-1)
+
+    const fullScreen = useMediaQuery('@media (max-width:930px)')
+    const ref = useOnStandaloneAppOutsideClick(handleClose)
+
+    useEffect(() => {
+        axios.post(settingsHost(), { action: 'get' }).then(({ data }) => {
+            if (data && data.TorznabUrls) {
+                setTrackers(data.TorznabUrls)
+            }
+        }).catch(console.error)
+    }, [])
+
+    const handleSearch = async () => {
+        if (!query) return
+        setLoading(true)
+        setSearched(true)
+        setResults([])
+        try {
+            const params = { query }
+            if (selectedTracker !== -1) {
+                params.index = selectedTracker
+            }
+            const { data } = await axios.get(torznabSearchHost(), { params })
+            setResults(data || [])
+        } catch (error) {
+            console.error(error)
+            setErrorMsg(t('Search failed'))
+        } finally {
+            setLoading(false)
+        }
+    }
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            handleSearch()
+        }
+    }
+
+    const handleAdd = async (item) => {
+        setAdding(true)
+        try {
+            const link = item.Magnet || item.Link
+            if (!link) {
+                setErrorMsg(t('No link found'))
+                return
+            }
+            await axios.post(torrentsHost(), {
+                action: 'add',
+                link,
+                title: item.Title,
+                save_to_db: true,
+                poster: item.Poster
+            })
+            setSuccessMsg(t('Torrent added successfully'))
+        } catch (error) {
+            console.error(error)
+            setErrorMsg(t('Failed to add torrent'))
+        } finally {
+            setAdding(false)
+        }
+    }
+
+    const handleAlertClose = (event, reason) => {
+        if (reason === 'clickaway') {
+            return
+        }
+        setSuccessMsg('')
+        setErrorMsg('')
+    }
+
+    return (
+        <StyledDialog open onClose={handleClose} fullScreen={fullScreen} fullWidth maxWidth="md" ref={ref}>
+            <StyledHeader>
+                {t('Search Torrents')}
+            </StyledHeader>
+            <Content>
+                <div style={{ padding: '20px' }}>
+                    <div style={{ display: 'flex', gap: '8px', marginBottom: '20px', alignItems: 'flex-start', flexWrap: fullScreen ? 'wrap' : 'nowrap' }}>
+                        <FormControl variant="outlined" size="small" style={{ minWidth: 150, flex: fullScreen ? '1 1 100%' : '0 0 auto' }}>
+                            <InputLabel>Tracker</InputLabel>
+                            <Select
+                                value={selectedTracker}
+                                onChange={(e) => setSelectedTracker(e.target.value)}
+                                label="Tracker"
+                            >
+                                <MenuItem value={-1}>All Trackers</MenuItem>
+                                {trackers.map((tracker, index) => (
+                                    <MenuItem key={`${tracker.Host}-${tracker.Key}`} value={index}>
+                                        {tracker.Name || tracker.Host}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                        <TextField
+                            label={t('Search Torznab')}
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            variant="outlined"
+                            size="small"
+                            fullWidth
+                            placeholder={t('Search movies, shows...')}
+                            autoFocus
+                        />
+                        <Button
+                            variant="contained"
+                            color="primary"
+                            onClick={handleSearch}
+                            disabled={loading}
+                            style={{ minWidth: fullScreen ? '80px' : '100px', height: '40px' }}
+                        >
+                            {loading ? <CircularProgress size={24} color="inherit" /> : t('Search')}
+                        </Button>
+                    </div>
+
+                    <div style={{ overflowY: 'auto', maxHeight: 'calc(100vh - 200px)' }}>
+                        {searched && results.length === 0 && !loading && (
+                            <Typography align="center" variant="body1" color="textSecondary">
+                                {t('No results found')}
+                            </Typography>
+                        )}
+
+                        <List>
+                            {results.map((item, index) => (
+                                <div key={item.Hash || item.Link || index}>
+                                    <ListItem button onClick={() => handleAdd(item)}>
+                                        <ListItemText
+                                            primary={item.Title}
+                                            secondary={
+                                                <>
+                                                    <Typography component="span" variant="body2" color="textPrimary">
+                                                        {item.Size}
+                                                    </Typography>
+                                                    {` • S: ${item.Seed} P: ${item.Peer}`}
+                                                </>
+                                            }
+                                        />
+                                        <ListItemSecondaryAction>
+                                            <IconButton edge="end" aria-label="add" onClick={() => handleAdd(item)} disabled={adding}>
+                                                <DownloadIcon color="secondary" />
+                                            </IconButton>
+                                        </ListItemSecondaryAction>
+                                    </ListItem>
+                                    <Divider component="li" />
+                                </div>
+                            ))}
+                        </List>
+                    </div>
+                </div>
+            </Content>
+
+            <Snackbar
+                open={!!successMsg}
+                autoHideDuration={3000}
+                onClose={handleAlertClose}
+                message={successMsg}
+            />
+            <Snackbar
+                open={!!errorMsg}
+                autoHideDuration={3000}
+                onClose={handleAlertClose}
+                message={errorMsg}
+            />
+
+            <div style={{ padding: '16px', display: 'flex', justifyContent: 'flex-end', borderTop: '1px solid rgba(0,0,0,0.12)' }}>
+                <Button onClick={handleClose} color="secondary" variant="outlined">
+                    {t('Close')}
+                </Button>
+            </div>
+
+        </StyledDialog>
+    )
+}

--- a/web/src/components/Search/index.jsx
+++ b/web/src/components/Search/index.jsx
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+import ListItemIcon from '@material-ui/core/ListItemIcon'
+import SearchIcon from '@material-ui/icons/Search'
+import ListItemText from '@material-ui/core/ListItemText'
+import ListItem from '@material-ui/core/ListItem'
+import { useTranslation } from 'react-i18next'
+import SearchDialog from './SearchDialog'
+
+export default function SearchDialogButton({ isOffline, isLoading }) {
+    const { t } = useTranslation()
+    const [isDialogOpen, setIsDialogOpen] = useState(false)
+    const handleClickOpen = () => setIsDialogOpen(true)
+    const handleClose = () => setIsDialogOpen(false)
+
+    return (
+        <>
+            <ListItem button onClick={handleClickOpen} disabled={isOffline || isLoading}>
+                <ListItemIcon>
+                    <SearchIcon />
+                </ListItemIcon>
+                <ListItemText primary={t('Search')} />
+            </ListItem>
+
+            {isDialogOpen && <SearchDialog handleClose={handleClose} />}
+        </>
+    )
+}

--- a/web/src/components/Search/style.js
+++ b/web/src/components/Search/style.js
@@ -1,0 +1,21 @@
+import styled, { css } from 'styled-components'
+
+export const Content = styled.div`
+  ${({
+    isLoading,
+    theme: {
+        settingsDialog: { contentBG },
+    },
+}) => css`
+    background: ${contentBG};
+    overflow: auto;
+    flex: 1;
+
+    ${isLoading &&
+    css`
+      min-height: 500px;
+      display: grid;
+      place-items: center;
+    `}
+  `}
+`

--- a/web/src/components/Settings/SettingsDialog.jsx
+++ b/web/src/components/Settings/SettingsDialog.jsx
@@ -20,6 +20,7 @@ import { a11yProps, TabPanel } from './tabComponents'
 import PrimarySettingsComponent from './PrimarySettingsComponent'
 import SecondarySettingsComponent from './SecondarySettingsComponent'
 import MobileAppSettings from './MobileAppSettings'
+import TorznabSettings from './TorznabSettings'
 
 export default function SettingsDialog({ handleClose }) {
   const { t } = useTranslation()
@@ -121,6 +122,8 @@ export default function SettingsDialog({ handleClose }) {
         >
           <Tab label={t('SettingsDialog.Tabs.Main')} {...a11yProps(0)} />
 
+          <Tab label="Torznab" {...a11yProps(1)} />
+
           <Tab
             disabled={!isProMode}
             label={
@@ -129,10 +132,10 @@ export default function SettingsDialog({ handleClose }) {
                 {!isProMode && <div style={{ fontSize: '9px' }}>{t('SettingsDialog.Tabs.AdditionalDisabled')}</div>}
               </>
             }
-            {...a11yProps(1)}
+            {...a11yProps(2)}
           />
 
-          {isStandaloneApp && <Tab label={t('SettingsDialog.Tabs.App')} {...a11yProps(2)} />}
+          {isStandaloneApp && <Tab label={t('SettingsDialog.Tabs.App')} {...a11yProps(3)} />}
         </Tabs>
       </AppBar>
 
@@ -160,11 +163,15 @@ export default function SettingsDialog({ handleClose }) {
               </TabPanel>
 
               <TabPanel value={selectedTab} index={1} dir={direction}>
-                <SecondarySettingsComponent settings={settings} inputForm={inputForm} />
+                <TorznabSettings settings={settings} inputForm={inputForm} updateSettings={updateSettings} />
+              </TabPanel>
+
+              <TabPanel value={selectedTab} index={2} dir={direction}>
+                <SecondarySettingsComponent settings={settings} inputForm={inputForm} updateSettings={updateSettings} />
               </TabPanel>
 
               {isStandaloneApp && (
-                <TabPanel value={selectedTab} index={2} dir={direction}>
+                <TabPanel value={selectedTab} index={3} dir={direction}>
                   <MobileAppSettings
                     isVlcUsed={isVlcUsed}
                     setIsVlcUsed={setIsVlcUsed}

--- a/web/src/components/Settings/TorznabSettings.jsx
+++ b/web/src/components/Settings/TorznabSettings.jsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+    FormControlLabel,
+    FormGroup,
+    FormHelperText,
+    Switch,
+    TextField,
+    Button,
+    List,
+    ListItem,
+    ListItemText,
+    ListItemSecondaryAction,
+    IconButton,
+    Typography
+} from '@material-ui/core'
+import DeleteIcon from '@material-ui/icons/Delete'
+import { SettingSectionLabel } from './style'
+import axios from 'axios'
+import { torznabTestHost } from 'utils/Hosts'
+import CircularProgress from '@material-ui/core/CircularProgress'
+
+export default function TorznabSettings({ settings, inputForm, updateSettings }) {
+    const { t } = useTranslation()
+    const { EnableTorznabSearch, TorznabUrls } = settings || {}
+    const [newHost, setNewHost] = useState('')
+    const [newKey, setNewKey] = useState('')
+    const [newName, setNewName] = useState('')
+    const [testing, setTesting] = useState(false)
+    const [testResult, setTestResult] = useState(null)
+
+    const handleAdd = () => {
+        if (newHost && newKey) {
+            const currentUrls = TorznabUrls || []
+            updateSettings({
+                TorznabUrls: [...currentUrls, { Host: newHost, Key: newKey, Name: newName }]
+            })
+            setNewHost('')
+            setNewKey('')
+            setNewName('')
+        }
+    }
+
+    const handleDelete = (index) => {
+        const currentUrls = TorznabUrls || []
+        const newUrls = [...currentUrls]
+        newUrls.splice(index, 1)
+        updateSettings({
+            TorznabUrls: newUrls
+        })
+    }
+
+    const handleTest = async () => {
+        setTesting(true)
+        setTestResult(null)
+        try {
+            const { data } = await axios.post(torznabTestHost(), {
+                host: newHost,
+                key: newKey
+            })
+            if (data.success) {
+                setTestResult({ success: true, msg: 'Connection successful' })
+            } else {
+                setTestResult({ success: false, msg: data.error })
+            }
+        } catch (e) {
+            setTestResult({ success: false, msg: e.message })
+        }
+        setTesting(false)
+    }
+
+    return (
+        <>
+            <SettingSectionLabel>Torznab</SettingSectionLabel>
+            <FormGroup>
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={EnableTorznabSearch || false}
+                            onChange={inputForm}
+                            id='EnableTorznabSearch'
+                            color='secondary'
+                        />
+                    }
+                    label='Enable Torznab Search'
+                    labelPlacement='start'
+                />
+                <FormHelperText margin='none'>Enable search via Torznab indexers (e.g. Jackett, Prowlarr)</FormHelperText>
+            </FormGroup>
+
+            <div style={{ marginTop: 10, paddingLeft: 10, opacity: EnableTorznabSearch ? 1 : 0.5, pointerEvents: EnableTorznabSearch ? 'auto' : 'none' }}>
+                <List dense>
+                    {(TorznabUrls || []).map((url, index) => (
+                        <ListItem key={`${url.Host}-${url.Key}`}>
+                            <ListItemText
+                                primary={url.Name || url.Host}
+                                secondary={
+                                    <>
+                                        {url.Name && <Typography component="span" variant="body2" display="block" color="textSecondary">{url.Host}</Typography>}
+                                        {`Key: ${url.Key.substring(0, 5)}...`}
+                                    </>
+                                }
+                            />
+                            <ListItemSecondaryAction>
+                                <IconButton edge="end" aria-label="delete" onClick={() => handleDelete(index)}>
+                                    <DeleteIcon />
+                                </IconButton>
+                            </ListItemSecondaryAction>
+                        </ListItem>
+                    ))}
+                </List>
+
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginTop: 10 }}>
+                    <TextField
+                        label="Name (Optional)"
+                        value={newName}
+                        onChange={(e) => setNewName(e.target.value)}
+                        placeholder="My Tracker"
+                        variant="outlined"
+                        size="small"
+                    />
+                    <TextField
+                        label="Torznab Host URL"
+                        value={newHost}
+                        onChange={(e) => setNewHost(e.target.value)}
+                        placeholder="http://localhost:9117"
+                        variant="outlined"
+                        size="small"
+                    />
+                    <TextField
+                        label="API Key"
+                        value={newKey}
+                        onChange={(e) => setNewKey(e.target.value)}
+                        variant="outlined"
+                        size="small"
+                    />
+                    <div style={{ display: 'flex', marginTop: 10 }}>
+                        <Button
+                            variant="outlined"
+                            color="secondary"
+                            onClick={handleTest}
+                            disabled={!newHost || !newKey || testing}
+                            style={{ marginRight: 10 }}
+                        >
+                            {testing ? <CircularProgress size={24} color="inherit" /> : 'Test'}
+                        </Button>
+                        <Button variant="contained" color="secondary" onClick={handleAdd} disabled={!newHost || !newKey}>
+                            Add Server
+                        </Button>
+                    </div>
+                    {testResult && (
+                        <Typography variant="caption" style={{ color: testResult.success ? 'green' : 'red' }}>
+                            {testResult.msg}
+                        </Typography>
+                    )}
+                </div>
+            </div>
+            <br />
+        </>
+    )
+}

--- a/web/src/utils/Hosts.js
+++ b/web/src/utils/Hosts.js
@@ -12,6 +12,7 @@ export const shutdownHost = () => `${torrserverHost}/shutdown`
 export const echoHost = () => `${torrserverHost}/echo`
 export const playlistTorrHost = () => `${torrserverHost}/stream`
 export const torznabSearchHost = () => `${torrserverHost}/torznab/search`
+export const searchHost = () => `${torrserverHost}/search`
 export const torznabTestHost = () => `${torrserverHost}/torznab/test`
 
 export const getTorrServerHost = () => torrserverHost

--- a/web/src/utils/Hosts.js
+++ b/web/src/utils/Hosts.js
@@ -11,6 +11,8 @@ export const streamHost = () => `${torrserverHost}/stream`
 export const shutdownHost = () => `${torrserverHost}/shutdown`
 export const echoHost = () => `${torrserverHost}/echo`
 export const playlistTorrHost = () => `${torrserverHost}/stream`
+export const torznabSearchHost = () => `${torrserverHost}/torznab/search`
+export const torznabTestHost = () => `${torrserverHost}/torznab/test`
 
 export const getTorrServerHost = () => torrserverHost
 export const setTorrServerHost = host => {


### PR DESCRIPTION
# Torznab Support for TorrServer

This PR implements Torznab support for TorrServer, allowing integration with indexer managers like Jackett and Prowlarr.

## Features

- **Search Integration**: Search for torrents directly from supported Torznab indexers.
- **Aggregated Search**: Search across multiple configured indexers simultaneously.

## Configuration

Torznab settings can be configured via the Web UI under `Settings > Torznab`.

### Parameters

Each Torznab indexer requires the following:

- **Host URL**: The full URL to the Torznab API endpoint.
  - Example: `http://192.168.1.10:9117/api/v2.0/indexers/all/results/torznab/` (Jackett)
  - Example: `http://localhost:9696/1/api` (Prowlarr)
  - *Note*: Ensure the URL ends with `/` or `/api` as appropriate for your indexer manager, though the server attempts to handle pathing intelligently.
- **API Key**: The API key provided by your Torznab indexer manager.