### PR TITLE
feat(scripts): add GStreamer build support for transcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,15 @@ allowing the cache size to be adjusted according to the system parameters and th
 - Torznab search (Jackett, Prowlarr, and similar indexer managers)
 - Cross-browser modern web interface
 - Optional DLNA server
+- Optional GStreamer build with transcoding support (from release 141.10)
 
 ## Getting Started
 
 ### Installation
 
 Download the application for the required platform in the [releases](https://github.com/YouROK/TorrServer/releases) page. After installation, open the link <http://127.0.0.1:8090> in the browser.
+
+Standard binaries are named `TorrServer-<platform>-<arch>` (for example, `TorrServer-linux-amd64`). From release **141.10**, an optional **GStreamer (gst)** build is also available as `TorrServer-gst-<platform>-<arch>` with transcoding support (published for **amd64** and **arm64** only). The install scripts below can install either variant.
 
 #### Windows
 
@@ -71,6 +74,7 @@ curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrSe
 The script supports interactive and non-interactive installation, configuration, updates, and removal. When running the script interactively, you can:
 
 - **Install/Update**: Choose to install or update TorrServer
+- **GStreamer build**: For releases 141.10+ on amd64/arm64, choose the gst build with transcoding support (or pass `--gst`)
 - **Reconfigure**: If TorrServer is already installed, you'll be prompted to reconfigure settings (port, auth, read-only mode, logging, BBR)
 - **Uninstall**: Type `Delete` (or `Удалить` in Russian) to uninstall TorrServer
 
@@ -92,6 +96,13 @@ curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrSe
 
   ```bash
   sudo bash ./installTorrServerLinux.sh --update --silent
+  ```
+
+- Install GStreamer build (141.10+):
+
+  ```bash
+  sudo bash ./installTorrServerLinux.sh --install --gst
+  sudo bash ./installTorrServerLinux.sh --update --gst --silent
   ```
 
 - Reconfigure settings interactively:
@@ -133,6 +144,7 @@ curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrSe
 - `--down VERSION` - Downgrade to specific version
 - `--remove` - Uninstall TorrServer
 - `--change-user USER` - Change service user (root|torrserver)
+- `--gst` - Install GStreamer build with transcoding support (141.10+, amd64/arm64 only)
 - `--root` - Run service as root user
 - `--silent` - Non-interactive mode with defaults
 - `--help` - Show help message
@@ -144,6 +156,28 @@ Run in Terminal.app
 ```bash
 curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerMac.sh -o installTorrserverMac.sh && chmod 755 installTorrServerMac.sh && bash ./installTorrServerMac.sh
 ```
+
+The macOS install script supports the same commands as the Linux script, including `--install`, `--update`, `--remove`, `--reconfigure`, and `--gst` for the GStreamer build (141.10+).
+
+**Command-line examples:**
+
+- Install latest version:
+
+  ```bash
+  bash ./installTorrServerMac.sh --install
+  ```
+
+- Install GStreamer build:
+
+  ```bash
+  bash ./installTorrServerMac.sh --install --gst
+  ```
+
+- Update silently:
+
+  ```bash
+  bash ./installTorrServerMac.sh --update --silent
+  ```
 
 Alternative install script for Intel Macs: <https://github.com/dancheskus/TorrServerMacInstaller>
 

--- a/installTorrServerLinux.sh
+++ b/installTorrServerLinux.sh
@@ -22,6 +22,9 @@ scriptname=$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")
 SILENT_MODE=0
 USE_ROOT_USER=0
 ROOT_PROMPTED=0
+USE_GST_BINARY=0
+GST_BINARY_EXPLICIT=0
+DETECTED_GST_VARIANT=-1
 
 # Command-line state
 parsedCommand=""
@@ -43,8 +46,10 @@ readonly REPO_URL="https://github.com/YouROK/TorrServer"
 readonly REPO_API_URL="https://api.github.com/repos/YouROK/TorrServer"
 readonly VERSION_PREFIX="MatriX"
 readonly BINARY_NAME_PREFIX="TorrServer-linux"
+readonly BINARY_PLATFORM="linux"
 readonly MIN_GLIBC_VERSION="2.32"
 readonly MIN_VERSION_REQUIRING_GLIBC=136
+readonly MIN_VERSION_WITH_GST="141.10"
 readonly SYSCTL_BBR_FILE="/etc/sysctl.d/90-torrserver.conf"
 
 # Color support
@@ -103,6 +108,10 @@ declare -A MSG_EN=(
 
   # Installation
   [installing_packages]="Installing missing packages…"
+  [pkg_running]="Running: %s"
+  [pkg_install_failed]="ERROR: Failed to install system packages"
+  [pkg_install_log]="Full log saved to: %s"
+  [pkg_install_output]="Package manager output:"
   [install_configure]="Install and configure TorrServer…"
   [starting_service]="Starting TorrServer…"
   [install_complete]="TorrServer %s installed to %s"
@@ -190,6 +199,12 @@ declare -A MSG_EN=(
   [installing_specific_version]="Installing specific version: %s"
   [service_reconfigured_user]="Service reconfigured for user: %s"
   [install_first_required]="Please install TorrServer first using: %s --install"
+  [enable_gst]="Install GStreamer (gst) build with transcoding support? (available from version %s+)"
+  [gst_not_available]="ERROR: GStreamer build is not available for version %s (requires %s+)"
+  [gst_not_available_arch]="ERROR: GStreamer build is not available for architecture %s (requires amd64 or arm64)"
+  [gst_fallback_standard]="Target version %s has no GStreamer build; using standard binary"
+  [using_gst_build]="Using GStreamer (gst) build"
+  [using_standard_build]="Using standard build"
 )
 
 declare -A MSG_RU=(
@@ -230,6 +245,10 @@ declare -A MSG_RU=(
 
   # Installation
   [installing_packages]="Устанавливаем недостающие пакеты…"
+  [pkg_running]="Выполняется: %s"
+  [pkg_install_failed]="ОШИБКА: Не удалось установить системные пакеты"
+  [pkg_install_log]="Полный журнал сохранён в: %s"
+  [pkg_install_output]="Вывод менеджера пакетов:"
   [install_configure]="Устанавливаем и настраиваем TorrServer…"
   [starting_service]="Запускаем службу TorrServer…"
   [install_complete]="TorrServer %s установлен в директории %s"
@@ -317,6 +336,12 @@ declare -A MSG_RU=(
   [installing_specific_version]="Установка конкретной версии: %s"
   [service_reconfigured_user]="Служба перенастроена для пользователя: %s"
   [install_first_required]="Пожалуйста, сначала установите TorrServer используя: %s --install"
+  [enable_gst]="Установить сборку GStreamer (gst) с поддержкой транскодирования? (доступна с версии %s+)"
+  [gst_not_available]="ОШИБКА: Сборка GStreamer недоступна для версии %s (требуется %s+)"
+  [gst_not_available_arch]="ОШИБКА: Сборка GStreamer недоступна для архитектуры %s (требуется amd64 или arm64)"
+  [gst_fallback_standard]="Для версии %s нет сборки GStreamer; используется стандартная сборка"
+  [using_gst_build]="Используется сборка GStreamer (gst)"
+  [using_standard_build]="Используется стандартная сборка"
 )
 
 # Translation function
@@ -366,7 +391,126 @@ isRoot() {
 }
 
 getBinaryName() {
-  echo "${BINARY_NAME_PREFIX}-${architecture}"
+  if [[ $USE_GST_BINARY -eq 1 ]]; then
+    echo "TorrServer-gst-${BINARY_PLATFORM}-${architecture}"
+  else
+    echo "${BINARY_NAME_PREFIX}-${architecture}"
+  fi
+}
+
+getAlternateBinaryName() {
+  if [[ $USE_GST_BINARY -eq 1 ]]; then
+    echo "${BINARY_NAME_PREFIX}-${architecture}"
+  else
+    echo "TorrServer-gst-${BINARY_PLATFORM}-${architecture}"
+  fi
+}
+
+getReleaseVersionNumber() {
+  local target_version="$1"
+  echo "${target_version#"${VERSION_PREFIX}".}"
+}
+
+supportsGstArch() {
+  [[ "$architecture" == "amd64" || "$architecture" == "arm64" ]]
+}
+
+supportsGstBinary() {
+  local target_version="$1"
+  local ver
+
+  supportsGstArch || return 1
+  ver=$(getReleaseVersionNumber "$target_version")
+  [[ -n "$ver" ]] && compareVersions "$ver" "$MIN_VERSION_WITH_GST"
+}
+
+reportGstUnavailableError() {
+  local target_version="$1"
+
+  if ! supportsGstArch; then
+    echo " - $(colorize red "$(msg gst_not_available_arch "$architecture")")"
+  else
+    echo " - $(colorize red "$(msg gst_not_available "$target_version" "$MIN_VERSION_WITH_GST")")"
+  fi
+  exit 1
+}
+
+detectInstalledBinaryVariant() {
+  if [[ $GST_BINARY_EXPLICIT -eq 1 ]]; then
+    return
+  fi
+
+  local gst_bin="TorrServer-gst-${BINARY_PLATFORM}-${architecture}"
+  local std_bin="${BINARY_NAME_PREFIX}-${architecture}"
+
+  if [[ -f "$dirInstall/$gst_bin" ]] && [[ $(stat -c%s "$dirInstall/$gst_bin" 2>/dev/null) -ne 0 ]]; then
+    DETECTED_GST_VARIANT=1
+    USE_GST_BINARY=1
+  elif [[ -f "$dirInstall/$std_bin" ]] && [[ $(stat -c%s "$dirInstall/$std_bin" 2>/dev/null) -ne 0 ]]; then
+    DETECTED_GST_VARIANT=0
+    USE_GST_BINARY=0
+  fi
+}
+
+removeAlternateBinary() {
+  local alt_bin
+  alt_bin=$(getAlternateBinaryName)
+  if [[ -f "$dirInstall/$alt_bin" ]]; then
+    rm -f "$dirInstall/$alt_bin"
+  fi
+}
+
+configureGstBinary() {
+  local target_version="$1"
+
+  if [[ $GST_BINARY_EXPLICIT -eq 1 ]]; then
+    if ! supportsGstBinary "$target_version"; then
+      reportGstUnavailableError "$target_version"
+    fi
+    USE_GST_BINARY=1
+    if [[ $SILENT_MODE -eq 0 ]]; then
+      echo " - $(msg using_gst_build)"
+    fi
+    return
+  fi
+
+  if ! supportsGstBinary "$target_version"; then
+    if [[ $USE_GST_BINARY -eq 1 ]]; then
+      USE_GST_BINARY=0
+      if [[ $SILENT_MODE -eq 0 ]]; then
+        echo " - $(msg gst_fallback_standard "$target_version")"
+      fi
+    else
+      USE_GST_BINARY=0
+    fi
+    return
+  fi
+
+  if [[ $SILENT_MODE -eq 1 ]]; then
+    if [[ $DETECTED_GST_VARIANT -eq 1 ]]; then
+      USE_GST_BINARY=1
+    else
+      USE_GST_BINARY=0
+    fi
+    return
+  fi
+
+  local recommended="n"
+  if [[ $DETECTED_GST_VARIANT -eq 1 ]]; then
+    recommended="y"
+  fi
+
+  if promptYesNo "$(msg enable_gst "$MIN_VERSION_WITH_GST")" "$recommended" "y"; then
+    USE_GST_BINARY=1
+  else
+    USE_GST_BINARY=0
+  fi
+
+  if [[ $USE_GST_BINARY -eq 1 ]]; then
+    echo " - $(msg using_gst_build)"
+  else
+    echo " - $(msg using_standard_build)"
+  fi
 }
 
 getVersionTag() {
@@ -789,10 +933,58 @@ delUser() {
 #     OS DETECTION & PACKAGES
 #############################################
 
+reportPackageInstallFailure() {
+  local cmd_display="$1"
+  local log_file="$2"
+
+  echo ""
+  echo " $(colorize red "$(msg pkg_install_failed)")"
+  echo " - $(msg pkg_running "$cmd_display")"
+  printf ' - %s\n' "$(msg pkg_install_log "$log_file")"
+  echo ""
+  echo " $(msg pkg_install_output)"
+  echo " -------------------------------------------------------------"
+  if [[ -s "$log_file" ]]; then
+    cat "$log_file" >&2
+  else
+    echo " (empty log)" >&2
+  fi
+  echo " -------------------------------------------------------------"
+  echo ""
+}
+
+runPackageManagerCommand() {
+  local log_file="$1"
+  local cmd_display="$2"
+  shift 2
+  local rc=0
+
+  if [[ $SILENT_MODE -eq 0 ]]; then
+    echo " - $(msg pkg_running "$cmd_display")"
+  fi
+
+  set +e
+  if [[ $SILENT_MODE -eq 0 ]]; then
+    "$@" 2>&1 | tee -a "$log_file"
+    rc=${PIPESTATUS[0]}
+  else
+    "$@" >>"$log_file" 2>&1
+    rc=$?
+  fi
+  set -e
+
+  if [[ $rc -ne 0 ]]; then
+    reportPackageInstallFailure "$cmd_display" "$log_file"
+    exit 1
+  fi
+}
+
 installPackages() {
   local pkg_type="$1"
   shift
   local packages=("$@")
+  local log_file
+  log_file=$(mktemp /tmp/torrserver-pkg-install.XXXXXX.log)
 
   case "$pkg_type" in
     deb)
@@ -806,8 +998,8 @@ installPackages() {
         if [[ $SILENT_MODE -eq 0 ]]; then
           echo " $(msg installing_packages)"
         fi
-        apt update >/dev/null 2>&1
-        apt -y install "${missing[@]}"
+        runPackageManagerCommand "$log_file" "apt update" apt update
+        runPackageManagerCommand "$log_file" "apt install ${missing[*]}" apt -y install "${missing[@]}"
       fi
       ;;
     rpm)
@@ -822,14 +1014,17 @@ installPackages() {
         fi
       done
       if [[ $needs_update -eq 1 ]]; then
+        if [[ $SILENT_MODE -eq 0 ]]; then
+          echo " $(msg installing_packages)"
+        fi
         if [[ "$pkg_manager" == "dnf" ]]; then
-          dnf makecache -q >/dev/null 2>&1 || true
+          runPackageManagerCommand "$log_file" "dnf makecache" dnf makecache -q
         elif [[ "$pkg_manager" == "yum" ]]; then
-          yum makecache fast -q >/dev/null 2>&1 || true
+          runPackageManagerCommand "$log_file" "yum makecache fast" yum makecache fast -q
         fi
         for pkg in "${packages[@]}"; do
           if [[ -z "$(rpm -qa "$pkg" 2>/dev/null)" ]]; then
-            $pkg_manager -y install "$pkg"
+            runPackageManagerCommand "$log_file" "$pkg_manager install $pkg" "$pkg_manager" -y install "$pkg"
           fi
         done
       fi
@@ -842,11 +1037,16 @@ installPackages() {
         fi
       done
       if [[ ${#missing[@]} -gt 0 ]]; then
-        pacman -Sy --noconfirm >/dev/null 2>&1
-        pacman -S --noconfirm "${missing[@]}"
+        if [[ $SILENT_MODE -eq 0 ]]; then
+          echo " $(msg installing_packages)"
+        fi
+        runPackageManagerCommand "$log_file" "pacman -Sy" pacman -Sy --noconfirm
+        runPackageManagerCommand "$log_file" "pacman -S ${missing[*]}" pacman -S --noconfirm "${missing[@]}"
       fi
       ;;
   esac
+
+  rm -f "$log_file"
 }
 
 getRpmPackageManager() {
@@ -987,6 +1187,8 @@ checkInstalled() {
       username="root"
     fi
   fi
+
+  detectInstalledBinaryVariant
 
   local binName
   binName=$(getBinaryName)
@@ -1516,6 +1718,9 @@ installTorrServer() {
     exit 1
   fi
 
+  detectInstalledBinaryVariant
+  configureGstBinary "$target_version"
+
   # Check if already installed and up to date
   if checkInstalled; then
       if ! checkInstalledVersion; then
@@ -1578,6 +1783,7 @@ installTorrServer() {
     fi
     downloadBinary "$urlBin" "$dirInstall/$binName" "$target_version"
   fi
+  removeAlternateBinary
 
   # Create service and config files
   createServiceFile
@@ -1659,6 +1865,9 @@ updateTorrServerVersion() {
     return 1
   fi
 
+  detectInstalledBinaryVariant
+  configureGstBinary "$target_version"
+
   if ! systemctlCmd stop "$serviceName.service"; then
     :
   fi
@@ -1673,6 +1882,7 @@ updateTorrServerVersion() {
   fi
 
   downloadBinary "$urlBin" "$dirInstall/$binName" "$target_version"
+  removeAlternateBinary
 
   # Update service file to reflect user change
   if [[ -f "$dirInstall/$serviceName.service" ]]; then
@@ -1849,6 +2059,7 @@ Commands:
     help
 
 Options:
+  --gst                             Install GStreamer build (141.10+, amd64/arm64 only)
   --root                            Run service as root user
   --silent                          Non-interactive mode with defaults
 
@@ -1858,6 +2069,9 @@ Examples:
 
   # Install specific version as root user silently
   sudo $scriptname --install 135 --root --silent
+
+  # Install GStreamer build
+  sudo $scriptname --install --gst
 
   # Update with silent mode
   sudo $scriptname --update --silent
@@ -1958,6 +2172,11 @@ parseArguments() {
         ;;
       --root)
         USE_ROOT_USER=1
+        shift
+        ;;
+      --gst)
+        USE_GST_BINARY=1
+        GST_BINARY_EXPLICIT=1
         shift
         ;;
       --silent)

--- a/installTorrServerMac.sh
+++ b/installTorrServerMac.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 set -euo pipefail
 
@@ -20,6 +21,9 @@ scriptname=$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")
 SILENT_MODE=0
 USE_USER_LAUNCHAGENT=0
 USER_PROMPTED=0
+USE_GST_BINARY=0
+GST_BINARY_EXPLICIT=0
+DETECTED_GST_VARIANT=-1
 
 # Command-line state
 parsedCommand=""
@@ -40,6 +44,8 @@ readonly REPO_URL="https://github.com/YouROK/TorrServer"
 readonly REPO_API_URL="https://api.github.com/repos/YouROK/TorrServer"
 readonly VERSION_PREFIX="MatriX"
 readonly BINARY_NAME_PREFIX="TorrServer-darwin"
+readonly BINARY_PLATFORM="darwin"
+readonly MIN_VERSION_WITH_GST="141.10"
 
 # Color support
 getColorCode() {
@@ -70,8 +76,8 @@ lang="en"
 #     TRANSLATION SYSTEM
 #############################################
 
-# Message dictionary
 # Message dictionary - bash 3.2 compatible (no associative arrays)
+# Message keys are resolved dynamically by msg().
 # English messages
 MSG_EN_lang_choice="Choose Language:"
 MSG_EN_lang_english="English"
@@ -132,6 +138,12 @@ MSG_EN_error_version_example="Example: %s -d 101"
 MSG_EN_error_unknown_option="Unknown option: %s"
 MSG_EN_installing_specific_version="Installing specific version: %s"
 MSG_EN_install_first_required="Please install TorrServer first using: %s --install"
+MSG_EN_enable_gst="Install GStreamer (gst) build with transcoding support? (available from version %s+)"
+MSG_EN_gst_not_available="ERROR: GStreamer build is not available for version %s (requires %s+)"
+MSG_EN_gst_not_available_arch="ERROR: GStreamer build is not available for architecture %s (requires amd64 or arm64)"
+MSG_EN_gst_fallback_standard="Target version %s has no GStreamer build; using standard binary"
+MSG_EN_using_gst_build="Using GStreamer (gst) build"
+MSG_EN_using_standard_build="Using standard build"
 
 # Russian messages
 MSG_RU_lang_choice="Choose Language:"
@@ -193,6 +205,12 @@ MSG_RU_error_version_example="Пример: %s -d 101"
 MSG_RU_error_unknown_option="Неизвестная опция: %s"
 MSG_RU_installing_specific_version="Установка конкретной версии: %s"
 MSG_RU_install_first_required="Пожалуйста, сначала установите TorrServer используя: %s --install"
+MSG_RU_enable_gst="Установить сборку GStreamer (gst) с поддержкой транскодирования? (доступна с версии %s+)"
+MSG_RU_gst_not_available="ОШИБКА: Сборка GStreamer недоступна для версии %s (требуется %s+)"
+MSG_RU_gst_not_available_arch="ОШИБКА: Сборка GStreamer недоступна для архитектуры %s (требуется amd64 или arm64)"
+MSG_RU_gst_fallback_standard="Для версии %s нет сборки GStreamer; используется стандартная сборка"
+MSG_RU_using_gst_build="Используется сборка GStreamer (gst)"
+MSG_RU_using_standard_build="Используется стандартная сборка"
 
 # Translation function - bash 3.2 compatible
 msg() {
@@ -207,8 +225,8 @@ msg() {
     var_name="MSG_EN_${key}"
   fi
 
-  # Use eval to get the variable value (bash 3.2 compatible)
-  eval "message=\"\${${var_name}:-${key}}\""
+  # Indirect expansion (bash 3.2 compatible)
+  message="${!var_name:-$key}"
 
   # Apply printf formatting if additional arguments provided
   if [[ $# -gt 0 ]]; then
@@ -243,7 +261,134 @@ highlightFirstLetter() {
 }
 
 getBinaryName() {
-  echo "${BINARY_NAME_PREFIX}-${architecture}"
+  if [[ $USE_GST_BINARY -eq 1 ]]; then
+    echo "TorrServer-gst-${BINARY_PLATFORM}-${architecture}"
+  else
+    echo "${BINARY_NAME_PREFIX}-${architecture}"
+  fi
+}
+
+getAlternateBinaryName() {
+  if [[ $USE_GST_BINARY -eq 1 ]]; then
+    echo "${BINARY_NAME_PREFIX}-${architecture}"
+  else
+    echo "TorrServer-gst-${BINARY_PLATFORM}-${architecture}"
+  fi
+}
+
+getReleaseVersionNumber() {
+  local target_version="$1"
+  echo "${target_version#"${VERSION_PREFIX}".}"
+}
+
+compareVersions() {
+  local ver1="$1"
+  local ver2="$2"
+  local sorted_first
+  sorted_first=$(printf '%s\n' "$ver1" "$ver2" | sort -V | head -n1)
+  [[ "$sorted_first" == "$ver2" ]]
+}
+
+supportsGstArch() {
+  [[ "$architecture" == "amd64" || "$architecture" == "arm64" ]]
+}
+
+supportsGstBinary() {
+  local target_version="$1"
+  local ver
+
+  supportsGstArch || return 1
+  ver=$(getReleaseVersionNumber "$target_version")
+  [[ -n "$ver" ]] && compareVersions "$ver" "$MIN_VERSION_WITH_GST"
+}
+
+reportGstUnavailableError() {
+  local target_version="$1"
+
+  if ! supportsGstArch; then
+    echo " - $(colorize red "$(msg gst_not_available_arch "$architecture")")"
+  else
+    echo " - $(colorize red "$(msg gst_not_available "$target_version" "$MIN_VERSION_WITH_GST")")"
+  fi
+  exit 1
+}
+
+detectInstalledBinaryVariant() {
+  if [[ $GST_BINARY_EXPLICIT -eq 1 ]]; then
+    return
+  fi
+
+  local gst_bin="TorrServer-gst-${BINARY_PLATFORM}-${architecture}"
+  local std_bin="${BINARY_NAME_PREFIX}-${architecture}"
+
+  if [[ -f "$dirInstall/$gst_bin" ]] && [[ $(stat -f%z "$dirInstall/$gst_bin" 2>/dev/null) -ne 0 ]]; then
+    DETECTED_GST_VARIANT=1
+    USE_GST_BINARY=1
+  elif [[ -f "$dirInstall/$std_bin" ]] && [[ $(stat -f%z "$dirInstall/$std_bin" 2>/dev/null) -ne 0 ]]; then
+    DETECTED_GST_VARIANT=0
+    USE_GST_BINARY=0
+  fi
+}
+
+removeAlternateBinary() {
+  local alt_bin
+  alt_bin=$(getAlternateBinaryName)
+  if [[ -f "$dirInstall/$alt_bin" ]]; then
+    rm -f "$dirInstall/$alt_bin"
+  fi
+}
+
+configureGstBinary() {
+  local target_version="$1"
+
+  if [[ $GST_BINARY_EXPLICIT -eq 1 ]]; then
+    if ! supportsGstBinary "$target_version"; then
+      reportGstUnavailableError "$target_version"
+    fi
+    USE_GST_BINARY=1
+    if [[ $SILENT_MODE -eq 0 ]]; then
+      echo " - $(msg using_gst_build)"
+    fi
+    return
+  fi
+
+  if ! supportsGstBinary "$target_version"; then
+    if [[ $USE_GST_BINARY -eq 1 ]]; then
+      USE_GST_BINARY=0
+      if [[ $SILENT_MODE -eq 0 ]]; then
+        echo " - $(msg gst_fallback_standard "$target_version")"
+      fi
+    else
+      USE_GST_BINARY=0
+    fi
+    return
+  fi
+
+  if [[ $SILENT_MODE -eq 1 ]]; then
+    if [[ $DETECTED_GST_VARIANT -eq 1 ]]; then
+      USE_GST_BINARY=1
+    else
+      USE_GST_BINARY=0
+    fi
+    return
+  fi
+
+  local recommended="n"
+  if [[ $DETECTED_GST_VARIANT -eq 1 ]]; then
+    recommended="y"
+  fi
+
+  if promptYesNo "$(msg enable_gst "$MIN_VERSION_WITH_GST")" "$recommended" "y"; then
+    USE_GST_BINARY=1
+  else
+    USE_GST_BINARY=0
+  fi
+
+  if [[ $USE_GST_BINARY -eq 1 ]]; then
+    echo " - $(msg using_gst_build)"
+  else
+    echo " - $(msg using_standard_build)"
+  fi
 }
 
 getVersionTag() {
@@ -446,12 +591,13 @@ launchctlCmd() {
 }
 
 killRunning() {
-  local self="$(basename "$0")"
-  local runningPid
-  runningPid=$(ps -ax | grep -i torrserver | grep -v grep | grep -v "$self" | awk '{print $1}' || echo "")
-  if [[ -n "$runningPid" ]]; then
-    sudo kill -9 "$runningPid" 2>/dev/null || true
-  fi
+  local pid
+
+  while IFS= read -r pid; do
+    if [[ -n "$pid" && "$pid" != "$$" ]]; then
+      sudo kill -9 "$pid" 2>/dev/null || true
+    fi
+  done < <(pgrep -fi '[Tt]orr[Ss]erver' 2>/dev/null || true)
 }
 
 #############################################
@@ -546,6 +692,8 @@ initialCheck() {
 #############################################
 
 checkInstalled() {
+  detectInstalledBinaryVariant
+
   local binName
   binName=$(getBinaryName)
   if [[ -f "$dirInstall/$binName" ]] && [[ $(stat -f%z "$dirInstall/$binName" 2>/dev/null) -ne 0 ]]; then
@@ -843,6 +991,9 @@ installTorrServer() {
     echo " - $(msg target_version) $target_version"
   fi
 
+  detectInstalledBinaryVariant
+  configureGstBinary "$target_version"
+
   # Check if already installed and up to date
   if checkInstalled; then
     if ! checkInstalledVersion; then
@@ -894,6 +1045,7 @@ installTorrServer() {
     fi
     downloadBinary "$urlBin" "$dirInstall/$binName" "$target_version"
   fi
+  removeAlternateBinary
 
   # Create plist and configure service
   configureService
@@ -983,10 +1135,12 @@ installService() {
 # Common function to update/downgrade TorrServer version
 updateTorrServerVersion() {
   local target_version="$1"
-  local cancel_message="$2"
-  local use_latest_url="${3:-0}"
+  local use_latest_url="${2:-0}"
 
   killRunning
+
+  detectInstalledBinaryVariant
+  configureGstBinary "$target_version"
 
   local binName
   binName=$(getBinaryName)
@@ -998,6 +1152,7 @@ updateTorrServerVersion() {
   fi
 
   downloadBinary "$urlBin" "$dirInstall/$binName" "$target_version"
+  removeAlternateBinary
 
   # Update plist file
   if [[ -f "$dirInstall/$serviceName.plist" ]]; then
@@ -1011,13 +1166,13 @@ updateTorrServerVersion() {
 UpdateVersion() {
   local target_version
   target_version=$(getTargetVersion)
-  updateTorrServerVersion "$target_version" "update_cancelled" 1
+  updateTorrServerVersion "$target_version" 1
 }
 
 DowngradeVersion() {
   local target_version
   target_version=$(getVersionTag "$downgradeRelease")
-  updateTorrServerVersion "$target_version" "downgrade_cancelled" 0
+  updateTorrServerVersion "$target_version" 0
 }
 
 #############################################
@@ -1126,6 +1281,7 @@ Commands:
     help
 
 Options:
+  --gst                             Install GStreamer build (141.10+, amd64/arm64 only)
   --silent                          Non-interactive mode with defaults
 
 Examples:
@@ -1134,6 +1290,9 @@ Examples:
 
   # Install specific version silently
   $scriptname --install 135 --silent
+
+  # Install GStreamer build
+  $scriptname --install --gst
 
   # Update with silent mode
   $scriptname --update --silent
@@ -1213,6 +1372,11 @@ parseArguments() {
         getLang  # Set language before showing help
         helpUsage
         exit 0
+        ;;
+      --gst)
+        USE_GST_BINARY=1
+        GST_BINARY_EXPLICIT=1
+        shift
         ;;
       --silent)
         SILENT_MODE=1


### PR DESCRIPTION
- add options to install GStreamer (gst) build with transcoding support in both Linux and macOS installation scripts.
- add command-line flags and user prompts for GStreamer installation.
- update README to reflect new GStreamer build availability and usage instructions.