### PR TITLE
Add proxy URL and mode options to docs and entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ On FreeBSD (TrueNAS/FreeNAS) you can use this plugin: <https://github.com/filka9
 - `--tg TGTOKEN`, `-T TGTOKEN` - telegram bot token
 - `--fuse FUSEPATH`, `-f FUSEPATH` - fuse mount path
 - `--webdav` - enable web dav
+- `--proxyurl PROXYURL` - set proxy URL for BitTorrent traffic (http, socks4, socks5, socks5h), example: socks5h://user:password@example.com:2080
+- `--proxymode PROXYMODE` - set proxy mode: "tracker" (only HTTP trackers, default), "peers" (only peer connections), or "full" (all traffic)
 - `--help`, `-h` - display this help and exit
 - `--version` - display version and exit
 
@@ -211,11 +213,13 @@ docker run --rm -d --name torrserver -v ~/ts:/opt/ts -p 8090:8090 ghcr.io/yourok
 - `TS_CONF_PATH` - for overriding torrserver config path inside container. Example `/opt/tsss`
 - `TS_TORR_DIR` - for overriding torrents directory. Example `/opt/torr_files`
 - `TS_LOG_PATH` - for overriding log path. Example `/opt/torrserver.log`
+- `TS_PROXYURL` - set proxy URL for BitTorrent traffic (http, socks4, socks5, socks5h), example: socks5h://user:password@example.com:2080
+- `TS_PROXYMODE` - set proxy mode: "tracker" (only HTTP trackers, default), "peers" (only peer connections), or "full" (all traffic)
 
 Example with full overrided command (on default values):
 
 ```bash
-docker run --rm -d -e TS_PORT=5665 -e TS_DONTKILL=1 -e TS_HTTPAUTH=1 -e TS_RDB=1 -e TS_CONF_PATH=/opt/ts/config -e TS_LOG_PATH=/opt/ts/log -e TS_TORR_DIR=/opt/ts/torrents --name torrserver -v ~/ts:/opt/ts -p 5665:5665 ghcr.io/yourok/torrserver:latest
+docker run --rm -d -e TS_PORT=5665 -e TS_DONTKILL=1 -e TS_HTTPAUTH=1 -e TS_RDB=1 -e TS_CONF_PATH=/opt/ts/config -e TS_LOG_PATH=/opt/ts/log -e TS_TORR_DIR=/opt/ts/torrents -e TS_PROXYURL=socks5h://user:password@example.com:2080 -e TS_PROXYMODE=tracker --name torrserver -v ~/ts:/opt/ts -p 5665:5665 ghcr.io/yourok/torrserver:latest
 ```
 
 #### Docker Compose

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,7 @@ if [[ "$TS_RDB" -eq 1 ]]; then FLAGS="${FLAGS} --rdb"; fi
 if [[ "$TS_DONTKILL" -eq 1 ]]; then FLAGS="${FLAGS} --dontkill"; fi
 if [[ "$TS_EN_SSL" -eq 1 ]]; then FLAGS="${FLAGS} --ssl"; fi
 if [[ -v "$TS_SSL_PORT" ]]; then FLAGS="${FLAGS} --sslport ${TS_SSL_PORT}"; fi
-if [[ ! -z "$TS_PROXY" ]]; then FLAGS="${FLAGS} --proxy ${TS_PROXY}"; fi
+if [[ ! -z "$TS_PROXYURL" ]]; then FLAGS="${FLAGS} --proxyurl ${TS_PROXYURL}"; fi
 if [[ ! -z "$TS_PROXYMODE" ]]; then FLAGS="${FLAGS} --proxymode ${TS_PROXYMODE}"; fi
 
 if [ ! -d $TS_CONF_PATH ]; then


### PR DESCRIPTION
Updated README.md to document new --proxyurl and --proxymode CLI options and corresponding TS_PROXYURL and TS_PROXYMODE environment variables. Modified docker-entrypoint.sh to use TS_PROXYURL and TS_PROXYMODE for configuring BitTorrent proxy settings.

==RU:
После изменения аргумента с proxy на proxyurl отвалилась установка параметра в docker-entrypoint, исправлено и добавлены изменения в README