### PR TITLE
fix(ci): set version dynamically from git tag in build process

### DIFF
--- a/.github/workflows/ts_release.yml
+++ b/.github/workflows/ts_release.yml
@@ -28,6 +28,9 @@ jobs:
           go-version: ${{ matrix.go_version }}
           cache: true
 
+      - name: Set version from tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - name: Install Swag
         run: go install github.com/swaggo/swag/cmd/swag@latest
 
@@ -40,7 +43,7 @@ jobs:
       - name: Build Standard Platforms
         if: matrix.group == 'standard'
         run: |
-          LDFLAGS="-s -w -checklinkname=0"
+          LDFLAGS="-s -w -checklinkname=0 -X server/version.Version=${{ env.VERSION }}"
           mkdir -p "${{ github.workspace }}/dist"
           cd server
           
@@ -75,7 +78,7 @@ jobs:
         run: |
           go run gen_web.go
           
-          LDFLAGS="-s -w -checklinkname=0"
+          LDFLAGS="-s -w -checklinkname=0 -X server/version.Version=${{ env.VERSION }}"
           mkdir -p "${{ github.workspace }}/dist"
           export NDK_TOOLCHAIN="$ANDROID_NDK_LATEST_HOME/toolchains/llvm/prebuilt/linux-x86_64"
           cd server

--- a/server/version/version.go
+++ b/server/version/version.go
@@ -5,7 +5,8 @@ import (
 	"runtime/debug"
 )
 
-const Version = "MatriX.140"
+// Version is set at build time via -ldflags "-X server/version.Version=<tag>"
+var Version = "MatriX.140"
 
 func GetTorrentVersion() string {
 	bi, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
Example:

```shell
 go build -ldflags="-X server/version.Version=MatriX.140.10" -o TorrServer-test ./cmd
 
 ./TorrServer-test --version
2026/02/25 16:27:40 ffprobe and avprobe not found in $PATH
TorrServer MatriX.140.10
```
 
 

