### PR TITLE
Fix: DiskPiece.ReadAt panic "io.Copy will get stuck"

### DIFF
--- a/server/torr/storage/torrstor/diskpiece.go
+++ b/server/torr/storage/torrstor/diskpiece.go
@@ -71,7 +71,7 @@ func (p *DiskPiece) ReadAt(b []byte, off int64) (n int, err error) {
 	if int64(len(b))+off >= p.piece.Size {
 		go p.piece.cache.cleanPieces()
 	}
-	return n, nil
+	return n, err
 }
 
 func (p *DiskPiece) Release() {


### PR DESCRIPTION
# Fix: DiskPiece.ReadAt panic "io.Copy will get stuck"

## What

`DiskPiece.ReadAt` discarded the error from `os.File.ReadAt` (`return n, nil`). When the piece file
existed but was empty/partial at the read offset, `ff.ReadAt` returned `(0, io.EOF)`, which the
anacrolix/torrent storage wrapper saw as `(0, nil)` and reacted to with its defensive
`panic("io.Copy will get stuck")` (`storage/wrappers.go:88`), crashing the process.

This is the same bug class as anacrolix/torrent#430; `MemPiece.ReadAt` already returns `io.EOF`
correctly on the zero-read path — only `DiskPiece` was broken.

## Fix

Propagate the error so the wrapper sees `io.EOF`, calls `MarkNotComplete()`, and the piece is
re-downloaded instead of panicking:

```diff
 	n, err = ff.ReadAt(b, off)
 	p.piece.Accessed = time.Now().Unix()
 	if int64(len(b))+off >= p.piece.Size {
 		go p.piece.cache.cleanPieces()
 	}
-	return n, nil
+	return n, err
```

## Validation

Reproduced the crash ~5×/hour during active streaming of a single torrent (MatriX.142, linux/arm64,
external NTFS via tntfs, `UseDisk:true`). With this one-line fix applied, the same torrent streams
with a stable PID and a flat crash log (zero panics). Detailed repro + trace in the linked issue.

## Scope

One-line change to `server/torr/storage/torrstor/diskpiece.go`. No API/config/behaviour change for
the happy path; only the error-return contract of `PieceImpl.ReadAt` is now honoured (matching
`MemPiece`).

Fixes #786.