### PR TITLE
Response header for Kodi

### DIFF
--- a/server/torr/stream.go
+++ b/server/torr/stream.go
@@ -111,6 +111,8 @@ func (t *Torrent) Stream(fileID int, req *http.Request, resp http.ResponseWriter
 
 	// Set response headers
 	resp.Header().Set("Connection", "close")
+	// Set response header for Kodi				  
+	resp.Header().Set("Server", "TorrServer (Portable SDK for UPnP devices)")
 	// Add timeout header if configured
 	if streamTimeout > 0 {
 		resp.Header().Set("X-Stream-Timeout", fmt.Sprintf("%d", streamTimeout))


### PR DESCRIPTION
Apparently, the Kodi source code includes a header that resolves the issue with double reader seek operations in Kodi, and it works just like other players such as Vimu, VLC etc.

This header is for info purposes only for Kodi, it won't affect anything. This header simply disables multi-session in kodi

I've tested it, and it works great
https://github.com/user-attachments/assets/47540ff8-2bf4-441d-aaaa-708ad8539d7d


```HTTP/1.1 200 OK
Accept-Ranges: bytes
Connection: close
Content-Length: 1562978304
Content-Type: video/avi
Etag: "613566343236336363666462656639306664313161383739616262373364346566303461376164362f536872656b2e4e617673656764612e323031302e5255532e42445269702e587669442e4143332e2d48512d566944454f2e617669"
Last-Modified: Fri, 29 May 2026 11:49:37 GMT
Server: TorrServer (Portable SDK for UPnP devices)
Transfermode.dlna.org: Streaming
X-Stream-Timeout: 30
Date: Fri, 29 May 2026 11:49:38 GMT
```
