### PR TITLE
Fix #537: protect rutor state with RWMutex to avoid concurrent map writes

### DIFF
--- a/server/rutor/race_test.go
+++ b/server/rutor/race_test.go
@@ -1,0 +1,97 @@
+package rutor
+
+import (
+	"bytes"
+	"compress/flate"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"server/rutor/models"
+	"server/settings"
+)
+
+// TestConcurrentSearchAndLoadDB проверяет отсутствие гонки при одновременном
+// обновлении индекса (loadDB) и поиске (Search). 
+// !Запускать с -count=3
+func TestConcurrentSearchAndLoadDB(t *testing.T) {
+	if settings.BTsets == nil {
+		settings.BTsets = &settings.BTSets{EnableRutorSearch: true}
+		defer func() { settings.BTsets = nil }()
+	} else {
+		old := settings.BTsets.EnableRutorSearch
+		settings.BTsets.EnableRutorSearch = true
+		defer func() { settings.BTsets.EnableRutorSearch = old }()
+	}
+
+	dir := t.TempDir()
+	oldPath := settings.Path
+	settings.Path = dir
+	defer func() { settings.Path = oldPath }()
+
+	const numTorrents = 800
+	seed := make([]*models.TorrentDetails, numTorrents)
+	for i := 0; i < numTorrents; i++ {
+		s := strconv.Itoa(i)
+		seed[i] = &models.TorrentDetails{
+			Title: "Test Film Number " + s + " Part One Two Three Year",
+			Name:  "Film " + s,
+			Year:  2015 + i%10,
+		}
+	}
+	data, err := json.Marshal(seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var compressed bytes.Buffer
+	w, _ := flate.NewWriter(&compressed, flate.DefaultCompression)
+	_, _ = w.Write(data)
+	_ = w.Close()
+	if err := os.WriteFile(filepath.Join(dir, "rutor.ls"), compressed.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Горутина: многократно перезагружает БД (долгая перезапись индекса)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			select {
+			case <-done:
+				return
+			default:
+				loadDB()
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Несколько горутин: постоянный поиск, пока идёт переиндексация
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			queries := []string{"Test", "Film", "Number", "Part", "Year", "xxx"}
+			for j := 0; j < 200; j++ {
+				select {
+				case <-done:
+					return
+				default:
+					_ = Search(queries[j%len(queries)])
+				}
+			}
+		}()
+	}
+
+	// Даём время на пересечение loadDB и Search
+	time.Sleep(800 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}


### PR DESCRIPTION
Rutor search was crashing with "fatal error: concurrent map writes" when
the index was updated (loadDB/updateDB) while Search or other readers
accessed shared state (torrs slice and torrsearch index) from other goroutines.

- Introduce a package-level sync.RWMutex and hold it around all reads and
  writes of torrs, isStop, and torrsearch index in Start, Stop, updateDB,
  loadDB, and Search.
- Ensure index is built and assigned under the same lock so no goroutine
  sees a half-updated state.

Add TestConcurrentSearchAndLoadDB to verify there is no data race between
concurrent loadDB and Search; run with: go test -race -count=3.