### PR TITLE
fix(web): correct meta tag for mobile web app capability

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -15,7 +15,7 @@
     <link rel="shortcut icon" href="/favicon.ico">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon" href="icon.png">
     <link rel="apple-touch-startup-image" href="apple-splash-2048-2732.jpg" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: portrait)">
     <link rel="apple-touch-startup-image" href="apple-splash-2732-2048.jpg" media="(device-width: 1024px) and (device-height: 1366px) and (-webkit-device-pixel-ratio: 2) and (orientation: landscape)">

--- a/web/src/components/Add/TorznabSearch.jsx
+++ b/web/src/components/Add/TorznabSearch.jsx
@@ -40,7 +40,6 @@ export default function TorznabSearch({ onSelect }) {
       const { data } = await axios.get(torznabSearchHost(), { params: { query } })
       setResults(data || [])
     } catch (error) {
-      console.error(error)
       setResults([])
     } finally {
       setLoading(false)

--- a/web/src/components/Add/helpers.js
+++ b/web/src/components/Add/helpers.js
@@ -22,8 +22,6 @@ const getTMDBSettings = async () => {
     tmdbSettingsCache = data
     return data
   } catch (error) {
-    console.error('Error fetching TMDB settings:', error)
-    // Return default values if API fails
     return {
       APIKey: process.env.REACT_APP_TMDB_API_KEY || '',
       APIURL: 'https://api.themoviedb.org/3',

--- a/web/src/components/Search/SearchDialog.jsx
+++ b/web/src/components/Search/SearchDialog.jsx
@@ -56,7 +56,7 @@ export default function SearchDialog({ handleClose }) {
           setEnableRutor(!!data.EnableRutorSearch)
         }
       })
-      .catch(console.error)
+      .catch(() => {})
   }, [])
 
   const handleSearch = async () => {
@@ -77,7 +77,6 @@ export default function SearchDialog({ handleClose }) {
       const { data } = await axios.get(url, { params })
       setResults(data || [])
     } catch (error) {
-      console.error(error)
       setErrorMsg(t('Torznab.SearchFailed'))
     } finally {
       setLoading(false)
@@ -107,7 +106,6 @@ export default function SearchDialog({ handleClose }) {
       })
       setSuccessMsg(t('Torznab.TorrentAddedSuccessfully'))
     } catch (error) {
-      console.error(error)
       setErrorMsg(t('Torznab.FailedToAddTorrent'))
     } finally {
       setAdding(false)

--- a/web/src/components/Settings/SecondarySettingsComponent.jsx
+++ b/web/src/components/Settings/SecondarySettingsComponent.jsx
@@ -96,7 +96,7 @@ export default function SecondarySettingsComponent({ settings, inputForm }) {
           setStorageSettings(prefs)
         }
       } catch (error) {
-        console.error('Failed to load storage settings:', error)
+        // eslint-disable-line no-console
       }
     }
     loadStorageSettings()

--- a/web/src/components/Settings/SettingsDialog.jsx
+++ b/web/src/components/Settings/SettingsDialog.jsx
@@ -13,7 +13,6 @@ import SwipeableViews from 'react-swipeable-views'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { StyledDialog } from 'style/CustomMaterialUiStyles'
 import useOnStandaloneAppOutsideClick from 'utils/useOnStandaloneAppOutsideClick'
-import { isStandaloneApp } from 'utils/Utils'
 
 import { SettingsHeader, FooterSection, Content } from './style'
 import defaultSettings from './defaultSettings'


### PR DESCRIPTION
- update the meta tag from 'apple-mobile-web-app-capable' to 'mobile-web-app-capable' for compatibility with mobile web applications
- eliminate console.error statement in TorznabSearch component to maintain silent error handling consistency across the application
- remove console.error statements in Add, SearchDialog, and SecondarySettingsComponent to prevent error details from being logged