### PR TITLE
HOTFix: nil pointer dereference in /viewed endpoint

### DIFF
--- a/server/web/api/viewed.go
+++ b/server/web/api/viewed.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	sets "server/settings"
@@ -15,7 +16,7 @@ file index starts from 1
 // Action: set, rem, list
 type viewedReqJS struct {
 	requestI
-	*sets.Viewed
+	sets.Viewed
 }
 
 // viewed godoc
@@ -57,12 +58,20 @@ func viewed(c *gin.Context) {
 }
 
 func setViewed(req viewedReqJS, c *gin.Context) {
-	sets.SetViewed(req.Viewed)
+	if req.Hash == "" {
+		c.AbortWithError(http.StatusBadRequest, errors.New("hash is required"))
+		return
+	}
+	sets.SetViewed(&req.Viewed)
 	c.Status(200)
 }
 
 func remViewed(req viewedReqJS, c *gin.Context) {
-	sets.RemViewed(req.Viewed)
+	if req.Hash == "" {
+		c.AbortWithError(http.StatusBadRequest, errors.New("hash is required"))
+		return
+	}
+	sets.RemViewed(&req.Viewed)
 	c.Status(200)
 }
 


### PR DESCRIPTION
Устраняет nil pointer dereference в эндпоинте /viewed, который возникал при вызове {"action":"list"} без поля hash - вложенный указатель *sets.Viewed оставался nil, и обращение req.Hash приводило к панике. Замена указателя на значение sets.Viewed делает структуру всегда инициализированной, а listViewed теперь безопасно возвращает все просмотренные файлы при пустом хеше. Для setViewed и remViewed добавлена валидация: при отсутствии хеша возвращается 400 Bad Request, что предотвращает молчаливую запись в BoltDB с пустым ключом.