### PR TITLE
feat(tgbot): add SOCKS5 proxy support for Telegram API requests

### DIFF
--- a/server/tgbot/README.md
+++ b/server/tgbot/README.md
@@ -46,6 +46,7 @@ Config file `tg.cfg` (JSON) in the TorrServer data directory:
 |------------|-------------|
 | `HostTG`   | Telegram API URL (default: `https://api.telegram.org`) |
 | `HostWeb`  | Base URL for stream links (auto-detected if empty) |
+| `Socks5`   | Optional SOCKS5 for reaching Telegram (e.g. `127.0.0.1:1080`, `socks5://user:pass@host:port`) if direct access to `api.telegram.org` is blocked or times out |
 | `WhiteIds` | Allowed user IDs (empty = allow all) |
 | `BlackIds` | Blocked user IDs |
 
@@ -55,10 +56,13 @@ Example:
 {
   "HostTG": "https://api.telegram.org",
   "HostWeb": "http://192.168.1.100:8090",
+  "Socks5": "127.0.0.1:1080",
   "WhiteIds": [123456789],
   "BlackIds": []
 }
 ```
+
+If your network cannot connect to Telegram’s API directly, run a local SOCKS5 proxy (for example [sing-box](https://github.com/SagerNet/sing-box), v2ray, or `ssh -D`) and set `Socks5` to its address.
 
 ## Commands
 

--- a/server/tgbot/bot.go
+++ b/server/tgbot/bot.go
@@ -1,12 +1,16 @@
 package tgbot
 
 import (
+	"context"
 	"errors"
+	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"golang.org/x/net/proxy"
 	tele "gopkg.in/telebot.v4"
 	"gopkg.in/telebot.v4/middleware"
 
@@ -14,6 +18,51 @@ import (
 	"server/tgbot/config"
 	up "server/tgbot/upload"
 )
+
+func newTelegramHTTPClient() *http.Client {
+	const timeout = 5 * time.Minute
+	trimmed := strings.TrimSpace(config.Cfg.Socks5)
+	if trimmed == "" {
+		return &http.Client{Timeout: timeout}
+	}
+	raw := trimmed
+	if !strings.Contains(raw, "://") {
+		raw = "socks5://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		log.TLogln("tg cfg Socks5 parse err, using direct", err)
+		return &http.Client{Timeout: timeout}
+	}
+	if u.Scheme != "socks5" {
+		log.TLogln("tg cfg Socks5: only socks5 is supported, got", u.Scheme)
+		return &http.Client{Timeout: timeout}
+	}
+	proxyHost := u.Host
+	if proxyHost == "" {
+		log.TLogln("tg cfg Socks5: empty host, using direct")
+		return &http.Client{Timeout: timeout}
+	}
+	var auth *proxy.Auth
+	if u.User != nil {
+		pw, _ := u.User.Password()
+		auth = &proxy.Auth{User: u.User.Username(), Password: pw}
+	}
+	socksDial, err := proxy.SOCKS5("tcp", proxyHost, auth, proxy.Direct)
+	if err != nil {
+		log.TLogln("tg socks5 dialer err, using direct", err)
+		return &http.Client{Timeout: timeout}
+	}
+	log.TLogln("tg using SOCKS5 proxy", proxyHost)
+	transport := &http.Transport{
+		Proxy: nil, // respect explicit socks only, not HTTP_PROXY, for this client
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			_ = ctx
+			return socksDial.Dial(network, address)
+		},
+	}
+	return &http.Client{Transport: transport, Timeout: timeout}
+}
 
 func Start(token string) error {
 	config.LoadConfig()
@@ -24,7 +73,7 @@ func Start(token string) error {
 		Token:     token,
 		Poller:    &tele.LongPoller{Timeout: 5 * time.Minute},
 		ParseMode: tele.ModeHTML,
-		Client:    &http.Client{Timeout: 5 * time.Minute},
+		Client:    newTelegramHTTPClient(),
 	}
 
 	log.TLogln("tg bot starting")

--- a/server/tgbot/config/config.go
+++ b/server/tgbot/config/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	HostTG   string
 	HostWeb  string
+	Socks5   string
 	WhiteIds []int64
 	BlackIds []int64
 }


### PR DESCRIPTION
- Implemented a new HTTP client that routes traffic through a SOCKS5 proxy if specified in the configuration
- Updated the README to include instructions for configuring the SOCKS5 proxy