### PR TITLE
Display only the file name instead of the full torrent path in the DLNA item title

### DIFF
--- a/server/dlna/list.go
+++ b/server/dlna/list.go
@@ -260,12 +260,14 @@ func getObjFromTorrent(path, parent, host string, torr *torr.Torrent, file *stat
 	if settings.BTsets.EnableDebug {
 		log.TLogln("mime type", mime.String(), file.Path)
 	}
+	
+	fileName := filepath.Base(file.Path)
 
 	obj := upnpav.Object{
 		ID:         parent + "%2F" + url.PathEscape(file.Path),
 		ParentID:   parent,
 		Restricted: 1,
-		Title:      file.Path,
+		Title:      fileName,
 		Class:      "object.item." + mime.Type() + "Item",
 		Date:       upnpav.Timestamp{Time: time.Now()},
 	}


### PR DESCRIPTION
This improves readability, especially for torrents containing many files (e.g. TV series), where long paths can make the file list harder to navigate.

**Before**
<img width="469" height="336" alt="2" src="https://github.com/user-attachments/assets/9f59227c-a4df-47dd-bb65-36351730ca8f" />

**After**
<img width="306" height="307" alt="1" src="https://github.com/user-attachments/assets/ceb368b5-5b89-4dbb-b564-75660408496d" />