### PR TITLE
feat: support repeatable `--ip` for multi-address binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ On FreeBSD (TrueNAS/FreeNAS) you can use this plugin: <https://github.com/filka9
 ### Server args
 
 - `--port PORT`, `-p PORT` - web server port (default 8090)
-- `--ip IP`, `-i IP` - web server addr (default empty, binds to all interfaces)
+- `--ip IP`, `-i IP` - web server bind addr (repeatable; default empty binds to all interfaces)
 - `--ssl` - enables https for web server
 - `--sslport PORT` -  web server https port (default 8091). If not set, will be taken from db (if stored previously) or the default will be used.
 - `--sslcert PATH` -  path to ssl cert file. If not set, will be taken from db (if stored previously) or default self-signed certificate/key will be generated.
@@ -223,7 +223,7 @@ On FreeBSD (TrueNAS/FreeNAS) you can use this plugin: <https://github.com/filka9
 Example:
 
 ```bash
-TorrServer-darwin-arm64 [--port PORT] [--ip IP] [--path PATH] [--logpath LOGPATH] [--weblogpath WEBLOGPATH] [--rdb] [--httpauth] [--dontkill] [--ui] [--torrentsdir TORRENTSDIR] [--torrentaddr TORRENTADDR] [--pubipv4 PUBIPV4] [--pubipv6 PUBIPV6] [--searchwa] [--maxsize MAXSIZE] [--tg TGTOKEN] [--fuse FUSEPATH] [--webdav] [--ssl] [--sslport PORT] [--sslcert PATH] [--sslkey PATH] [--force-https]
+TorrServer-darwin-arm64 [--port PORT] [--ip IP ...] [--path PATH] [--logpath LOGPATH] [--weblogpath WEBLOGPATH] [--rdb] [--httpauth] [--dontkill] [--ui] [--torrentsdir TORRENTSDIR] [--torrentaddr TORRENTADDR] [--pubipv4 PUBIPV4] [--pubipv6 PUBIPV6] [--searchwa] [--maxsize MAXSIZE] [--tg TGTOKEN] [--fuse FUSEPATH] [--webdav] [--ssl] [--sslport PORT] [--sslcert PATH] [--sslkey PATH] [--force-https]
 ```
 
 ### Running in Docker & Docker Compose

--- a/server/cmd/main.go
+++ b/server/cmd/main.go
@@ -28,7 +28,7 @@ import (
 
 type args struct {
 	Port        string `arg:"-p" help:"web server port (default 8090)"`
-	IP          string `arg:"-i" help:"web server addr (default empty)"`
+	IPs         []string `arg:"-i,--ip,separate" help:"web server bind addr (repeatable; default empty binds all interfaces)"`
 	Ssl         bool   `help:"enables https"`
 	SslPort     string `help:"web server ssl port, If not set, will be set to default 8091 or taken from db(if stored previously). Accepted if --ssl enabled."`
 	SslCert     string `help:"path to ssl cert file. If not set, will be taken from db(if stored previously) or default self-signed certificate/key will be generated. Accepted if --ssl enabled."`
@@ -150,7 +150,7 @@ func main() {
 
 	settings.Args = &settings.ExecArgs{
 		Port:        params.Port,
-		IP:          params.IP,
+		IPs:         params.IPs,
 		Ssl:         params.Ssl,
 		SslPort:     params.SslPort,
 		SslCert:     params.SslCert,

--- a/server/cmd/main_test.go
+++ b/server/cmd/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/alexflint/go-arg"
+)
+
+func TestIPsSeparateFlag(t *testing.T) {
+	var params args
+	p, err := arg.NewParser(arg.Config{}, &params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Parse([]string{"--ip", "127.0.0.1", "--ip", "192.168.1.100"}); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"127.0.0.1", "192.168.1.100"}
+	if len(params.IPs) != len(want) {
+		t.Fatalf("IPs = %#v, want %#v", params.IPs, want)
+	}
+	for i := range want {
+		if params.IPs[i] != want[i] {
+			t.Fatalf("IPs = %#v, want %#v", params.IPs, want)
+		}
+	}
+}

--- a/server/dlna/dlna.go
+++ b/server/dlna/dlna.go
@@ -16,6 +16,7 @@ import (
 	"github.com/anacrolix/log"
 	"github.com/wlynxg/anet"
 
+	"server/netbind"
 	"server/settings"
 	"server/web/pages/template"
 )
@@ -47,17 +48,13 @@ func Start() {
 			port := 9080
 			for {
 				logger.Levelf(log.Info, "Check dlna port %d", port)
-				m, err := net.Listen("tcp", settings.IP+":"+strconv.Itoa(port))
-				if m != nil {
-					m.Close()
-				}
-				if err == nil {
+				if err := netbind.CheckPort(settings.IPs, strconv.Itoa(port)); err == nil {
 					break
 				}
 				port++
 			}
 			logger.Levelf(log.Info, "Set dlna port %d", port)
-			conn, err := net.Listen("tcp", settings.IP+":"+strconv.Itoa(port))
+			conn, err := netbind.Listen(settings.IPs, strconv.Itoa(port))
 			if err != nil {
 				logger.Levelf(log.Error, "%v", err)
 				os.Exit(1)

--- a/server/netbind/netbind.go
+++ b/server/netbind/netbind.go
@@ -1,0 +1,117 @@
+package netbind
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+// Normalize returns unique bind hosts. An empty list means all interfaces once.
+func Normalize(ips []string) []string {
+	if len(ips) == 0 {
+		return []string{""}
+	}
+	out := make([]string, 0, len(ips))
+	seen := make(map[string]struct{}, len(ips))
+	for _, ip := range ips {
+		if _, ok := seen[ip]; ok {
+			continue
+		}
+		seen[ip] = struct{}{}
+		out = append(out, ip)
+	}
+	return out
+}
+
+// Addr formats host:port for net.Listen.
+func Addr(host, port string) string {
+	if host == "" {
+		return ":" + port
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// CheckPort verifies that TCP port is available on every bind host.
+func CheckPort(hosts []string, port string) error {
+	for _, host := range Normalize(hosts) {
+		addr := Addr(host, port)
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("%s: %w", addr, err)
+		}
+		l.Close()
+	}
+	return nil
+}
+
+// Listen binds TCP on each host and returns a listener that accepts from all of them.
+func Listen(hosts []string, port string) (net.Listener, error) {
+	hosts = Normalize(hosts)
+	if len(hosts) == 1 {
+		return net.Listen("tcp", Addr(hosts[0], port))
+	}
+
+	ml := &multiListener{
+		conns: make(chan net.Conn),
+		errs:  make(chan error, len(hosts)),
+	}
+	for _, host := range hosts {
+		l, err := net.Listen("tcp", Addr(host, port))
+		if err != nil {
+			ml.Close()
+			return nil, err
+		}
+		ml.listeners = append(ml.listeners, l)
+		go ml.acceptLoop(l)
+	}
+	return ml, nil
+}
+
+type multiListener struct {
+	listeners []net.Listener
+	conns     chan net.Conn
+	errs      chan error
+	closeOnce sync.Once
+}
+
+func (ml *multiListener) acceptLoop(l net.Listener) {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			select {
+			case ml.errs <- err:
+			default:
+			}
+			return
+		}
+		ml.conns <- c
+	}
+}
+
+func (ml *multiListener) Accept() (net.Conn, error) {
+	select {
+	case c := <-ml.conns:
+		return c, nil
+	case err := <-ml.errs:
+		return nil, err
+	}
+}
+
+func (ml *multiListener) Close() error {
+	var err error
+	ml.closeOnce.Do(func() {
+		for _, l := range ml.listeners {
+			if closeErr := l.Close(); closeErr != nil && err == nil {
+				err = closeErr
+			}
+		}
+	})
+	return err
+}
+
+func (ml *multiListener) Addr() net.Addr {
+	if len(ml.listeners) == 0 {
+		return nil
+	}
+	return ml.listeners[0].Addr()
+}

--- a/server/netbind/netbind_test.go
+++ b/server/netbind/netbind_test.go
@@ -1,0 +1,49 @@
+package netbind
+
+import (
+	"strconv"
+
+	"net"
+	"testing"
+)
+
+func TestNormalizeEmpty(t *testing.T) {
+	got := Normalize(nil)
+	if len(got) != 1 || got[0] != "" {
+		t.Fatalf("Normalize(nil) = %#v, want [\"\"]", got)
+	}
+}
+
+func TestNormalizeDedup(t *testing.T) {
+	got := Normalize([]string{"127.0.0.1", "127.0.0.1", "::1"})
+	if len(got) != 2 {
+		t.Fatalf("Normalize dedup = %#v, want 2 entries", got)
+	}
+}
+
+func TestAddr(t *testing.T) {
+	if got := Addr("", "8090"); got != ":8090" {
+		t.Fatalf("Addr empty host = %q", got)
+	}
+	if got := Addr("127.0.0.1", "8090"); got != "127.0.0.1:8090" {
+		t.Fatalf("Addr ipv4 = %q", got)
+	}
+	if got := Addr("::1", "8090"); got != "[::1]:8090" {
+		t.Fatalf("Addr ipv6 = %q", got)
+	}
+}
+
+func TestListenMultiple(t *testing.T) {
+	l, err := Listen([]string{"127.0.0.1"}, "0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+
+	port := l.Addr().(*net.TCPAddr).Port
+	conn, err := net.Dial("tcp", Addr("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -10,6 +9,7 @@ import (
 	"server/tgbot"
 
 	"server/log"
+	"server/netbind"
 	"server/settings"
 	"server/torr/utils"
 	"server/web"
@@ -41,11 +41,7 @@ func Start() {
 			settings.BTsets.SslKey = settings.Args.SslKey
 		}
 		log.TLogln("Check web ssl port", settings.Args.SslPort)
-		l, err := net.Listen("tcp", settings.Args.IP+":"+settings.Args.SslPort)
-		if l != nil {
-			l.Close()
-		}
-		if err != nil {
+		if err := netbind.CheckPort(settings.Args.IPs, settings.Args.SslPort); err != nil {
 			log.TLogln("Port", settings.Args.SslPort, "already in use! Please set different ssl port for HTTPS. Abort")
 			os.Exit(1)
 		}
@@ -55,13 +51,9 @@ func Start() {
 		settings.Args.Port = "8090"
 	}
 
-	log.TLogln("Check web port", settings.Args.Port)
-	l, err := net.Listen("tcp", settings.Args.IP+":"+settings.Args.Port)
-	if l != nil {
-		l.Close()
-	}
-	if err != nil {
-		log.TLogln("Port", settings.Args.Port, "already in use! Please set different port for HTTP. Abort")
+	log.TLogln("Check web port", settings.Args.Port, "on", netbind.Normalize(settings.Args.IPs))
+	if err := netbind.CheckPort(settings.Args.IPs, settings.Args.Port); err != nil {
+		log.TLogln("Cannot bind HTTP port", settings.Args.Port+":", err)
 		os.Exit(1)
 	}
 	// remove old disk caches
@@ -69,7 +61,7 @@ func Start() {
 	// set settings http and https ports. Start web server.
 	settings.Port = settings.Args.Port
 	settings.SslPort = settings.Args.SslPort
-	settings.IP = settings.Args.IP
+	settings.IPs = settings.Args.IPs
 
 	if settings.Args.TGToken != "" {
 		if err := tgbot.Start(settings.Args.TGToken); err != nil {

--- a/server/settings/args.go
+++ b/server/settings/args.go
@@ -2,7 +2,7 @@ package settings
 
 type ExecArgs struct {
 	Port        string
-	IP          string
+	IPs         []string
 	Ssl         bool
 	SslPort     string
 	SslCert     string

--- a/server/settings/settings.go
+++ b/server/settings/settings.go
@@ -24,7 +24,7 @@ func IsDebug() bool {
 var (
 	tdb      TorrServerDB
 	Path     string
-	IP       string
+	IPs      []string
 	Port     string
 	Ssl      bool
 	SslPort  string

--- a/server/web/server.go
+++ b/server/web/server.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	gstreamer "server/gstreamer/bridge"
+	"server/netbind"
 	"sort"
 
 	"server/torrfs/fuse"
@@ -112,19 +113,33 @@ func Start() {
 			settings.SetBTSets(settings.BTsets)
 		}
 		go func() {
-			log.TLogln("Start https server at", settings.IP+":"+settings.SslPort)
-			waitChan <- route.RunTLS(settings.IP+":"+settings.SslPort, settings.BTsets.SslCert, settings.BTsets.SslKey)
+			for _, ip := range netbind.Normalize(settings.IPs) {
+				addr := netbind.Addr(ip, settings.SslPort)
+				go func(addr string) {
+					log.TLogln("Start https server at", addr)
+					waitChan <- route.RunTLS(addr, settings.BTsets.SslCert, settings.BTsets.SslKey)
+				}(addr)
+			}
 		}()
 	}
 
 	go func() {
-		addr := settings.IP + ":" + settings.Port
 		if settings.Args != nil && settings.Args.ForceHTTPS && settings.Ssl {
-			waitChan <- runHTTPRedirectToHTTPS(addr)
+			for _, ip := range netbind.Normalize(settings.IPs) {
+				addr := netbind.Addr(ip, settings.Port)
+				go func(addr string) {
+					waitChan <- runHTTPRedirectToHTTPS(addr)
+				}(addr)
+			}
 			return
 		}
-		log.TLogln("Start http server at", addr)
-		waitChan <- route.Run(addr)
+		for _, ip := range netbind.Normalize(settings.IPs) {
+			addr := netbind.Addr(ip, settings.Port)
+			go func(addr string) {
+				log.TLogln("Start http server at", addr)
+				waitChan <- route.Run(addr)
+			}(addr)
+		}
 	}()
 }
 


### PR DESCRIPTION
Allow binding HTTP/HTTPS and DLNA to specific interfaces without opening 0.0.0.0, e.g. --ip 127.0.0.1 --ip 192.168.1.100.

#782 