### PR TITLE
Prevent nil pointer dereference and duplicate cache creation

### DIFF
--- a/server/torr/storage/torrstor/cache.go
+++ b/server/torr/storage/torrstor/cache.go
@@ -354,6 +354,9 @@ func (c *Cache) CloseReader(r *Reader) {
 }
 
 func (c *Cache) clearPriority() {
+	if c.torrent == nil { 
+        return 
+    }
 	time.Sleep(time.Second)
 	ranges := make([]Range, 0)
 	c.muReaders.Lock()

--- a/server/torr/storage/torrstor/storage.go
+++ b/server/torr/storage/torrstor/storage.go
@@ -30,6 +30,9 @@ func (s *Storage) OpenTorrent(info *metainfo.Info, infoHash metainfo.Hash) (ts.T
 	// } //	NE
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if ch, ok := s.caches[infoHash]; ok {
+		return ch, nil
+	}
 	ch := NewCache(s.capacity, s)
 	ch.Init(info, infoHash)
 	s.caches[infoHash] = ch


### PR DESCRIPTION
### Changes made:

In `storage.go`: Modified `OpenTorrent` to check if a cache instance for the given `infoHash` already exists. If found, it returns the existing instance instead of creating and initializing a new one

In `cache.go`: Added a safety check in `clearPriority()` to ensure `c.torrent `is not nil before accessing its methods. This prevents the server from crashing if a cache cleanup is triggered before the torrent object is fully initialized.

### Why this is important:

Stability: Prevents `SIGSEGV` crashes on systems with high latency or concurrent requests.

Resource Management: Prevents `"race conditions"` where multiple requests for the same torrent would trigger multiple Init calls.

Efficiency: Ensures that only one `"torrent"` instance is created per hash.