### PR TITLE
Refactored watchTDir to replace polling with event-driven filesystem monitoring using fsnotify

### DIFF
--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/alexflint/go-arg"
 	"github.com/pkg/browser"
+	"github.com/fsnotify/fsnotify"
 
 	"server"
 	"server/docs"
@@ -192,44 +193,89 @@ func main() {
 }
 
 func watchTDir(dir string) {
-	time.Sleep(5 * time.Second)
-	path, err := filepath.Abs(dir)
+
+	path, err := filepath.Abs(dir) // Attempt to convert the provided dir path into an absolute (full) filesystem path.
 	if err != nil {
 		path = dir
+	} // If an error occurs while obtaining the absolute path, the original relative path is used.
+
+	watcher, err := fsnotify.NewWatcher() // Create a new filesystem watcher (event-based instead of polling).
+	if err != nil {
+		log.TLogln("Error creating watcher:", err)
+		return
 	}
-	for {
-		files, err := os.ReadDir(path)
-		if err == nil {
-			for _, file := range files {
-				filename := filepath.Join(path, file.Name())
-				if strings.ToLower(filepath.Ext(file.Name())) == ".torrent" {
-					sp, err := utils.OpenTorrentFile(filename)
-					if err == nil {
-						tor, err := torr.AddTorrent(sp, "", "", "", "")
-						if err == nil {
-							if tor.GotInfo() {
-								if tor.Title == "" {
-									tor.Title = tor.Name()
-								}
-								torr.SaveTorrentToDB(tor)
-								tor.Drop()
-								os.Remove(filename)
-								time.Sleep(time.Second)
-							} else {
-								log.TLogln("Error get info from torrent")
-							}
-						} else {
-							log.TLogln("Error parse torrent file:", err)
-						}
-					} else {
-						log.TLogln("Error parse file name:", err)
-					}
-				}
+	defer watcher.Close()
+
+	err = watcher.Add(path) // Add target directory to watcher to receive filesystem events.
+	if err != nil {
+		log.TLogln("Error adding directory to watcher:", err)
+		return
+	}
+
+	for { // Start of an infinite loop for continuous background monitoring using filesystem events.
+
+		select {
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
 			}
-		} else {
-			log.TLogln("Error read dir:", err)
+
+			// Process only file creation or modification events
+			if event.Op&(fsnotify.Create|fsnotify.Write) == 0 {
+				continue
+			}
+
+			filename := event.Name
+			if strings.ToLower(filepath.Ext(filename)) != ".torrent" {
+				continue
+			}
+
+			func() { // Open an anonymous function to isolate processing context per file.
+				defer func() { // Deferred execution of a safety function that always runs at the end (even in case of panic).
+					if r := recover(); r != nil { // Catch critical runtime errors (panic) during torrent processing.
+						log.TLogln("Recovered from panic in watchTDir:", r) // Log recovered panic to prevent full service crash.
+					}
+				}()
+
+				sp, err := utils.OpenTorrentFile(filename) // Parse the torrent file: read Bencode structure and extract metadata.
+				if err != nil {
+					log.TLogln("Error parse file name:", err)
+					return
+				}
+
+				tor, err := torr.AddTorrent(sp, "", "", "", "") // Add parsed torrent specification into active torrent engine.
+				if err != nil {
+					log.TLogln("Error parse torrent file:", err)
+					return
+				}
+
+				if !tor.GotInfo() { // Check whether torrent metadata (info section) is available.
+					log.TLogln("Error get info from torrent") // If metadata is missing, log error and skip processing.
+					return
+				}
+
+				if tor.Title == "" { // If torrent has no custom title, assign default name from metadata.
+					tor.Title = tor.Name()
+				}
+
+				// Safely remove the original torrent file before writing to database.
+				// This prevents reprocessing in case of repeated filesystem events.
+				if err := os.Remove(filename); err != nil {
+					log.TLogln("Error removing torrent file:", err)
+				}
+
+				// Long database operation is now safe
+				torr.SaveTorrentToDB(tor) // Save torrent metadata into SQLite database.
+				tor.Drop() // Free RAM by removing torrent from active memory after processing.
+			}()
+
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			// Log filesystem watcher errors
+			log.TLogln("Watcher error:", err)
 		}
-		time.Sleep(time.Second * 5)
 	}
 }
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/anacrolix/publicip v0.3.1
 	github.com/anacrolix/torrent v1.59.1
 	github.com/dustin/go-humanize v1.0.1
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-contrib/location/v2 v2.0.0
 	github.com/gin-gonic/gin v1.11.0

--- a/server/go.sum
+++ b/server/go.sum
@@ -254,6 +254,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=
 github.com/gabriel-vasile/mimetype v1.4.12/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
### Improvements

* Replaced periodic directory scanning with filesystem events.
* Reduced CPU and disk usage by removing polling.
* Process new `.torrent` files as soon as they are created.
* Added better error handling.
* Isolated per-file processing to keep failures isolated.
* Added panic recovery to keep the watcher running.
* Reduced the chance of processing the same torrent more than once.

I tested the functionality on `Android`, `Linux`, and `Windows`