### PR TITLE
Fix multi-reader handling

### DIFF
--- a/server/torr/storage/torrstor/reader.go
+++ b/server/torr/storage/torrstor/reader.go
@@ -161,7 +161,15 @@ func (r *Reader) getOffsetRange() (int64, int64) {
 }
 
 func (r *Reader) checkReader() {
-	if time.Now().Unix() > r.lastAccess+60 && len(r.cache.readers) > 1 {
+	if len(r.cache.readers) > 1 {
+		for o := range r.cache.readers {
+			if o != r && o.lastAccess > r.lastAccess {
+				r.readerOff()
+				return
+			}
+		}
+	}
+	if time.Now().Unix() > r.lastAccess+60 {
 		r.readerOff()
 	} else {
 		r.readerOn()


### PR DESCRIPTION
The only addition is improved handling for multi-reader scenarios (e.g. Kodi). When multiple readers exist, the older reader is now properly detected and closed to avoid cache conflicts

The original behavior has not been changed for single-reader playback.

**Before:**
https://github.com/user-attachments/assets/5f205eb1-2160-4c01-bd3f-d1386199ed56

**After:**
https://github.com/user-attachments/assets/75c190b1-7363-4475-aad0-78eec8213b13

