### PR TITLE
fix: bump golang to 1.26 in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN yarn run build
 
 
 ### BUILD TORRSERVER MULTIARCH START ###
-FROM --platform=$BUILDPLATFORM golang:1.24.0-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine AS builder
 
 COPY . /opt/src
 COPY --from=front /app/build /opt/src/web/build


### PR DESCRIPTION
* Бампнул образ golang на 1.26 в соответствии с версией golang в проекте
* Потестил на MatriX.138, все собирается и работает
* Можно пересобрать докер MatriX.138