### PR TITLE
Fix critical server hangs

### DIFF
--- a/server/torr/apihelper.go
+++ b/server/torr/apihelper.go
@@ -158,25 +158,50 @@ func SetTorrent(hashHex, title, poster, category string, data string) *Torrent {
 	}
 }
 
+
 func RemTorrent(hashHex string) {
 	if sets.ReadOnly {
 		log.TLogln("API RemTorrent: Read-only DB mode!", hashHex)
 		return
 	}
 	hash := metainfo.NewHashFromHex(hashHex)
-	if bts.RemoveTorrent(hash) {
+	
+	// Download the torrent before deleting it to get the "closed" status
+	torr := bts.GetTorrent(hash)
+	if torr == nil {
+		// If the torrent isn't in memory, just delete it from the database and the files
+		RemTorrentDB(hash)
 		if sets.BTsets.UseDisk && hashHex != "" && hashHex != "/" {
 			name := filepath.Join(sets.BTsets.TorrentsSavePath, hashHex)
-			ff, _ := os.ReadDir(name)
-			for _, f := range ff {
-				os.Remove(filepath.Join(name, f.Name()))
-			}
-			err := os.Remove(name)
-			if err != nil {
-				log.TLogln("Error remove cache:", err)
+			os.RemoveAll(name)
+		}
+		return
+	}
+	
+	closedChan := torr.closed
+	
+	// Clear from memory
+	if bts.RemoveTorrent(hash) {
+		// Waiting for confirmation from the library via the closed channel
+		select {
+		case <-closedChan:
+			// The library has confirmed the closure
+			log.TLogln("Torrent closed by library:", hashHex)
+		case <-time.After(5 * time.Second):
+			log.TLogln("Warning: timeout waiting for torrent close:", hashHex)
+		}
+		
+		// Now we can safely delete the files from the disk
+		if sets.BTsets.UseDisk && hashHex != "" && hashHex != "/" {
+			name := filepath.Join(sets.BTsets.TorrentsSavePath, hashHex)
+			if _, err := os.Stat(name); err == nil {
+				log.TLogln("Removing cache files for:", hashHex)
+				os.RemoveAll(name)
 			}
 		}
 	}
+	
+	// Delete from the database
 	RemTorrentDB(hash)
 }
 

--- a/server/torr/storage/torrstor/cache.go
+++ b/server/torr/storage/torrstor/cache.go
@@ -188,14 +188,15 @@ func (c *Cache) cleanPieces() {
 	if c.isRemove || c.isClosed {
 		return
 	}
-	c.muRemove.Lock()
-	if c.isRemove {
-		c.muRemove.Unlock()
-		return
+	
+	// Protection against concurrent deletion
+	if !c.muRemove.TryLock() {
+		return // Cleanup is already in progress in another goroutine
 	}
+	defer c.muRemove.Unlock()
+	
 	c.isRemove = true
 	defer func() { c.isRemove = false }()
-	c.muRemove.Unlock()
 
 	remPieces := c.getRemPieces()
 	if c.filled > c.capacity {
@@ -212,20 +213,28 @@ func (c *Cache) cleanPieces() {
 }
 
 func (c *Cache) getRemPieces() []*Piece {
-	piecesRemove := make([]*Piece, 0)
-	fill := int64(0)
-
-	ranges := make([]Range, 0)
+	// Copy readers without a long lock
 	c.muReaders.Lock()
+	readers := make([]*Reader, 0, len(c.readers))
 	for r := range c.readers {
+		readers = append(readers, r)
+	}
+	c.muReaders.Unlock()
+
+	// Collect read ranges from active readers
+	ranges := make([]Range, 0)
+	for _, r := range readers {
 		r.checkReader()
 		if r.isUse {
 			ranges = append(ranges, r.getPiecesRange())
 		}
 	}
-	c.muReaders.Unlock()
 	ranges = mergeRange(ranges)
 
+	piecesRemove := make([]*Piece, 0)
+	fill := int64(0)
+
+	// Determine which chunks can be deleted
 	for id, p := range c.pieces {
 		if p.Size > 0 {
 			fill += p.Size
@@ -237,7 +246,7 @@ func (c *Cache) getRemPieces() []*Piece {
 				}
 			}
 		} else {
-			// on preload clean
+			// When preloading, clear everything except the beginning and end of the file
 			if p.Size > 0 && !c.isIdInFileBE(ranges, id) {
 				piecesRemove = append(piecesRemove, p)
 			}
@@ -247,6 +256,7 @@ func (c *Cache) getRemPieces() []*Piece {
 	c.clearPriority()
 	c.setLoadPriority(ranges)
 
+	// Sort by last access time (oldest first)
 	sort.Slice(piecesRemove, func(i, j int) bool {
 		return piecesRemove[i].Accessed < piecesRemove[j].Accessed
 	})

--- a/server/torr/storage/torrstor/piece.go
+++ b/server/torr/storage/torrstor/piece.go
@@ -74,8 +74,8 @@ func (p *Piece) Release() {
 	} else {
 		p.dPiece.Release()
 	}
-	if !p.cache.isClosed {
+	//if !p.cache.isClosed {
 		p.cache.torrent.Piece(p.Id).SetPriority(torrent.PiecePriorityNone)
 		p.cache.torrent.Piece(p.Id).UpdateCompletion()
-	}
+	//}
 }


### PR DESCRIPTION
- torrent.go: Add nil cache check in expired() and protect against double close
- piece.go: Remove isClosed check in Release() to prevent library deadlock
- apihelper.go: Wait for torrent close via closedChan before deleting files
- cache.go: Fix deadlock in getRemPieces() (copy readers without locking)
- cache.go: Add TryLock() in cleanPieces() to prevent recursive calls

Co-authored-by: @lexandr0s
Co-authored-by: Vuzzy