### PR TITLE
Add proxy support for BitTorrent traffic

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
 FLAGS="--path $TS_CONF_PATH --logpath $TS_LOG_PATH --port $TS_PORT --torrentsdir $TS_TORR_DIR"
+if [[ ! -z "$TS_IP" ]]; then FLAGS="${FLAGS} -i ${TS_IP}"; fi
 if [[ "$TS_HTTPAUTH" -eq 1 ]]; then FLAGS="${FLAGS} --httpauth"; fi
 if [[ "$TS_RDB" -eq 1 ]]; then FLAGS="${FLAGS} --rdb"; fi
 if [[ "$TS_DONTKILL" -eq 1 ]]; then FLAGS="${FLAGS} --dontkill"; fi
 if [[ "$TS_EN_SSL" -eq 1 ]]; then FLAGS="${FLAGS} --ssl"; fi
 if [[ -v "$TS_SSL_PORT" ]]; then FLAGS="${FLAGS} --sslport ${TS_SSL_PORT}"; fi
-
+if [[ ! -z "$TS_PROXY" ]]; then FLAGS="${FLAGS} --proxy ${TS_PROXY}"; fi
+if [[ ! -z "$TS_PROXYMODE" ]]; then FLAGS="${FLAGS} --proxymode ${TS_PROXYMODE}"; fi
 
 if [ ! -d $TS_CONF_PATH ]; then
   mkdir -p $TS_CONF_PATH

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -48,6 +48,8 @@ type args struct {
 	TGToken     string `arg:"-T" help:"telegram bot token"`
 	FusePath    string `arg:"-f" help:"fuse mount path"`
 	WebDAV      bool   `help:"web dav enable"`
+	Proxy       string `help:"proxy URL for BitTorrent traffic (http, socks4, socks5, socks5h), e.g. socks5://user:password@127.0.0.1:8080"`
+	ProxyMode   string `help:"proxy mode: tracker (only HTTP trackers, default), peers (only peer connections), or full (all traffic)"`
 }
 
 func (args) Version() string {
@@ -136,6 +138,19 @@ func main() {
 		}
 	}
 
+	if params.Proxy != "" {
+		settings.ProxyURL = params.Proxy
+		settings.ProxyMode = params.ProxyMode
+		if settings.ProxyMode == "" {
+			settings.ProxyMode = "tracker" // default
+		}
+		// Update BTsets if already loaded
+		if settings.BTsets != nil {
+			settings.BTsets.ProxyURL = params.Proxy
+			settings.BTsets.ProxyMode = settings.ProxyMode
+		}
+	}
+
 	settings.Args = &settings.ExecArgs{
 		Port:        params.Port,
 		IP:          params.IP,
@@ -159,6 +174,12 @@ func main() {
 		TGToken:     params.TGToken,
 		FusePath:    params.FusePath,
 		WebDAV:      params.WebDAV,
+		Proxy:       params.Proxy,
+		ProxyMode:   params.ProxyMode,
+	}
+
+	if params.Proxy != "" {
+		log.TLogln("Proxy configured from CLI:", params.Proxy, "mode:", settings.ProxyMode)
 	}
 
 	server.Start()

--- a/server/settings/args.go
+++ b/server/settings/args.go
@@ -23,6 +23,8 @@ type ExecArgs struct {
 	TGToken     string
 	FusePath    string
 	WebDAV      bool
+	Proxy       string
+	ProxyMode   string
 }
 
 var Args *ExecArgs

--- a/server/settings/btsets.go
+++ b/server/settings/btsets.go
@@ -72,6 +72,10 @@ type BTSets struct {
 	// Storage preferences
 	StoreSettingsInJson bool
 	StoreViewedInJson   bool
+
+	// Proxy
+	ProxyURL  string // Proxy URL for BitTorrent traffic (http, socks4, socks5, socks5h)
+	ProxyMode string // tracker (HTTP trackers only, default), peers (peer connections only), or full (all traffic)
 }
 
 func (v *BTSets) String() string {
@@ -108,6 +112,14 @@ func SetBTSets(sets *BTSets) {
 	}
 	if sets.PreloadCache > 100 {
 		sets.PreloadCache = 100
+	}
+
+	if sets.ProxyURL != "" && sets.ProxyMode == "" {
+		sets.ProxyMode = "tracker" // default
+	}
+	if sets.ProxyMode != "" && sets.ProxyMode != "tracker" && sets.ProxyMode != "peers" && sets.ProxyMode != "full" {
+		log.TLogln("Invalid proxy mode, using default 'tracker'")
+		sets.ProxyMode = "tracker"
 	}
 
 	if sets.TorrentsSavePath == "" {

--- a/server/settings/settings.go
+++ b/server/settings/settings.go
@@ -22,19 +22,21 @@ func IsDebug() bool {
 }
 
 var (
-	tdb      TorrServerDB
-	Path     string
-	IP       string
-	Port     string
-	Ssl      bool
-	SslPort  string
-	ReadOnly bool
-	HttpAuth bool
-	SearchWA bool
-	PubIPv4  string
-	PubIPv6  string
-	TorAddr  string
-	MaxSize  int64
+	tdb       TorrServerDB
+	Path      string
+	IP        string
+	Port      string
+	Ssl       bool
+	SslPort   string
+	ReadOnly  bool
+	HttpAuth  bool
+	SearchWA  bool
+	PubIPv4   string
+	PubIPv6   string
+	TorAddr   string
+	MaxSize   int64
+	ProxyURL  string
+	ProxyMode string
 )
 
 func InitSets(readOnly, searchWA bool) {


### PR DESCRIPTION
Introduces proxy configuration for BitTorrent traffic via new CLI arguments and environment variables, supporting http, socks4, socks5, and socks5h protocols. Allows selection of proxy mode (tracker, peers, or full) and integrates proxy settings into the server configuration and BTsets. Updates Docker entrypoint, main server logic, and BTServer to handle and validate proxy settings.

==RU:
Добавил возможность указать прокси сервер, 3 режима:
1. tracker - проксирует http запросы к трекерам, полезно если доступ к трекерам заблокирован
2. peers - только соединения для загрузки, может быть полезно против обнаружения загрузки контента
3. full - проксировать весь трафик

Для docker env:
TS_PROXY=socks5h://user:password@example.com:2080 #proxy URL for BitTorrent traffic (http, socks4, socks5, socks5h), e.g. socks5://user:password@127.0.0.1:8080
TS_PROXYMODE=tracker #proxy mode: tracker (only HTTP trackers, default), peers (only peer connections), or full (all traffic)
Для аргументов:
--proxy
--proxymode
Соответственно.
Для docker добавил возможность установки IP адреса веб панели через environment:
TS_IP=127.0.0.1
Полезно если контейнер в режиме host, но веб панель проксируется другим сервисом

PS: В веб панель вносить изменения не стал, не уверен что в этом есть необходимость, на усмотрение комьюнити можно добавить