### PR TITLE
Add filtering by category and search to M3U playlist API

### DIFF
--- a/server/web/api/m3u.go
+++ b/server/web/api/m3u.go
@@ -36,6 +36,30 @@ import (
 func allPlayList(c *gin.Context) {
 	torrs := torr.ListTorrent()
 
+	category := c.Query("category")
+	search := c.Query("search")
+
+	if category != "" || search != "" {
+		var filtered []*torr.Torrent
+		for _, tr := range torrs {
+			st := tr.Status()
+			
+			if category == "uncategorized" {
+				if st.Category != "" {
+					continue
+			    }
+            } else if category != "" && st.Category != category {
+				continue
+			}
+			if search != "" &&
+				!strings.Contains(strings.ToLower(st.Title), strings.ToLower(search)) {
+				continue
+			}
+			filtered = append(filtered, tr)
+		}
+		torrs = filtered
+	}
+
 	host := utils.GetScheme(c) + "://" + utils.GetHost(c)
 	list := "#EXTM3U\n"
 	hash := ""


### PR DESCRIPTION
- Added filtering support for category `query` parameter
```
http://localhost:8090/playlistall/all.m3u?category=movie
http://localhost:8090/playlistall/all.m3u?category=tv
http://localhost:8090/playlistall/all.m3u?category=music
http://localhost:8090/playlistall/all.m3u?category=other
http://localhost:8090/playlistall/all.m3u?category=uncategorized
```
- Added filtering support for search `query` parameter
```
http://localhost:8090/playlistall/all.m3u?search=
```