### PR TITLE
feat: add ForceHTTPS option and HTTP to HTTPS redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ On FreeBSD (TrueNAS/FreeNAS) you can use this plugin: <https://github.com/filka9
 - `--sslport PORT` -  web server https port (default 8091). If not set, will be taken from db (if stored previously) or the default will be used.
 - `--sslcert PATH` -  path to ssl cert file. If not set, will be taken from db (if stored previously) or default self-signed certificate/key will be generated.
 - `--sslkey PATH` - path to ssl key file. If not set, will be taken from db (if stored previously) or default self-signed certificate/key will be generated.
+- `--force-https` - with `--ssl`, the HTTP listener (`--port`) answers only with **307 Temporary Redirect** to the same path on HTTPS (`--sslport`). The web UI and API are served on HTTPS only; nothing is served on HTTP except redirects. Requires `--ssl` (startup fails if `--force-https` is set without `--ssl`). Default is off so plain HTTP still works when SSL is disabled.
 - `--path PATH`, `-d PATH` - database and config dir path
 - `--logpath LOGPATH`, `-l LOGPATH` - server log file path
 - `--weblogpath WEBLOGPATH`, `-w WEBLOGPATH` - web access log file path
@@ -187,7 +188,7 @@ On FreeBSD (TrueNAS/FreeNAS) you can use this plugin: <https://github.com/filka9
 Example:
 
 ```bash
-TorrServer-darwin-arm64 [--port PORT] [--ip IP] [--path PATH] [--logpath LOGPATH] [--weblogpath WEBLOGPATH] [--rdb] [--httpauth] [--dontkill] [--ui] [--torrentsdir TORRENTSDIR] [--torrentaddr TORRENTADDR] [--pubipv4 PUBIPV4] [--pubipv6 PUBIPV6] [--searchwa] [--maxsize MAXSIZE] [--tg TGTOKEN] [--fuse FUSEPATH] [--webdav]
+TorrServer-darwin-arm64 [--port PORT] [--ip IP] [--path PATH] [--logpath LOGPATH] [--weblogpath WEBLOGPATH] [--rdb] [--httpauth] [--dontkill] [--ui] [--torrentsdir TORRENTSDIR] [--torrentaddr TORRENTADDR] [--pubipv4 PUBIPV4] [--pubipv6 PUBIPV6] [--searchwa] [--maxsize MAXSIZE] [--tg TGTOKEN] [--fuse FUSEPATH] [--webdav] [--ssl] [--sslport PORT] [--sslcert PATH] [--sslkey PATH] [--force-https]
 ```
 
 ### Running in Docker & Docker Compose

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -50,6 +50,7 @@ type args struct {
 	WebDAV      bool   `help:"web dav enable"`
 	ProxyURL    string `help:"proxy URL for BitTorrent traffic (http, socks4, socks5, socks5h), e.g. socks5://user:password@127.0.0.1:8080"`
 	ProxyMode   string `help:"proxy mode: tracker (only HTTP trackers, default), peers (only peer connections), or full (all traffic)"`
+	ForceHTTPS  bool   `arg:"--force-https" help:"redirect all HTTP requests to HTTPS (requires --ssl)"`
 }
 
 func (args) Version() string {
@@ -171,10 +172,16 @@ func main() {
 		WebDAV:      params.WebDAV,
 		ProxyURL:    params.ProxyURL,
 		ProxyMode:   params.ProxyMode,
+		ForceHTTPS:  params.ForceHTTPS,
 	}
 
 	if params.ProxyURL != "" {
 		log.TLogln("Proxy configured from CLI:", params.ProxyURL, "mode:", settings.Args.ProxyMode)
+	}
+
+	if params.ForceHTTPS && !params.Ssl {
+		log.TLogln("Error: --force-https requires --ssl")
+		os.Exit(1)
 	}
 
 	server.Start()

--- a/server/settings/args.go
+++ b/server/settings/args.go
@@ -25,6 +25,7 @@ type ExecArgs struct {
 	WebDAV      bool
 	ProxyURL    string
 	ProxyMode   string
+	ForceHTTPS  bool
 }
 
 var Args *ExecArgs

--- a/server/web/https_redirect.go
+++ b/server/web/https_redirect.go
@@ -1,0 +1,48 @@
+package web
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+
+	"server/log"
+	"server/settings"
+)
+
+func runHTTPRedirectToHTTPS(addr string) error {
+	h := func(w http.ResponseWriter, r *http.Request) {
+		target := buildHTTPSRedirectTarget(r)
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+	}
+	log.TLogln("Start http server (redirect to https) at", addr)
+	return http.ListenAndServe(addr, http.HandlerFunc(h))
+}
+
+func buildHTTPSRedirectTarget(r *http.Request) string {
+	host := r.Host
+	hostName, _, err := net.SplitHostPort(host)
+	if err != nil {
+		hostName = host
+	}
+	sslPort := settings.SslPort
+	if sslPort == "" {
+		sslPort = "8091"
+	}
+	var httpsHost string
+	if sslPort == "443" {
+		httpsHost = hostName
+	} else {
+		httpsHost = net.JoinHostPort(hostName, sslPort)
+	}
+	path := r.URL.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	u := &url.URL{
+		Scheme:   "https",
+		Host:     httpsHost,
+		Path:     path,
+		RawQuery: r.URL.RawQuery,
+	}
+	return u.String()
+}

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -120,8 +120,13 @@ func Start() {
 	}
 
 	go func() {
-		log.TLogln("Start http server at", settings.IP+":"+settings.Port)
-		waitChan <- route.Run(settings.IP + ":" + settings.Port)
+		addr := settings.IP + ":" + settings.Port
+		if settings.Args != nil && settings.Args.ForceHTTPS && settings.Ssl {
+			waitChan <- runHTTPRedirectToHTTPS(addr)
+			return
+		}
+		log.TLogln("Start http server at", addr)
+		waitChan <- route.Run(addr)
 	}()
 }
 


### PR DESCRIPTION
Resolve #669 
- Introduced a new ForceHTTPS flag in the configuration to enforce redirection of all HTTP requests to HTTPS.
- Implemented an HTTP server that handles redirection to HTTPS when the ForceHTTPS option is enabled.