### PR TITLE
Fix shell syntax errors for docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,27 +1,27 @@
 #!/bin/sh
 
 FLAGS="--path $TS_CONF_PATH --logpath $TS_LOG_PATH --port $TS_PORT --torrentsdir $TS_TORR_DIR"
-if [[ ! -z "$TS_IP" ]]; then FLAGS="${FLAGS} -i ${TS_IP}"; fi
-if [[ "$TS_HTTPAUTH" -eq 1 ]]; then FLAGS="${FLAGS} --httpauth"; fi
-if [[ "$TS_RDB" -eq 1 ]]; then FLAGS="${FLAGS} --rdb"; fi
-if [[ "$TS_DONTKILL" -eq 1 ]]; then FLAGS="${FLAGS} --dontkill"; fi
-if [[ "$TS_EN_SSL" -eq 1 ]]; then FLAGS="${FLAGS} --ssl"; fi
-if [[ -v "$TS_SSL_PORT" ]]; then FLAGS="${FLAGS} --sslport ${TS_SSL_PORT}"; fi
-if [[ ! -z "$TS_PROXYURL" ]]; then FLAGS="${FLAGS} --proxyurl ${TS_PROXYURL}"; fi
-if [[ ! -z "$TS_PROXYMODE" ]]; then FLAGS="${FLAGS} --proxymode ${TS_PROXYMODE}"; fi
+if [ -n "$TS_IP" ]; then FLAGS="${FLAGS} -i ${TS_IP}"; fi
+if [ "$TS_HTTPAUTH" = "1" ]; then FLAGS="${FLAGS} --httpauth"; fi
+if [ "$TS_RDB" = "1" ]; then FLAGS="${FLAGS} --rdb"; fi
+if [ "$TS_DONTKILL" = "1" ]; then FLAGS="${FLAGS} --dontkill"; fi
+if [ "$TS_EN_SSL" = "1" ]; then FLAGS="${FLAGS} --ssl"; fi
+if [ -n "$TS_SSL_PORT" ]; then FLAGS="${FLAGS} --sslport ${TS_SSL_PORT}"; fi
+if [ -n "$TS_PROXYURL" ]; then FLAGS="${FLAGS} --proxyurl ${TS_PROXYURL}"; fi
+if [ -n "$TS_PROXYMODE" ]; then FLAGS="${FLAGS} --proxymode ${TS_PROXYMODE}"; fi
 
-if [ ! -d $TS_CONF_PATH ]; then
-  mkdir -p $TS_CONF_PATH
+if [ ! -d "$TS_CONF_PATH" ]; then
+  mkdir -p "$TS_CONF_PATH"
 fi
 
-if [ ! -d $TS_TORR_DIR ]; then
-  mkdir -p $TS_TORR_DIR
+if [ ! -d "$TS_TORR_DIR" ]; then
+  mkdir -p "$TS_TORR_DIR"
 fi
 
-if [ ! -f $TS_LOG_PATH ]; then
-  touch $TS_LOG_PATH
+if [ ! -f "$TS_LOG_PATH" ]; then
+  touch "$TS_LOG_PATH"
 fi
 
 echo "Running with: ${FLAGS}"
 
-torrserver $FLAGS
+exec torrserver $FLAGS


### PR DESCRIPTION
Из-за содержания в скрипте синтаксиса, характерного только для bash (`[[ ]]`), скрипт при запуске контейнера выдает следующие ошибки:
```
sh: out of range
sh: out of range
sh: : unknown operand
```
И не применяет тем самым переменные `TS_IP`, `TS_HTTPAUTH`, `TS_RDB`, `TS_DONTKILL`, `TS_EN_SSL`, `TS_SSL_PORT`, `TS_PROXYURL`, `TS_PROXYMODE`.

Я слегка поменял синтаксис, чтобы он соответствовал чистому sh.

---

exec добавлен, чтобы в контейнере процесс TorrServer стал основным
До:
```
PID   USER     TIME  COMMAND
    1 root      0:00 {docker-entrypoi} /bin/sh /docker-entrypoint.sh
    8 root      0:01 torrserver --path /opt/ts/config --logpath /opt/ts/log --port 5665 --torrentsdir /opt/ts/torrents --dontkill
   17 root      0:00 ps
```
После:
```
PID   USER     TIME  COMMAND
    1 root      0:01 torrserver --path /opt/ts/config --logpath /opt/ts/log --port 5665 --torrentsdir /opt/ts/torrents --dontkill
   29 root      0:00 ps
```