### PR TITLE
feat: multi-file torrent upload with per-file editing

### DIFF
--- a/server/web/api/upload.go
+++ b/server/web/api/upload.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"mime/multipart"
 	"net/http"
 
 	"server/log"
 	set "server/settings"
 	"server/torr"
+	"server/torr/state"
 	"server/web/api/utils"
 
 	"github.com/gin-gonic/gin"
@@ -13,22 +15,22 @@ import (
 
 // torrentUpload godoc
 //
-//	@Summary		Add .torrent file
-//	@Description	Only one file support.
+//	@Summary		Add .torrent files
+//	@Description	Supports multiple files. Returns array of statuses.
 //
 //	@Tags			API
 //
-//	@Param			file	formData	file	true	"Torrent file to insert"
+//	@Param			file	formData	file	true	"Torrent file(s) to insert"
 //	@Param			save	formData	string	false	"Save to DB"
-//	@Param			title	formData	string	false	"Torrent title"
+//	@Param			title	formData	string	false	"Torrent title (single file only)"
 //	@Param			category	formData	string	false	"Torrent category"
-//	@Param			poster	formData	string	false	"Torrent poster"
+//	@Param			poster	formData	string	false	"Torrent poster (single file only)"
 //	@Param			data	formData	string	false	"Torrent data"
 //
 //	@Accept			multipart/form-data
 //
 //	@Produce		json
-//	@Success		200	{object}	state.TorrentStatus	"Torrent status"
+//	@Success		200	{array}		state.TorrentStatus	"Torrent statuses"
 //	@Router			/torrent/upload [post]
 func torrentUpload(c *gin.Context) {
 	form, err := c.MultipartForm()
@@ -55,24 +57,34 @@ func torrentUpload(c *gin.Context) {
 	if len(form.Value["data"]) > 0 {
 		data = form.Value["data"][0]
 	}
-	var tor *torr.Torrent
-	for name, file := range form.File {
-		log.TLogln("add .torrent", name)
 
-		torrFile, err := file[0].Open()
+	var files []*multipart.FileHeader
+	for _, fh := range form.File {
+		files = append(files, fh...)
+	}
+
+	var stats []*state.TorrentStatus
+	for _, fh := range files {
+		log.TLogln("add .torrent", fh.Filename)
+
+		torrFile, err := fh.Open()
 		if err != nil {
 			log.TLogln("error upload torrent:", err)
 			continue
 		}
-		defer torrFile.Close()
 
 		spec, err := utils.ParseFile(torrFile)
+		torrFile.Close()
 		if err != nil {
 			log.TLogln("error upload torrent:", err)
 			continue
 		}
 
-		tor, err = torr.AddTorrent(spec, title, poster, data, category)
+		tor, err := torr.AddTorrent(spec, title, poster, data, category)
+		if err != nil {
+			log.TLogln("error upload torrent:", err)
+			continue
+		}
 
 		if tor.Data != "" && set.BTsets.EnableDebug {
 			log.TLogln("torrent data:", tor.Data)
@@ -81,27 +93,22 @@ func torrentUpload(c *gin.Context) {
 			log.TLogln("torrent category:", tor.Category)
 		}
 
-		if err != nil {
-			log.TLogln("error upload torrent:", err)
-			continue
-		}
-
-		go func() {
-			if !tor.GotInfo() {
+		go func(t *torr.Torrent) {
+			if !t.GotInfo() {
 				log.TLogln("error add torrent:", "torrent connection timeout")
 				return
 			}
 
-			if tor.Title == "" {
-				tor.Title = tor.Name()
+			if t.Title == "" {
+				t.Title = t.Name()
 			}
 
 			if save {
-				torr.SaveTorrentToDB(tor)
+				torr.SaveTorrentToDB(t)
 			}
-		}()
+		}(tor)
 
-		break
+		stats = append(stats, tor.Status())
 	}
-	c.JSON(200, tor.Status())
+	c.JSON(200, stats)
 }

--- a/web/src/components/Add/AddDialog.jsx
+++ b/web/src/components/Add/AddDialog.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Button from '@material-ui/core/Button'
-import { torrentsHost, torrentUploadHost } from 'utils/Hosts'
+import { torrentsHost } from 'utils/Hosts'
 import axios from 'axios'
 import { useTranslation } from 'react-i18next'
 import debounce from 'lodash/debounce'
@@ -19,6 +19,7 @@ import { checkImageURL, getMoviePosters, checkTorrentSource, parseTorrentTitle }
 import { Content } from './style'
 import RightSideComponent from './RightSideComponent'
 import LeftSideComponent from './LeftSideComponent'
+import MultiAddDialog from './MultiAddDialog'
 
 export default function AddDialog({
   handleClose,
@@ -42,37 +43,35 @@ export default function AddDialog({
   const [posterList, setPosterList] = useState()
   const [isUserInteractedWithPoster, setIsUserInteractedWithPoster] = useState(isEditMode)
   const [currentLang] = useChangeLanguage()
-  const [selectedFile, setSelectedFile] = useState()
   const [posterSearchLanguage, setPosterSearchLanguage] = useState(currentLang === 'ru' ? 'ru' : 'en')
   const [isSaving, setIsSaving] = useState(false)
   const [skipDebounce, setSkipDebounce] = useState(false)
   const [isCustomTitleEnabled, setIsCustomTitleEnabled] = useState(false)
   const [currentSourceHash, setCurrentSourceHash] = useState()
 
+  // When files are dropped/selected, switch to MultiAddDialog
+  const [multiFiles, setMultiFiles] = useState(null)
+
   const ref = useOnStandaloneAppOutsideClick(handleClose)
 
   const { data: torrents } = useQuery('torrents', getTorrents, { retry: 1, refetchInterval: 1000 })
 
   useEffect(() => {
-    // getting hash from added torrent source
-    parseTorrent.remote(selectedFile || torrentSource, (_, { infoHash } = {}) => setCurrentSourceHash(infoHash))
-  }, [selectedFile, torrentSource])
+    parseTorrent.remote(torrentSource, (_, { infoHash } = {}) => setCurrentSourceHash(infoHash))
+  }, [torrentSource])
 
   useEffect(() => {
-    // checking if torrent already exists in DB
-    if (!setCurrentSourceHash) return
+    if (!currentSourceHash || !torrents) return
 
     const allHashes = torrents.map(({ hash }) => hash)
     setIsHashAlreadyExists(allHashes.includes(currentSourceHash))
   }, [currentSourceHash, torrents])
 
   useEffect(() => {
-    // closing dialog when torrent successfully added in DB
-    if (!isSaving) return
+    if (!isSaving || !torrents) return
 
     const allHashes = torrents.map(({ hash }) => hash)
     allHashes.includes(currentSourceHash) && handleClose()
-    // FIXME! check api reply on add links
     const linkRegex = /^(http(s?)):\/\/.*/i
     torrentSource.match(linkRegex) !== null && handleClose()
   }, [isSaving, torrents, torrentSource, currentSourceHash, handleClose])
@@ -80,7 +79,7 @@ export default function AddDialog({
   const fullScreen = useMediaQuery('@media (max-width:930px)')
 
   const updateTitleFromSource = useCallback(() => {
-    parseTorrentTitle(selectedFile || torrentSource, ({ parsedTitle, originalName }) => {
+    parseTorrentTitle(torrentSource, ({ parsedTitle, originalName }) => {
       if (!originalName) return
 
       setSkipDebounce(true)
@@ -89,10 +88,10 @@ export default function AddDialog({
       setOriginalTorrentTitle(originalName)
       setParsedTitle(parsedTitle)
     })
-  }, [selectedFile, torrentSource])
+  }, [torrentSource])
 
   useEffect(() => {
-    if (!selectedFile && !torrentSource) {
+    if (!torrentSource) {
       setTitle('')
       setOriginalTorrentTitle('')
       setParsedTitle('')
@@ -101,7 +100,7 @@ export default function AddDialog({
       removePoster()
       setIsUserInteractedWithPoster(false)
     }
-  }, [selectedFile, torrentSource])
+  }, [torrentSource])
 
   const removePoster = () => {
     setIsPosterUrlCorrect(false)
@@ -114,7 +113,6 @@ export default function AddDialog({
         correctImage ? setIsPosterUrlCorrect(true) : removePoster()
       })
     }
-    // This is needed only on mount. Do not remove line below
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -160,17 +158,15 @@ export default function AddDialog({
 
     setIsTorrentSourceCorrect(true)
 
-    // if torrentSource is updated then we are getting title from the source
     const torrentSourceChanged = torrentSource !== prevTorrentSourceState
     if (!torrentSourceChanged) return
 
     updateTitleFromSource()
-  }, [prevTorrentSourceState, selectedFile, torrentSource, updateTitleFromSource])
+  }, [prevTorrentSourceState, torrentSource, updateTitleFromSource])
 
   const prevTitleState = usePreviousState(title)
 
   useEffect(() => {
-    // if title exists and title was changed then search poster.
     const titleChanged = title !== prevTitleState
     if (!titleChanged && !parsedTitle) return
 
@@ -199,6 +195,11 @@ export default function AddDialog({
     isUserInteractedWithPoster,
   ])
 
+  const handleSetSelectedFile = useCallback((fileOrFiles) => {
+    const files = Array.isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles]
+    setMultiFiles(files)
+  }, [])
+
   const handleSave = () => {
     setIsSaving(true)
 
@@ -212,15 +213,6 @@ export default function AddDialog({
           category,
         })
         .finally(handleClose)
-    } else if (selectedFile) {
-      // file save
-      const data = new FormData()
-      data.append('save', 'true')
-      data.append('file', selectedFile)
-      title && data.append('title', title)
-      category && data.append('category', category)
-      posterUrl && data.append('poster', posterUrl)
-      axios.post(torrentUploadHost(), data).catch(handleClose)
     } else {
       // link save
       axios
@@ -236,6 +228,10 @@ export default function AddDialog({
     }
   }
 
+  if (multiFiles) {
+    return <MultiAddDialog files={multiFiles} handleClose={handleClose} />
+  }
+
   return (
     <StyledDialog open onClose={handleClose} fullScreen={fullScreen} fullWidth maxWidth='md' ref={ref}>
       <StyledHeader>{t(isEditMode ? 'EditTorrent' : 'AddNewTorrent')}</StyledHeader>
@@ -244,8 +240,7 @@ export default function AddDialog({
         {!isEditMode && (
           <LeftSideComponent
             setIsUserInteractedWithPoster={setIsUserInteractedWithPoster}
-            selectedFile={selectedFile}
-            setSelectedFile={setSelectedFile}
+            setSelectedFile={handleSetSelectedFile}
             torrentSource={torrentSource}
             setTorrentSource={setTorrentSource}
           />

--- a/web/src/components/Add/LeftSideComponent.jsx
+++ b/web/src/components/Add/LeftSideComponent.jsx
@@ -1,18 +1,14 @@
 import { useTranslation } from 'react-i18next'
 import { useDropzone } from 'react-dropzone'
-import { AddItemIcon, TorrentIcon } from 'icons'
+import { AddItemIcon } from 'icons'
 import TextField from '@material-ui/core/TextField'
-import { Cancel as CancelIcon } from '@material-ui/icons'
 import { useState } from 'react'
 
 import {
-  CancelIconWrapper,
   IconWrapper,
   LeftSide,
-  LeftSideBottomSectionFileSelected,
   LeftSideBottomSectionNoFile,
   LeftSideTopSection,
-  TorrentIconWrapper,
 } from './style'
 
 export default function LeftSideComponent({
@@ -20,29 +16,20 @@ export default function LeftSideComponent({
   setSelectedFile,
   torrentSource,
   setTorrentSource,
-  selectedFile,
 }) {
   const { t } = useTranslation()
 
   const handleCapture = files => {
-    const [file] = files
-    if (!file) return
-
+    if (!files.length) return
     setIsUserInteractedWithPoster(false)
-    setSelectedFile(file)
-    setTorrentSource(file.name)
-  }
-
-  const clearSelectedFile = () => {
-    setSelectedFile()
-    setTorrentSource('')
+    setSelectedFile(files.length === 1 ? files[0] : files)
   }
 
   const [isTorrentSourceActive, setIsTorrentSourceActive] = useState(false)
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop: handleCapture,
     accept: '.torrent',
-    multiple: false,
+    multiple: true,
   })
 
   const handleTorrentSourceChange = ({ target: { value } }) => setTorrentSource(value)
@@ -63,31 +50,18 @@ export default function LeftSideComponent({
           onFocus={() => setIsTorrentSourceActive(true)}
           onBlur={() => setIsTorrentSourceActive(false)}
           inputProps={{ autoComplete: 'off' }}
-          disabled={!!selectedFile}
         />
       </LeftSideTopSection>
 
-      {selectedFile ? (
-        <LeftSideBottomSectionFileSelected>
-          <TorrentIconWrapper>
-            <TorrentIcon />
+      <LeftSideBottomSectionNoFile isDragActive={isDragActive} {...getRootProps()}>
+        <input {...getInputProps()} />
+        <div>{t('AddDialog.AppendFile.Or')}</div>
 
-            <CancelIconWrapper onClick={clearSelectedFile}>
-              <CancelIcon />
-            </CancelIconWrapper>
-          </TorrentIconWrapper>
-        </LeftSideBottomSectionFileSelected>
-      ) : (
-        <LeftSideBottomSectionNoFile isDragActive={isDragActive} {...getRootProps()}>
-          <input {...getInputProps()} />
-          <div>{t('AddDialog.AppendFile.Or')}</div>
-
-          <IconWrapper>
-            <AddItemIcon color='primary' />
-            <div>{t('AddDialog.AppendFile.ClickOrDrag')}</div>
-          </IconWrapper>
-        </LeftSideBottomSectionNoFile>
-      )}
+        <IconWrapper>
+          <AddItemIcon color='primary' />
+          <div>{t('AddDialog.AppendFile.ClickOrDrag')}</div>
+        </IconWrapper>
+      </LeftSideBottomSectionNoFile>
     </LeftSide>
   )
 }

--- a/web/src/components/Add/MultiAddDialog.jsx
+++ b/web/src/components/Add/MultiAddDialog.jsx
@@ -1,0 +1,231 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import Button from '@material-ui/core/Button'
+import { torrentUploadHost } from 'utils/Hosts'
+import axios from 'axios'
+import { useTranslation } from 'react-i18next'
+import { useMediaQuery, TextField, FormControl, FormHelperText, Select, MenuItem, IconButton } from '@material-ui/core'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import { Delete as DeleteIcon } from '@material-ui/icons'
+import { ButtonWrapper } from 'style/DialogStyles'
+import { StyledDialog, StyledHeader } from 'style/CustomMaterialUiStyles'
+import useOnStandaloneAppOutsideClick from 'utils/useOnStandaloneAppOutsideClick'
+import { TORRENT_CATEGORIES } from 'components/categories'
+import { NoImageIcon } from 'icons'
+import { useQuery } from 'react-query'
+import { getTorrents } from 'utils/Utils'
+import useChangeLanguage from 'utils/useChangeLanguage'
+import parseTorrent from 'parse-torrent'
+import { parseTorrentTitle, checkImageURL, getMoviePosters } from './helpers'
+import { MultiFileRow, MultiFilePoster, MultiFileInfo, MultiFileList } from './style'
+
+function FileRow({ file, fileState, index, onUpdate, onRemove, existingTorrents }) {
+  const { t } = useTranslation()
+  const [currentLang] = useChangeLanguage()
+  const handleTitleChange = ({ target: { value } }) => onUpdate({ title: value })
+  const handleCategoryChange = ({ target: { value } }) => onUpdate({ category: value })
+  const handlePosterChange = ({ target: { value } }) => {
+    onUpdate({ poster: value })
+    checkImageURL(value).then(ok => onUpdate({ isPosterOk: ok }))
+  }
+
+  useEffect(() => {
+    // Extract infohash and check for duplicates
+    parseTorrent.remote(file, (err, parsed) => {
+      if (!err && parsed?.infoHash) {
+        const existing = existingTorrents.find(tor => tor.hash === parsed.infoHash)
+        if (existing) {
+          const updates = { infoHash: parsed.infoHash, alreadyExists: true }
+          if (existing.title) updates.title = existing.title
+          if (existing.category) updates.category = existing.category
+          if (existing.poster) {
+            updates.poster = existing.poster
+            updates.isPosterOk = true
+          }
+          onUpdate(updates)
+          return
+        }
+        onUpdate({ infoHash: parsed.infoHash })
+      }
+    })
+
+    // Parse title and search poster
+    const posterLang = currentLang === 'ru' ? 'ru' : 'en'
+    parseTorrentTitle(file, ({ parsedTitle, originalName }) => {
+      if (!originalName) return
+      onUpdate({ originalName, parsedTitle: parsedTitle || '' })
+
+      const searchTitle = parsedTitle || originalName
+      if (searchTitle) {
+        getMoviePosters(searchTitle, posterLang).then(urls => {
+          if (urls && urls.length > 0) {
+            checkImageURL(urls[0]).then(ok => {
+              if (ok) onUpdate({ poster: urls[0], isPosterOk: true })
+            })
+          }
+        })
+      }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [file])
+
+  return (
+    <MultiFileRow>
+      <MultiFilePoster>
+        <span className='file-index'>{index + 1}</span>
+        {fileState.isPosterOk ? (
+          <img src={fileState.poster} alt='poster' />
+        ) : (
+          <NoImageIcon style={{ opacity: 0.3, width: 40, height: 40 }} />
+        )}
+      </MultiFilePoster>
+
+      <MultiFileInfo>
+        <TextField
+          onChange={handleTitleChange}
+          value={fileState.title}
+          margin='dense'
+          label={t('AddDialog.TitleBlank')}
+          type='text'
+          variant='outlined'
+          fullWidth
+          size='small'
+        />
+
+        <TextField
+          onChange={handlePosterChange}
+          value={fileState.poster}
+          margin='dense'
+          label={t('AddDialog.AddPosterLinkInput')}
+          type='url'
+          variant='outlined'
+          fullWidth
+          size='small'
+        />
+
+        <FormControl fullWidth size='small' style={{ marginTop: 4 }}>
+          <FormHelperText style={{ padding: '0 0.5em' }}>
+            {t('AddDialog.CategoryHelperText')}
+          </FormHelperText>
+          <Select
+            value={fileState.category}
+            margin='dense'
+            onChange={handleCategoryChange}
+            variant='outlined'
+            fullWidth
+            defaultValue=''
+          >
+            <MenuItem value=''><em>—</em></MenuItem>
+            {TORRENT_CATEGORIES.map(cat => (
+              <MenuItem key={cat.key} value={cat.key}>
+                {t(cat.name)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </MultiFileInfo>
+
+      <IconButton onClick={onRemove} size='medium'>
+        <DeleteIcon />
+      </IconButton>
+    </MultiFileRow>
+  )
+}
+
+export default function MultiAddDialog({ files, handleClose }) {
+  const { t } = useTranslation()
+  const fullScreen = useMediaQuery('@media (max-width:930px)')
+  const ref = useOnStandaloneAppOutsideClick(handleClose)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const { data: torrents } = useQuery('torrents', getTorrents, { retry: 1 })
+  const existingTorrents = torrents || []
+
+  const [fileList, setFileList] = useState(() =>
+    files.map(f => ({
+      file: f,
+      title: f.name.replace(/\.torrent$/i, ''),
+      category: '',
+      poster: '',
+      isPosterOk: false,
+      originalName: '',
+      parsedTitle: '',
+      infoHash: '',
+      alreadyExists: false,
+    }))
+  )
+
+  const newFiles = useMemo(() => fileList.filter(item => !item.alreadyExists), [fileList])
+  const newCount = newFiles.length
+
+  const handleUpdate = useCallback((index, updates) => {
+    setFileList(prev => prev.map((item, i) => i === index ? { ...item, ...updates } : item))
+  }, [])
+
+  const handleRemove = useCallback((index) => {
+    setFileList(prev => {
+      const next = prev.filter((_, i) => i !== index)
+      if (next.length === 0) handleClose()
+      return next
+    })
+  }, [handleClose])
+
+  const handleSaveAll = () => {
+    setIsSaving(true)
+    const uploads = newFiles.map(item => {
+      const data = new FormData()
+      data.append('save', 'true')
+      data.append('file', item.file)
+      item.title && data.append('title', item.title)
+      item.poster && data.append('poster', item.poster)
+      item.category && data.append('category', item.category)
+      return axios.post(torrentUploadHost(), data).catch(() => {})
+    })
+    Promise.all(uploads).finally(handleClose)
+  }
+
+  return (
+    <StyledDialog open onClose={handleClose} fullScreen={fullScreen} fullWidth maxWidth='md' ref={ref}>
+      <StyledHeader>
+        {t('AddNewTorrent')} ({newCount})
+      </StyledHeader>
+
+      <MultiFileList>
+        {(() => {
+          let visibleIndex = 0
+          return fileList.map((item, index) => {
+            if (item.alreadyExists) return null
+            const currentIndex = visibleIndex++
+            return (
+              <FileRow
+                // eslint-disable-next-line react/no-array-index-key
+                key={item.file.name + index}
+                file={item.file}
+                fileState={item}
+                index={currentIndex}
+                onUpdate={updates => handleUpdate(index, updates)}
+                onRemove={() => handleRemove(index)}
+                existingTorrents={existingTorrents}
+              />
+            )
+          })
+        })()}
+      </MultiFileList>
+
+      <ButtonWrapper>
+        <Button onClick={handleClose} color='secondary' variant='outlined'>
+          {t('Cancel')}
+        </Button>
+
+        <Button
+          variant='contained'
+          style={{ minWidth: '110px' }}
+          disabled={newCount === 0}
+          onClick={handleSaveAll}
+          color='secondary'
+        >
+          {isSaving ? <CircularProgress style={{ color: 'white' }} size={20} /> : `${t('Add')} (${newCount})`}
+        </Button>
+      </ButtonWrapper>
+    </StyledDialog>
+  )
+}

--- a/web/src/components/Add/RightSideComponent.jsx
+++ b/web/src/components/Add/RightSideComponent.jsx
@@ -70,9 +70,7 @@ export default function RightSideComponent({
     checkImageURL(url).then(setIsPosterUrlCorrect)
     setIsUserInteractedWithPoster(true)
   }
-  // main categories
   const catIndex = TORRENT_CATEGORIES.findIndex(e => e.key === category)
-  // const catArray = TORRENT_CATEGORIES.find(e => e.key === category)
 
   return (
     <RightSide>

--- a/web/src/components/Add/helpers.js
+++ b/web/src/components/Add/helpers.js
@@ -79,7 +79,7 @@ export const checkImageURL = async url => {
 }
 
 const magnetRegex = /^magnet:\?xt=urn:[a-z0-9].*/i
-export const hashRegex = /^\b[0-9a-f]{32}\b$|^\b[0-9a-f]{40}\b$|^\b[0-9a-f]{64}\b$/i
+const hashRegex = /^\b[0-9a-f]{32}\b$|^\b[0-9a-f]{40}\b$|^\b[0-9a-f]{64}\b$/i
 const torrentRegex = /^.*\.(torrent)$/i
 const linkRegex = /^(http(s?)):\/\/.*/i
 const torrsRegex = /^(torrs):\/\/.*/i

--- a/web/src/components/Add/style.js
+++ b/web/src/components/Add/style.js
@@ -127,38 +127,6 @@ export const LeftSideBottomSectionNoFile = styled.div`
   }
 `
 
-export const LeftSideBottomSectionFileSelected = styled.div`
-  ${LeftSideBottomSectionBasicStyles}
-  place-items: center;
-
-  @media (max-width: 930px) {
-    height: 400px;
-  }
-
-  @media (max-width: 500px) {
-    height: 170px;
-  }
-`
-
-export const TorrentIconWrapper = styled.div`
-  position: relative;
-`
-
-export const CancelIconWrapper = styled.div`
-  position: absolute;
-  top: -9px;
-  left: 10px;
-  cursor: pointer;
-
-  > svg {
-    transition: all 0.3s;
-    fill: rgba(0, 0, 0, 0.7);
-
-    :hover {
-      fill: rgba(0, 0, 0, 0.6);
-    }
-  }
-`
 
 export const IconWrapper = styled.div`
   display: grid;
@@ -347,6 +315,75 @@ export const PosterLanguageSwitch = styled.div`
       filter: brightness(1.1);
     }
   `}
+`
+
+export const MultiFileRow = styled.div`
+  padding: 12px 16px;
+  margin: 8px 12px;
+  border-radius: 5px;
+  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.12), 0px 1px 2px rgba(0, 0, 0, 0.08);
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 12px;
+  align-items: start;
+  transition: box-shadow 0.2s;
+
+  :hover {
+    box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.16), 0px 1px 4px rgba(0, 0, 0, 0.12);
+  }
+`
+
+export const MultiFilePoster = styled.div`
+  ${({
+    theme: {
+      addDialog: { posterBGColor },
+    },
+  }) => css`
+    width: 80px;
+    height: 110px;
+    border-radius: 4px;
+    overflow: hidden;
+    background: ${posterBGColor};
+    display: grid;
+    place-items: center;
+    position: relative;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .file-index {
+      position: absolute;
+      top: 4px;
+      left: 4px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.5);
+      color: #fff;
+      font-size: 11px;
+      font-weight: 600;
+      display: grid;
+      place-items: center;
+    }
+  `}
+`
+
+export const MultiFileInfo = styled.div`
+  .file-name {
+    font-size: 13px;
+    opacity: 0.6;
+    margin-bottom: 4px;
+  }
+
+`
+
+export const MultiFileList = styled.div`
+  max-height: 500px;
+  overflow: auto;
+  padding: 4px 0;
 `
 
 export const StyledPWAAddButton = styled.div`

--- a/web/src/components/App/style.js
+++ b/web/src/components/App/style.js
@@ -103,7 +103,7 @@ export const TorrentListWrapper = styled.div`
 
   display: grid;
   place-content: start;
-  grid-template-columns: repeat(auto-fit, minmax(max-content, 570px));
+  grid-template-columns: repeat(auto-fit, minmax(450px, 570px));
   gap: 20px;
 
   @media (max-width: 1260px), (max-height: 500px) {

--- a/web/src/components/TorrentCard/index.jsx
+++ b/web/src/components/TorrentCard/index.jsx
@@ -248,4 +248,18 @@ export const StatusIndicator = ({ stat }) => {
   )
 }
 
-export default memo(Torrent)
+export default memo(Torrent, (prev, next) => {
+  const p = prev.torrent
+  const n = next.torrent
+  return (
+    p.hash === n.hash &&
+    p.title === n.title &&
+    p.name === n.name &&
+    p.poster === n.poster &&
+    p.category === n.category &&
+    p.stat === n.stat &&
+    p.torrent_size === n.torrent_size &&
+    p.download_speed === n.download_speed &&
+    p.data === n.data
+  )
+})

--- a/web/src/components/TorrentList/index.jsx
+++ b/web/src/components/TorrentList/index.jsx
@@ -1,14 +1,30 @@
+import { useMemo } from 'react'
 import TorrentCard from 'components/TorrentCard'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import { TorrentListWrapper, CenteredGrid } from 'components/App/style'
-// import { useTranslation } from 'react-i18next'
 
 import NoServerConnection from './NoServerConnection'
 import AddFirstTorrent from './AddFirstTorrent'
 
 export default function TorrentList({ isOffline, isLoading, sortABC, torrents, sortCategory }) {
-  // const { t } = useTranslation()
-  if (isLoading || isOffline || !torrents.length) {
+  const sortedTorrents = useMemo(() => {
+    if (!torrents) return []
+    const filtered = torrents.filter(torrent => sortCategory === 'all' || torrent.category === sortCategory)
+
+    if (sortABC) {
+      return [...filtered].sort((a, b) => (a.title || '').localeCompare(b.title || '') || a.hash.localeCompare(b.hash))
+    }
+
+    // Default: keep API order but stabilize by hash to prevent jumping
+    return [...filtered].sort((a, b) => {
+      const tsA = a.timestamp || 0
+      const tsB = b.timestamp || 0
+      if (tsA !== tsB) return tsB - tsA
+      return a.hash.localeCompare(b.hash)
+    })
+  }, [torrents, sortCategory, sortABC])
+
+  if (isLoading || isOffline || !torrents?.length) {
     return (
       <CenteredGrid>
         {isOffline ? (
@@ -22,19 +38,9 @@ export default function TorrentList({ isOffline, isLoading, sortABC, torrents, s
     )
   }
 
-  const filteredTorrents = torrents.filter(torrent => sortCategory === 'all' || torrent.category === sortCategory)
-
-  return sortABC ? (
+  return (
     <TorrentListWrapper>
-      {filteredTorrents
-        .sort((a, b) => a.title > b.title)
-        .map(torrent => (
-          <TorrentCard key={torrent.hash} torrent={torrent} />
-        ))}
-    </TorrentListWrapper>
-  ) : (
-    <TorrentListWrapper>
-      {filteredTorrents.map(torrent => (
+      {sortedTorrents.map(torrent => (
         <TorrentCard key={torrent.hash} torrent={torrent} />
       ))}
     </TorrentListWrapper>

--- a/web/src/locales/bg/translation.json
+++ b/web/src/locales/bg/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "Линк към плаката",
     "AddTorrentSourceNotification": "Първо добавете вашия торент източник",
     "AppendFile": {
-      "ClickOrDrag": "Щракнете / Влачи§Пусни (.torrent)",
+      "ClickOrDrag": "Щракнете / Влачи§Пусни ФАЙЛОВЕ (.torrent)",
       "Or": "или"
     },
     "CategoryHelperText": "Торент категория",

--- a/web/src/locales/en/translation.json
+++ b/web/src/locales/en/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "Poster link",
     "AddTorrentSourceNotification": "First add your torrent source",
     "AppendFile": {
-      "ClickOrDrag": "CLICK / DRAG & DROP (.torrent)",
+      "ClickOrDrag": "CLICK / DRAG & DROP FILES (.torrent)",
       "Or": "OR"
     },
     "CategoryHelperText": "Torrent category",

--- a/web/src/locales/fr/translation.json
+++ b/web/src/locales/fr/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "Lien de l'affiche",
     "AddTorrentSourceNotification": "Ajoutez d'abord votre source de torrent",
     "AppendFile": {
-      "ClickOrDrag": "CLIQUER / GLISSER-DÉPOSER (.torrent)",
+      "ClickOrDrag": "CLIQUER / GLISSER-DÉPOSER DES FICHIERS (.torrent)",
       "Or": "OU"
     },
     "CategoryHelperText": "Catégorie du torrent",

--- a/web/src/locales/ro/translation.json
+++ b/web/src/locales/ro/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "Link către poster",
     "AddTorrentSourceNotification": "Mai întâi adăugați sursa torrentului",
     "AppendFile": {
-      "ClickOrDrag": "CLICK / TRAGE ȘI PLASEAZĂ (.torrent)",
+      "ClickOrDrag": "CLICK / TRAGE ȘI PLASEAZĂ FIȘIERE (.torrent)",
       "Or": "SAU"
     },
     "CategoryHelperText": "Categorie torrent",

--- a/web/src/locales/ru/translation.json
+++ b/web/src/locales/ru/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "Ссылка на постер",
     "AddTorrentSourceNotification": "Сначала добавьте торрент",
     "AppendFile": {
-      "ClickOrDrag": "НАЖМИТЕ / ПЕРЕТАЩИТЕ ФАЙЛ (.torrent)",
+      "ClickOrDrag": "НАЖМИТЕ / ПЕРЕТАЩИТЕ ФАЙЛЫ (.torrent)",
       "Or": "ИЛИ"
     },
     "CategoryHelperText": "Категория для торрента",

--- a/web/src/locales/ua/translation.json
+++ b/web/src/locales/ua/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "Посилання на плакат",
     "AddTorrentSourceNotification": "Спочатку додайте torrent-джерело",
     "AppendFile": {
-      "ClickOrDrag": "НАТИСНІТЬ / ПЕРЕТЯГНІТЬ ФАЙЛ (.torrent)",
+      "ClickOrDrag": "НАТИСНІТЬ / ПЕРЕТЯГНІТЬ ФАЙЛИ (.torrent)",
       "Or": "ЧИ"
     },
     "CategoryHelperText": "Торрент-категорія",

--- a/web/src/locales/zh/translation.json
+++ b/web/src/locales/zh/translation.json
@@ -6,7 +6,7 @@
     "AddPosterLinkInput": "海报链接",
     "AddTorrentSourceNotification": "先添加你的种子",
     "AppendFile": {
-      "ClickOrDrag": "点击/拖放上传 (.torrent)",
+      "ClickOrDrag": "点击/拖放上传文件 (.torrent)",
       "Or": "或"
     },
     "CategoryHelperText": "Torrent 类别",


### PR DESCRIPTION
## Summary

Adds support for selecting and uploading multiple `.torrent` files at once, with a dedicated dialog for editing each file's metadata before saving.

### New functionality

- **Multi-file upload**: Dropzone now accepts multiple `.torrent` files (drag & drop or file picker)
- **MultiAddDialog**: When files are selected, a new dialog displays all files as a scrollable list. Each file has:
  - Poster thumbnail with index number (auto-fetched from TMDB)
  - Editable title field (pre-filled with filename without .torrent extension)
  - Editable poster URL field
  - Category selector
  - Delete button to remove from batch
- **Duplicate filtering**: Each file's infohash is parsed client-side and compared against existing torrents in DB. Duplicates are silently filtered out — only new torrents are shown and uploaded
- **Unified flow**: Both single and multiple file uploads use the same list-based UI
- **Card separation**: Each file displayed as a distinct card with border-radius, shadow and spacing

### Code changes

- New `MultiAddDialog` component with styled-components (`MultiFileRow`, `MultiFilePoster`, `MultiFileInfo`, `MultiFileList`)
- Simplified `AddDialog`: file uploads delegated to `MultiAddDialog`, handles only link/magnet/hash and edit mode
- Simplified `LeftSideComponent`: no "file selected" state, dropzone always visible
- Backend `upload.go`: cleaned up dead multiFile title/poster blanking logic
- Stable torrent list sort via `useMemo` (timestamp + hash tiebreaker)
- `TorrentCard` memo optimization with custom comparator for visible fields
- Grid layout fix: `minmax(450px, 570px)` instead of unstable `minmax(max-content, 570px)`
- Null guards for `torrents` before `.map()/.filter()` (crash fix on initial render)
- Removed dead code: `LeftSideBottomSectionFileSelected`, `TorrentIconWrapper`, `CancelIconWrapper`, unused `hashRegex` export
- Updated `ClickOrDrag` text in all 7 locales for multiple file support

## Test plan

- [ ] Drop single `.torrent` file — list with one editable item
- [ ] Drop multiple `.torrent` files — all shown with individual fields and correct numbering
- [ ] Drop already-added `.torrent` files — duplicates filtered out, only new shown
- [ ] All files are duplicates — dialog closes (nothing to add)
- [ ] Add via magnet/hash/link — original flow unchanged
- [ ] Edit existing torrent — edit dialog unchanged
- [ ] Verify cards don't jump after adding
- [ ] Test on narrow screen (<700px) — dialog goes fullscreen