### PR TITLE
Improve Reader Management

### DIFF
--- a/server/torr/storage/torrstor/reader.go
+++ b/server/torr/storage/torrstor/reader.go
@@ -36,6 +36,13 @@ func newReader(file *torrent.File, cache *Cache) *Reader {
 	r.isUse = true
 
 	cache.muReaders.Lock()
+	for old := range cache.readers {
+		if old.file == file {
+			old.Close()
+			delete(cache.readers, old)
+		}
+	}
+
 	cache.readers[r] = struct{}{}
 	cache.muReaders.Unlock()
 	return r


### PR DESCRIPTION
This PR improves the Reader lifecycle management in the torrent HTTP streaming layer by enforcing a single active reader per file.
It ensures that when a new reader is created for the same file, any existing reader for that file is closed and removed from the cache.

**Changes**
Added automatic cleanup of existing readers per file in `newReader`
Ensured only one active reader exists per torrent file
Prevented stale readers from accumulating in `cache.readers`
Improved behavior for Kodi seek / fast-forward / rewind scenarios

**Benefits**
Improves streaming stability
Reduces resource usage
Compatible with all players, checked on vimu, vlc, kodi

**Before:**
https://github.com/user-attachments/assets/1a750b6c-a69e-4abc-be1a-3bf691cd03f8

**After:**
https://github.com/user-attachments/assets/b7f5416b-5d9f-4a2e-89d5-2e0097926cc8


