### PR TITLE
feat(docker): add version argument and update build flags

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -43,6 +43,25 @@ jobs:
         env:
           REPO: "${{ github.repository }}"
 
+      - name: Set version
+        run: |
+          SERVER_VERSION=$(sed -n 's/.*Version = "\([^"]*\)".*/\1/p' server/version/version.go)
+          SERVER_VER="${SERVER_VERSION#MatriX.}"
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            if [[ "$TAG" == MatriX.* ]]; then
+              VERSION="$TAG"
+            else
+              VERSION="MatriX.${TAG}"
+            fi
+          elif [[ "${{ github.ref }}" == refs/heads/* ]]; then
+            VERSION="MatriX.${SERVER_VER}.${GITHUB_SHA:0:7}"
+          else
+            VERSION="${SERVER_VERSION}"
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "Version: ${VERSION}"
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -64,5 +83,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             REACT_APP_TMDB_API_KEY=${{ secrets.TMDB_API_KEY }}
+            VERSION=${{ env.VERSION }}
           cache-from: type=gha,scope=${{ github.workflow }}
           cache-to: type=gha,mode=max,scope=${{ github.workflow }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=front /app/build /opt/src/web/build
 WORKDIR /opt/src
 
 ARG TARGETARCH
+ARG VERSION=MatriX.Docker
 
 # Step for multiarch build with docker buildx
 ENV GOARCH=$TARGETARCH
@@ -39,7 +40,7 @@ RUN apk add --update g++ \
     && cd server \
     && go mod tidy \
     && go clean -i -r -cache \
-    && go build -ldflags '-w -s' --o "torrserver" ./cmd
+    && go build -ldflags "-s -w -checklinkname=0 -X server/version.Version=${VERSION}" --o "torrserver" ./cmd
 ### BUILD TORRSERVER MULTIARCH END ###
 
 


### PR DESCRIPTION
The server version string is set at **build time** (Go `-ldflags`) and shown in the web UI, logs, and `--version`.

| How you build | `VERSION` value | Example |
|---------------|-----------------|---------|
| **Git tag** (CI) | tag name as-is | tag `MatriX.141.4` → `MatriX.141.4` |
| **Branch push** (CI: `master`, feature, …) | `MatriX.<base>.<sha>` | `MatriX.141.a1b2c3d` |
| **Local `docker build`** (no `--build-arg`) | Dockerfile default | `MatriX.141` |
| **CI fallback** (unusual ref) | `server/version/version.go` | `MatriX.141` |

- **Tag builds** — git tags use the full version name (e.g. `MatriX.141.4`). Legacy numeric tags (e.g. `141.4`) still get a `MatriX.` prefix.
- **Branch builds** — base number is read from `server/version/version.go` (part after `MatriX.`), then the first 7 characters of the commit SHA are appended.
- **Local Docker build** — if you omit `VERSION`, the Dockerfile `ARG VERSION=…` default is used (keep it in sync with `server/version/version.go`).
- **Override locally** — pass an explicit build arg:

  ```bash
  docker build --build-arg VERSION=MatriX.141.dev .
  ```