### PR TITLE
Respect standard proxy header for hostname when generating M3U playlist

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/anacrolix/torrent v1.59.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gin-contrib/cors v1.7.6
-	github.com/gin-contrib/location v1.0.3
+	github.com/gin-contrib/location/v2 v2.0.0
 	github.com/gin-gonic/gin v1.11.0
 	github.com/hanwen/go-fuse/v2 v2.9.0
 	github.com/kljensen/snowball v0.10.0
@@ -99,7 +99,6 @@ require (
 	github.com/ryszard/goskiplist v0.0.0-20150312221310-2dfbae5fcf46 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.1 // indirect
-	go.uber.org/mock v0.6.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.23.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -230,8 +230,8 @@ github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQ
 github.com/gin-contrib/cors v1.7.6/go.mod h1:Ulcl+xN4jel9t1Ry8vqph23a60FwH9xVLd+3ykmTjOk=
 github.com/gin-contrib/gzip v0.0.6 h1:NjcunTcGAj5CO1gn4N8jHOSIeRFHIbn51z6K+xaN4d4=
 github.com/gin-contrib/gzip v0.0.6/go.mod h1:QOJlmV2xmayAjkNS2Y8NQsMneuRShOU/kjovCXNuzzk=
-github.com/gin-contrib/location v1.0.3 h1:iy5FY2JsunZ73Lnq8YZsx7wkGFY1xcyRdKiRh/8Uptg=
-github.com/gin-contrib/location v1.0.3/go.mod h1:fMoqRQxX0d5ycvxzP7e5VtqfID00RPb4jMGDh3oT0pk=
+github.com/gin-contrib/location/v2 v2.0.0 h1:iLx5RatHQHSxgC0tm2AG0sIuQKecI7FhREessVd6RWY=
+github.com/gin-contrib/location/v2 v2.0.0/go.mod h1:276TDNr25NENBA/NQZUuEIlwxy/I5CYVFIr/d2TgOdU=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.11.0 h1:OW/6PLjyusp2PPXtyxKHU0RbX6I/l28FTdDlae5ueWk=

--- a/server/utils/location.go
+++ b/server/utils/location.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/gin-contrib/location"
+	"github.com/gin-contrib/location/v2"
 	"github.com/gin-gonic/gin"
 )
 

--- a/server/utils/location.go
+++ b/server/utils/location.go
@@ -12,3 +12,11 @@ func GetScheme(c *gin.Context) string {
 	}
 	return url.Scheme
 }
+
+func GetHost(c *gin.Context) string {
+	url := location.Get(c)
+	if url == nil {
+		return c.Request.Host
+	}
+	return url.Host
+}

--- a/server/web/api/m3u.go
+++ b/server/web/api/m3u.go
@@ -35,7 +35,7 @@ import (
 func allPlayList(c *gin.Context) {
 	torrs := torr.ListTorrent()
 
-	host := utils.GetScheme(c) + "://" + c.Request.Host
+	host := utils.GetScheme(c) + "://" + utils.GetHost(c)
 	list := "#EXTM3U\n"
 	hash := ""
 	// fn=file.m3u fix forkplayer bug with end .m3u in link
@@ -87,7 +87,7 @@ func playList(c *gin.Context) {
 		}
 	}
 
-	host := utils.GetScheme(c) + "://" + c.Request.Host
+	host := utils.GetScheme(c) + "://" + utils.GetHost(c)
 	list := getM3uList(tor.Status(), host, fromlast)
 	list = "#EXTM3U\n" + list
 	name := strings.ReplaceAll(c.Param("fname"), `/`, "") // strip starting / from param

--- a/server/web/api/stream.go
+++ b/server/web/api/stream.go
@@ -179,7 +179,7 @@ func stream(c *gin.Context) {
 		} else if !strings.HasSuffix(strings.ToLower(name), ".m3u") && !strings.HasSuffix(strings.ToLower(name), ".m3u8") {
 			name += ".m3u"
 		}
-		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+c.Request.Host, fromlast)
+		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+utils2.GetHost(c), fromlast)
 		sendM3U(c, name, tor.Hash().HexString(), m3ulist)
 		return
 	} else
@@ -299,7 +299,7 @@ func streamNoAuth(c *gin.Context) {
 		} else if !strings.HasSuffix(strings.ToLower(name), ".m3u") && !strings.HasSuffix(strings.ToLower(name), ".m3u8") {
 			name += ".m3u"
 		}
-		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+c.Request.Host, fromlast)
+		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+utils2.GetHost(c), fromlast)
 		sendM3U(c, name, tor.Hash().HexString(), m3ulist)
 		return
 	} else

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -11,7 +11,7 @@ import (
 	"server/rutor"
 
 	"github.com/gin-contrib/cors"
-	"github.com/gin-contrib/location"
+	"github.com/gin-contrib/location/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/wlynxg/anet"
 


### PR DESCRIPTION
Fixes #610 

First commit makes preparations, with no effective change, whereas the 2nd has the actual fix.
This is my first exposure to Go, so pardon me for not writing any tests 🥺 

Manual testing done:

1. Default address — playlist entries point to the proper address 🟢 

        $ curl \
        > 'http://localhost:8090/stream/Big%20Buck%20Bunny.m3u?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&m3u'
        #EXTM3U
        #EXTINF:0,Big Buck Bunny.mp4
        #EXTVLCOPT:input-slave=http://localhost:8090/stream/Big%20Buck%20Bunny.en.srt?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=1&play#http://localhost:8090/stream/poster.jpg?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=3&play#
        http://localhost:8090/stream/Big%20Buck%20Bunny.mp4?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=2&play

    
2. Pretend we are behind a reverse proxy — playlist entries point to the proper address 🟢 

        $ curl \
        > -H 'X-Forwarded-Proto: https' \
        > -H 'X-Forwarded-Host: torr.example.org' \
        > 'http://localhost:8090/stream/Big%20Buck%20Bunny.m3u?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&m3u'
        #EXTM3U
        #EXTINF:0,Big Buck Bunny.mp4
        #EXTVLCOPT:input-slave=https://torr.example.org/stream/Big%20Buck%20Bunny.en.srt?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=1&play#https://torr.example.org/stream/poster.jpg?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=3&play#
        https://torr.example.org/stream/Big%20Buck%20Bunny.mp4?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=2&play

    For comparison, at 28f4f94b (current `master`) — playlist entries point to the proper schema 🟢  but wrong address 🔴 

        $ curl \
        > -H 'X-Forwarded-Proto: https' \
        > -H 'X-Forwarded-Host: torr.example.org' \
        > 'http://localhost:8090/stream/Big%20Buck%20Bunny.m3u?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&m3u'
        #EXTM3U
        #EXTINF:0,Big Buck Bunny.mp4
        #EXTVLCOPT:input-slave=https://localhost:8090/stream/Big%20Buck%20Bunny.en.srt?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=1&play#https://localhost:8090/stream/poster.jpg?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=3&play#
        https://localhost:8090/stream/Big%20Buck%20Bunny.mp4?link=dd8255ecdc7ca55fb0bbf81323d87062db1f6d1c&index=2&play