### PR TITLE
feat: optimize torrent list API with lightweight status and filtering

### DIFF
--- a/server/torr/apihelper.go
+++ b/server/torr/apihelper.go
@@ -206,6 +206,32 @@ func ListTorrent() []*Torrent {
 	return ret
 }
 
+func ListTorrentFiltered(filter string) []*Torrent {
+	switch filter {
+	case "last":
+		all := ListTorrent()
+		if len(all) > 0 {
+			return all[:1]
+		}
+		return nil
+	case "active":
+		btlist := bts.ListTorrents()
+		var ret []*Torrent
+		for _, t := range btlist {
+			ret = append(ret, t)
+		}
+		sort.Slice(ret, func(i, j int) bool {
+			if ret[i].Timestamp != ret[j].Timestamp {
+				return ret[i].Timestamp > ret[j].Timestamp
+			}
+			return ret[i].Title > ret[j].Title
+		})
+		return ret
+	default:
+		return ListTorrent()
+	}
+}
+
 func DropTorrent(hashHex string) {
 	hash := metainfo.NewHashFromHex(hashHex)
 	bts.RemoveTorrent(hash)

--- a/server/torr/torrent.go
+++ b/server/torr/torrent.go
@@ -385,6 +385,45 @@ func (t *Torrent) Status() *state.TorrentStatus {
 	return st
 }
 
+func (t *Torrent) StatusLight() *state.TorrentStatus {
+	t.muTorrent.Lock()
+	defer t.muTorrent.Unlock()
+
+	st := new(state.TorrentStatus)
+
+	st.Stat = t.Stat
+	st.StatString = t.Stat.String()
+	st.Title = t.Title
+	st.Category = t.Category
+	st.Poster = t.Poster
+	st.Data = t.Data
+	st.Timestamp = t.Timestamp
+	st.TorrentSize = t.Size
+	st.BitRate = t.BitRate
+	st.DurationSeconds = t.DurationSeconds
+
+	if t.TorrentSpec != nil {
+		st.Hash = t.TorrentSpec.InfoHash.HexString()
+	}
+	if t.Torrent != nil {
+		st.Name = t.Torrent.Name()
+		st.Hash = t.Torrent.InfoHash().HexString()
+		st.DownloadSpeed = t.DownloadSpeed
+		st.UploadSpeed = t.UploadSpeed
+
+		tst := t.Torrent.Stats()
+		st.TotalPeers = tst.TotalPeers
+		st.ActivePeers = tst.ActivePeers
+		st.ConnectedSeeders = tst.ConnectedSeeders
+
+		if t.Torrent.Info() != nil {
+			st.TorrentSize = t.Torrent.Length()
+		}
+	}
+
+	return st
+}
+
 func (t *Torrent) CacheState() *cacheSt.CacheState {
 	if t.Torrent != nil && t.cache != nil {
 		st := t.cache.GetState()

--- a/server/web/api/torrents.go
+++ b/server/web/api/torrents.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"server/torrshash"
 	"strings"
+	"sync"
+	"time"
 
 	"server/dlna"
 	"server/log"
@@ -27,7 +29,15 @@ type torrReqJS struct {
 	Poster   string `json:"poster,omitempty"`
 	Data     string `json:"data,omitempty"`
 	SaveToDB bool   `json:"save_to_db,omitempty"`
+	Filter   string `json:"filter,omitempty"`
 }
+
+var (
+	listCache     []*state.TorrentStatus
+	listCacheTime time.Time
+	listCacheMu   sync.Mutex
+	listCacheTTL  = 2 * time.Second
+)
 
 // torrents godoc
 //
@@ -69,7 +79,7 @@ func torrents(c *gin.Context) {
 		}
 	case "list":
 		{
-			listTorrents(c)
+			listTorrents(c, req.Filter)
 		}
 	case "drop":
 		{
@@ -193,16 +203,41 @@ func remTorrent(req torrReqJS, c *gin.Context) {
 	c.Status(200)
 }
 
-func listTorrents(c *gin.Context) {
-	list := torr.ListTorrent()
+func listTorrents(c *gin.Context, filter string) {
+	if filter == "" {
+		filter = "all"
+	}
+
+	// Return cached response for "all" filter if fresh enough
+	if filter == "all" {
+		listCacheMu.Lock()
+		if listCache != nil && time.Since(listCacheTime) < listCacheTTL {
+			cached := listCache
+			listCacheMu.Unlock()
+			c.JSON(200, cached)
+			return
+		}
+		listCacheMu.Unlock()
+	}
+
+	list := torr.ListTorrentFiltered(filter)
 	if len(list) == 0 {
 		c.JSON(200, []*state.TorrentStatus{})
 		return
 	}
 	var stats []*state.TorrentStatus
 	for _, tr := range list {
-		stats = append(stats, tr.Status())
+		stats = append(stats, tr.StatusLight())
 	}
+
+	// Cache "all" results
+	if filter == "all" {
+		listCacheMu.Lock()
+		listCache = stats
+		listCacheTime = time.Now()
+		listCacheMu.Unlock()
+	}
+
 	c.JSON(200, stats)
 }
 


### PR DESCRIPTION
Optimize /torrents action:"list" endpoint for servers with large number of torrents.

Problem: with 100+ torrents the list request hangs — Status() is called for each torrent,
performing file listing, sorting, TorrsHash generation and detailed byte/chunk statistics.

Changes:
- StatusLight() — lightweight status without FileStats, TorrsHash and detailed statistics
- Filter field in list request: "all" (default), "active" (in-memory only), "last" (most recent by timestamp)
- 2-second response cache for list to reduce load from frequent polling

Full status with files is still available via action:"get" by hash.