### PR TITLE
fix(torr): enhance image URL validation in `AddTorrentDB`

### DIFF
--- a/server/torr/dbwrapper.go
+++ b/server/torr/dbwrapper.go
@@ -32,7 +32,8 @@ func AddTorrentDB(torr *Torrent) {
 	} else {
 		t.Data = torr.Data
 	}
-	if utils.CheckImgUrl(torr.Poster) {
+
+	if torr.Poster != "" && utils.CheckImgUrl(torr.Poster) {
 		t.Poster = torr.Poster
 	}
 	t.Size = torr.Size

--- a/server/torr/utils/webImageChecker.go
+++ b/server/torr/utils/webImageChecker.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"context"
 	"image"
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"golang.org/x/image/webp"
 
@@ -17,20 +20,37 @@ func CheckImgUrl(link string) bool {
 	if link == "" {
 		return false
 	}
-	resp, err := http.Get(link)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", link, nil)
+	if err != nil {
+		log.TLogln("Error create request for image:", err)
+		return false
+	}
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		log.TLogln("Error check image:", err)
 		return false
 	}
 	defer resp.Body.Close()
+
+	limitedReader := io.LimitReader(resp.Body, 512*1024)
+
 	if strings.HasSuffix(link, ".webp") {
-		_, err = webp.Decode(resp.Body)
+		_, err = webp.Decode(limitedReader)
 	} else {
-		_, _, err = image.Decode(resp.Body)
+		_, _, err = image.Decode(limitedReader)
 	}
 	if err != nil {
 		log.TLogln("Error decode image:", err)
 		return false
 	}
-	return err == nil
+	return true
 }


### PR DESCRIPTION
- update `AddTorrentDB` to only set the poster if the URL is non-empty and valid
- refactor `CheckImgUrl` to use a context with a timeout for HTTP requests

possible fix for #533 