### PR TITLE
Gstreamer: bug fix, subs

### DIFF
--- a/server/gstreamer/config.go
+++ b/server/gstreamer/config.go
@@ -22,11 +22,11 @@ type Config struct {
 
 	InactiveMinutes int `json:"InactiveMinutes"`
 
-	AACBitrateKbps int `json:"AACBitrateKbps"`
-	AACChannels    int `json:"AACChannels"`
-	AACSamplerate  int `json:"AACSamplerate"`
-	SegmentSeconds int `json:"SegmentSeconds"`
-	AppSinkBuffers int `json:"appsinkBuffers"`
+	AACBitrateKbps   int `json:"AACBitrateKbps"`
+	AACChannels      int `json:"AACChannels"`
+	AACSamplerate    int `json:"AACSamplerate"`
+	SegmentSeconds   int `json:"SegmentSeconds"`
+	AppSinkBuffers   int `json:"appsinkBuffers"`
 
 	TranscodeH264 bool `json:"TranscodeH264"`
 	TranscodeH265 bool `json:"TranscodeH265"`
@@ -44,14 +44,14 @@ func DefaultConfig() Config {
 
 func defaultConfigWithoutSettings() Config {
 	conf := Config{
-		GSTVersion:      minGSTVersion,
-		Source:          "stream",
-		InactiveMinutes: 5,
-		AACBitrateKbps:  256,
-		SegmentSeconds:  6,
-		AppSinkBuffers:  1000,
-		VideoBitrate:    10_000,
-		TempFS:          false,
+		GSTVersion:       minGSTVersion,
+		Source:           "stream",
+		InactiveMinutes:  5,
+		AACBitrateKbps:   256,
+		SegmentSeconds:   6,
+		AppSinkBuffers:   1000,
+		VideoBitrate:     10_000,
+		TempFS:           false,
 	}
 
 	if runtime.GOOS == "windows" {
@@ -112,11 +112,11 @@ type storedConfig struct {
 
 	InactiveMinutes *int
 
-	AACBitrateKbps *int
-	AACChannels    *int
-	AACSamplerate  *int
-	SegmentSeconds *int
-	AppSinkBuffers *int `json:"appsinkBuffers"`
+	AACBitrateKbps   *int
+	AACChannels      *int
+	AACSamplerate    *int
+	SegmentSeconds   *int
+	AppSinkBuffers   *int `json:"appsinkBuffers"`
 
 	TranscodeH264 *bool
 	TranscodeH265 *bool

--- a/server/gstreamer/gst_api.go
+++ b/server/gstreamer/gst_api.go
@@ -23,9 +23,10 @@ const (
 
 	gstFormatTime int32 = 3
 
-	gstSeekFlagFlush     int32 = 1
-	gstSeekFlagKeyUnit   int32 = 4
-	gstSeekFlagSnapAfter int32 = 64
+	gstSeekFlagFlush      int32 = 1
+	gstSeekFlagKeyUnit    int32 = 4
+	gstSeekFlagSnapBefore int32 = 32
+	gstSeekFlagSnapAfter  int32 = 64
 
 	gstMapRead int32 = 1
 
@@ -55,24 +56,33 @@ func (v gstVersionInfo) atLeast(major uint32, minor uint32) bool {
 type gstAPI struct {
 	handles []uintptr
 
-	gstInitCheck            func(argc unsafe.Pointer, argv unsafe.Pointer, err unsafe.Pointer) int32
-	gstVersion              func(major unsafe.Pointer, minor unsafe.Pointer, micro unsafe.Pointer, nano unsafe.Pointer)
-	gstParseLaunch          func(description string, err unsafe.Pointer) uintptr
-	gstBinGetByName         func(bin uintptr, name string) uintptr
-	gstObjectUnref          func(obj uintptr)
-	gstMiniObjectUnref      func(obj uintptr)
-	gstElementSetState      func(element uintptr, state int32) int32
-	gstElementGetState      func(element uintptr, state unsafe.Pointer, pending unsafe.Pointer, timeout uint64) int32
-	gstElementSeekSimple    func(element uintptr, format int32, flags int32, position int64) int32
-	gstElementQueryPosition func(element uintptr, format int32, cur unsafe.Pointer) int32
-	gstPipelineGetBus       func(pipeline uintptr) uintptr
-	gstBusTimedPopFiltered  func(bus uintptr, timeout uint64, types int32) uintptr
-	gstMessageParseError    func(msg uintptr, err unsafe.Pointer, debug unsafe.Pointer)
-	gstSampleGetBuffer      func(sample uintptr) uintptr
-	gstSampleUnref          func(sample uintptr)
-	gstBufferGetSize        func(buffer uintptr) uintptr
-	gstBufferMap            func(buffer uintptr, mapInfo unsafe.Pointer, flags int32) int32
-	gstBufferUnmap          func(buffer uintptr, mapInfo unsafe.Pointer)
+	gstInitCheck             func(argc unsafe.Pointer, argv unsafe.Pointer, err unsafe.Pointer) int32
+	gstVersion               func(major unsafe.Pointer, minor unsafe.Pointer, micro unsafe.Pointer, nano unsafe.Pointer)
+	gstParseLaunch           func(description string, err unsafe.Pointer) uintptr
+	gstBinGetByName          func(bin uintptr, name string) uintptr
+	gstElementGetStaticPad   func(element uintptr, name string) uintptr
+	gstObjectUnref           func(obj uintptr)
+	gstMiniObjectUnref       func(obj uintptr)
+	gstElementSetState       func(element uintptr, state int32) int32
+	gstElementGetState       func(element uintptr, state unsafe.Pointer, pending unsafe.Pointer, timeout uint64) int32
+	gstElementSeekSimple     func(element uintptr, format int32, flags int32, position int64) int32
+	gstElementQueryPosition  func(element uintptr, format int32, cur unsafe.Pointer) int32
+	gstPipelineGetBus        func(pipeline uintptr) uintptr
+	gstBusTimedPopFiltered   func(bus uintptr, timeout uint64, types int32) uintptr
+	gstMessageParseError     func(msg uintptr, err unsafe.Pointer, debug unsafe.Pointer)
+	gstSampleGetBuffer       func(sample uintptr) uintptr
+	gstSampleUnref           func(sample uintptr)
+	gstBufferGetSize         func(buffer uintptr) uintptr
+	gstBufferMap             func(buffer uintptr, mapInfo unsafe.Pointer, flags int32) int32
+	gstBufferUnmap           func(buffer uintptr, mapInfo unsafe.Pointer)
+	gstPadAddProbe           func(pad uintptr, mask int32, callback uintptr, userData uintptr, destroyData uintptr) uintptr
+	gstPadRemoveProbe        func(pad uintptr, id uintptr)
+	gstPadProbeInfoGetBuffer func(info uintptr) uintptr
+	gstPadProbeInfoGetEvent  func(info uintptr) uintptr
+	gstEventTypeGetName      func(eventType int32) uintptr
+	gstEventParseCaps        func(event uintptr, caps unsafe.Pointer)
+	gstEventParseSegment     func(event uintptr, segment unsafe.Pointer)
+	gstCapsToString          func(caps uintptr) uintptr
 
 	gstAppSinkTryPullSample func(sink uintptr, timeout uint64) uintptr
 	gstAppSinkIsEOS         func(sink uintptr) int32
@@ -94,6 +104,7 @@ func (g *gstAPI) bind(gstHandle uintptr, gstAppHandle uintptr, glibHandle uintpt
 	purego.RegisterLibFunc(&g.gstVersion, gstHandle, "gst_version")
 	purego.RegisterLibFunc(&g.gstParseLaunch, gstHandle, "gst_parse_launch")
 	purego.RegisterLibFunc(&g.gstBinGetByName, gstHandle, "gst_bin_get_by_name")
+	purego.RegisterLibFunc(&g.gstElementGetStaticPad, gstHandle, "gst_element_get_static_pad")
 	purego.RegisterLibFunc(&g.gstObjectUnref, gstHandle, "gst_object_unref")
 	purego.RegisterLibFunc(&g.gstMiniObjectUnref, gstHandle, "gst_mini_object_unref")
 	purego.RegisterLibFunc(&g.gstElementSetState, gstHandle, "gst_element_set_state")
@@ -108,6 +119,14 @@ func (g *gstAPI) bind(gstHandle uintptr, gstAppHandle uintptr, glibHandle uintpt
 	purego.RegisterLibFunc(&g.gstBufferGetSize, gstHandle, "gst_buffer_get_size")
 	purego.RegisterLibFunc(&g.gstBufferMap, gstHandle, "gst_buffer_map")
 	purego.RegisterLibFunc(&g.gstBufferUnmap, gstHandle, "gst_buffer_unmap")
+	purego.RegisterLibFunc(&g.gstPadAddProbe, gstHandle, "gst_pad_add_probe")
+	purego.RegisterLibFunc(&g.gstPadRemoveProbe, gstHandle, "gst_pad_remove_probe")
+	purego.RegisterLibFunc(&g.gstPadProbeInfoGetBuffer, gstHandle, "gst_pad_probe_info_get_buffer")
+	purego.RegisterLibFunc(&g.gstPadProbeInfoGetEvent, gstHandle, "gst_pad_probe_info_get_event")
+	purego.RegisterLibFunc(&g.gstEventTypeGetName, gstHandle, "gst_event_type_get_name")
+	purego.RegisterLibFunc(&g.gstEventParseCaps, gstHandle, "gst_event_parse_caps")
+	purego.RegisterLibFunc(&g.gstEventParseSegment, gstHandle, "gst_event_parse_segment")
+	purego.RegisterLibFunc(&g.gstCapsToString, gstHandle, "gst_caps_to_string")
 
 	purego.RegisterLibFunc(&g.gstAppSinkTryPullSample, gstAppHandle, "gst_app_sink_try_pull_sample")
 	purego.RegisterLibFunc(&g.gstAppSinkIsEOS, gstAppHandle, "gst_app_sink_is_eos")
@@ -172,6 +191,13 @@ func (g *gstAPI) binGetByName(bin uintptr, name string) uintptr {
 		return 0
 	}
 	return g.gstBinGetByName(bin, name)
+}
+
+func (g *gstAPI) elementGetStaticPad(element uintptr, name string) uintptr {
+	if element == 0 {
+		return 0
+	}
+	return g.gstElementGetStaticPad(element, name)
 }
 
 func (g *gstAPI) objectUnref(obj uintptr) {
@@ -279,6 +305,69 @@ func (g *gstAPI) withSampleBytes(sample uintptr, consume func([]byte) error) err
 
 	data := unsafe.Slice((*byte)(unsafe.Pointer(dataPtr)), size)
 	return consume(data)
+}
+
+func (g *gstAPI) padAddProbe(pad uintptr, mask int32, callback uintptr, userData uintptr) uintptr {
+	if pad == 0 || callback == 0 {
+		return 0
+	}
+	return g.gstPadAddProbe(pad, mask, callback, userData, 0)
+}
+
+func (g *gstAPI) padRemoveProbe(pad uintptr, id uintptr) {
+	if pad != 0 && id != 0 {
+		g.gstPadRemoveProbe(pad, id)
+	}
+}
+
+func (g *gstAPI) padProbeInfoBuffer(info uintptr) uintptr {
+	if info == 0 {
+		return 0
+	}
+	return g.gstPadProbeInfoGetBuffer(info)
+}
+
+func (g *gstAPI) padProbeInfoEvent(info uintptr) uintptr {
+	if info == 0 {
+		return 0
+	}
+	return g.gstPadProbeInfoGetEvent(info)
+}
+
+func (g *gstAPI) eventTypeName(eventType int32) string {
+	if g.gstEventTypeGetName == nil {
+		return ""
+	}
+	return cString(g.gstEventTypeGetName(eventType))
+}
+
+func (g *gstAPI) eventCapsString(event uintptr) string {
+	if event == 0 || g.gstEventParseCaps == nil || g.gstCapsToString == nil {
+		return ""
+	}
+	var caps uintptr
+	g.gstEventParseCaps(event, unsafe.Pointer(&caps))
+	if caps == 0 {
+		return ""
+	}
+	textPtr := g.gstCapsToString(caps)
+	text := cString(textPtr)
+	if textPtr != 0 {
+		g.gFree(textPtr)
+	}
+	return text
+}
+
+func (g *gstAPI) eventSegment(event uintptr) (gstSegmentSnapshot, bool) {
+	if event == 0 || g.gstEventParseSegment == nil {
+		return gstSegmentSnapshot{}, false
+	}
+	var segmentPtr uintptr
+	g.gstEventParseSegment(event, unsafe.Pointer(&segmentPtr))
+	if segmentPtr == 0 {
+		return gstSegmentSnapshot{}, false
+	}
+	return readGstSegment(segmentPtr), true
 }
 
 func validateGStreamerSampleSize(bufferSize uintptr, mapSize int) error {

--- a/server/gstreamer/gst_api_samples_gst.go
+++ b/server/gstreamer/gst_api_samples_gst.go
@@ -1,0 +1,49 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"errors"
+	"unsafe"
+)
+
+func (g *gstAPI) withSampleBuffer(sample uintptr, consume func(gstBufferSnapshot, []byte) error) error {
+	if sample == 0 {
+		return nil
+	}
+	if consume == nil {
+		return errors.New("nil gst sample consumer")
+	}
+
+	buffer := g.gstSampleGetBuffer(sample)
+	if buffer == 0 {
+		return errors.New("gst_sample_get_buffer returned nil")
+	}
+
+	bufferSize := g.gstBufferGetSize(buffer)
+	if bufferSize == 0 {
+		return nil
+	}
+	if err := validateGStreamerSampleSize(bufferSize, 0); err != nil {
+		return err
+	}
+
+	meta := readGstBuffer(buffer)
+
+	var mapInfo [128]byte
+	if g.gstBufferMap(buffer, unsafe.Pointer(&mapInfo[0]), gstMapRead) == 0 {
+		return errors.New("gst_buffer_map failed")
+	}
+	defer g.gstBufferUnmap(buffer, unsafe.Pointer(&mapInfo[0]))
+
+	dataPtr, size := gstMapInfoData(&mapInfo)
+	if dataPtr == 0 || size == 0 {
+		return nil
+	}
+	if err := validateGStreamerSampleSize(bufferSize, size); err != nil {
+		return err
+	}
+
+	data := unsafe.Slice((*byte)(unsafe.Pointer(dataPtr)), size)
+	return consume(meta, data)
+}

--- a/server/gstreamer/handlers.go
+++ b/server/gstreamer/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -66,30 +67,43 @@ func (s *Service) probe(c *gin.Context) {
 }
 
 func (s *Service) master(c *gin.Context) {
+	started := time.Now()
 	noCache(c)
 
 	hash := c.Param("hash")
 	fileID := firstNonEmpty(c.Query("index"), c.Query("id"), c.Query("fileID"))
 	audio := parseQueryInt(c, "audio", 0)
+	seconds := parseQueryInt(c, "seconds", 0)
+	gstDebugf("HTTP master start hash=%s file=%s audio=%d seconds=%d range=%q", hash, fileID, audio, seconds, c.GetHeader("Range"))
 
 	task, err := s.GetOrAdd(hash, fileID, audio)
 	if err != nil {
+		logHTTPError("HTTP master", hash, fileID, audio, -1, err, started)
 		abortWithSourceError(c, err)
 		return
 	}
 
-	duration := task.Probe.DurationSeconds()
-	if duration <= 0 {
-		duration = 200 * 60
+	segmentSeconds := task.Config.SegmentSeconds
+	rawDuration := task.Probe.DurationSeconds()
+	duration, fallbackDuration := playlistDurationSeconds(rawDuration, segmentSeconds)
+	if fallbackDuration {
+		gstDebugf("HTTP master duration fallback task=%s file=%s audio=%d seconds=%d rawDuration=%d segmentSeconds=%d playlistDuration=%d", task.ID, task.FileID, audio, seconds, rawDuration, segmentSeconds, duration)
 	}
 
-	segmentSeconds := task.Config.SegmentSeconds
 	count := duration / segmentSeconds
-	startIndex := startSegmentIndex(parseQueryInt(c, "seconds", 0), segmentSeconds, count)
+	startIndex := startSegmentIndex(seconds, segmentSeconds, count)
 	startSeconds := startIndex * segmentSeconds
 
 	playlist := buildMasterPlaylist(segmentSeconds, startIndex, startSeconds, count, audio)
 	c.Data(http.StatusOK, "application/vnd.apple.mpegurl; charset=utf-8", []byte(playlist))
+	gstDebugf("HTTP master completed task=%s file=%s audio=%d startIndex=%d seconds=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, startIndex, seconds, c.Writer.Status(), len(playlist), time.Since(started))
+}
+
+func playlistDurationSeconds(rawDuration int, segmentSeconds int) (int, bool) {
+	if rawDuration <= 0 || rawDuration < segmentSeconds {
+		return unknownPlaylistDurationSeconds, true
+	}
+	return rawDuration, false
 }
 
 func buildMasterPlaylist(segmentSeconds int, startIndex int, startSeconds int, count int, audio int) string {
@@ -125,67 +139,101 @@ func buildMasterPlaylist(segmentSeconds int, startIndex int, startSeconds int, c
 }
 
 func (s *Service) initMP4(c *gin.Context) {
+	started := time.Now()
 	noCache(c)
 
-	task := s.Get(c.Param("hash"))
+	hash := c.Param("hash")
+	task := s.Get(hash)
 	if task == nil {
+		gstDebugf("HTTP init start hash=%s file= audio=0 seconds=0 startIndex=0 range=%q", hash, c.GetHeader("Range"))
+		gstErrorf("HTTP init failed hash=%s file= audio=0 segment=-1 status=%d err=%v duration=%s", hash, http.StatusNotFound, ErrTaskNotFound, time.Since(started))
 		c.Status(http.StatusNotFound)
 		return
 	}
 
 	audio := parseQueryInt(c, "audio", task.Audio)
-	startIndex := startSegmentIndex(parseQueryInt(c, "seconds", 0), task.Config.SegmentSeconds, task.Probe.DurationSeconds()/task.Config.SegmentSeconds)
+	seconds := parseQueryInt(c, "seconds", 0)
+	segmentSeconds := task.Config.SegmentSeconds
+	rawDuration := task.Probe.DurationSeconds()
+	duration, fallbackDuration := playlistDurationSeconds(rawDuration, segmentSeconds)
+	if fallbackDuration {
+		gstDebugf("HTTP init duration fallback task=%s file=%s audio=%d seconds=%d rawDuration=%d segmentSeconds=%d playlistDuration=%d", task.ID, task.FileID, audio, seconds, rawDuration, segmentSeconds, duration)
+	}
+	startIndex := startSegmentIndex(seconds, segmentSeconds, duration/segmentSeconds)
+	gstDebugf("HTTP init start task=%s file=%s audio=%d seconds=%d startIndex=%d range=%q", task.ID, task.FileID, audio, seconds, startIndex, c.GetHeader("Range"))
 	if err := task.EnsureInit(c.Request.Context(), audio, startIndex); err != nil {
+		logHTTPError("HTTP init EnsureInit", task.ID, task.FileID, audio, -1, err, started)
 		c.AbortWithError(http.StatusBadGateway, err)
 		return
 	}
+	gstDebugf("HTTP init EnsureInit completed task=%s file=%s audio=%d startIndex=%d elapsed=%s", task.ID, task.FileID, audio, startIndex, time.Since(started))
 
+	var sent int
 	if err := task.WithInitMP4(func(init []byte) error {
+		sent = len(init)
 		c.Header("Content-Length", strconv.Itoa(len(init)))
 		c.Data(http.StatusOK, "video/mp4", init)
 		return nil
 	}); err != nil {
+		logHTTPError("HTTP init write", task.ID, task.FileID, audio, -1, err, started)
 		c.AbortWithError(http.StatusBadGateway, err)
 		return
 	}
+	gstDebugf("HTTP init completed task=%s file=%s audio=%d startIndex=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, startIndex, c.Writer.Status(), sent, time.Since(started))
 }
 
 func (s *Service) segment(c *gin.Context) {
+	started := time.Now()
 	noCache(c)
 
-	task := s.Get(c.Param("hash"))
+	hash := c.Param("hash")
+	task := s.Get(hash)
 	if task == nil {
+		gstDebugf("HTTP segment start hash=%s file= audio=0 segment=-1 range=%q", hash, c.GetHeader("Range"))
+		gstErrorf("HTTP segment failed hash=%s file= audio=0 segment=-1 status=%d err=%v duration=%s", hash, http.StatusNotFound, ErrTaskNotFound, time.Since(started))
 		c.Status(http.StatusNotFound)
 		return
 	}
 
 	index, err := parseSegmentIndex(c.Param("segment"))
 	if err != nil {
+		logHTTPError("HTTP segment parse", task.ID, task.FileID, task.Audio, -1, err, started)
 		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
 
 	audio := parseQueryInt(c, "audio", task.Audio)
+	gstDebugf("HTTP segment start task=%s file=%s audio=%d segment=%d range=%q uri=%q ua=%q", task.ID, task.FileID, audio, index, c.GetHeader("Range"), c.Request.RequestURI, c.GetHeader("User-Agent"))
 	if !task.hasInitMP4() {
 		if err := task.EnsureInit(c.Request.Context(), audio, index); err != nil {
+			logHTTPError("HTTP segment EnsureInit", task.ID, task.FileID, audio, index, err, started)
 			c.AbortWithError(http.StatusBadGateway, err)
 			return
 		}
+		gstDebugf("HTTP segment EnsureInit completed task=%s file=%s audio=%d segment=%d elapsed=%s", task.ID, task.FileID, audio, index, time.Since(started))
 	}
 
+	var sent int64
 	err = task.WithSegment(c.Request.Context(), index, audio, func(seg Segment) error {
 		if seg.Empty() {
 			return ErrSegmentNotReady
 		}
-		return writeSegment(c, seg)
+		gstDebugf("HTTP segment GetSegment completed task=%s file=%s audio=%d segment=%d size=%d elapsed=%s", task.ID, task.FileID, audio, index, seg.Len(), time.Since(started))
+		var writeErr error
+		sent, writeErr = writeSegment(c, seg)
+		return writeErr
 	})
 	if err != nil {
+		logHTTPError("HTTP segment GetSegment", task.ID, task.FileID, audio, index, err, started)
 		c.AbortWithError(http.StatusBadGateway, err)
 		return
 	}
+	gstDebugf("HTTP segment response written task=%s file=%s audio=%d segment=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, index, c.Writer.Status(), sent, time.Since(started))
 }
 
-func writeSegment(c *gin.Context, seg Segment) error {
+const unknownPlaylistDurationSeconds = 6*60*60 + 6*60 + 6
+
+func writeSegment(c *gin.Context, seg Segment) (int64, error) {
 	totalLength := int64(seg.Len())
 
 	c.Header("Content-Type", "video/mp4")
@@ -194,14 +242,14 @@ func writeSegment(c *gin.Context, seg Segment) error {
 	rangeHeader := c.GetHeader("Range")
 	if rangeHeader == "" {
 		c.Header("Content-Length", strconv.FormatInt(totalLength, 10))
-		return seg.WriteTo(c.Writer)
+		return totalLength, seg.WriteTo(c.Writer)
 	}
 
 	start, end, ok := parseSingleRange(rangeHeader, totalLength)
 	if !ok {
 		c.Header("Content-Range", "bytes */"+strconv.FormatInt(totalLength, 10))
 		c.Status(http.StatusRequestedRangeNotSatisfiable)
-		return nil
+		return 0, nil
 	}
 
 	length := end - start + 1
@@ -209,7 +257,19 @@ func writeSegment(c *gin.Context, seg Segment) error {
 	c.Header("Content-Range", "bytes "+strconv.FormatInt(start, 10)+"-"+strconv.FormatInt(end, 10)+"/"+strconv.FormatInt(totalLength, 10))
 	c.Header("Content-Length", strconv.FormatInt(length, 10))
 
-	return seg.WriteRange(c.Writer, start, length)
+	return length, seg.WriteRange(c.Writer, start, length)
+}
+
+func logHTTPError(prefix string, task string, fileID string, audio int, segment int, err error, started time.Time) {
+	if errors.Is(err, context.Canceled) {
+		gstErrorf("%s context canceled task=%s file=%s audio=%d segment=%d err=%v duration=%s", prefix, task, fileID, audio, segment, err, time.Since(started))
+		return
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		gstErrorf("%s deadline exceeded task=%s file=%s audio=%d segment=%d err=%v duration=%s", prefix, task, fileID, audio, segment, err, time.Since(started))
+		return
+	}
+	gstErrorf("%s failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", prefix, task, fileID, audio, segment, err, time.Since(started))
 }
 
 func parseSingleRange(header string, totalLength int64) (int64, int64, bool) {
@@ -218,113 +278,44 @@ func parseSingleRange(header string, totalLength int64) (int64, int64, bool) {
 		return 0, 0, false
 	}
 
-	spec := strings.TrimSpace(strings.TrimPrefix(header, prefix))
-	if spec == "" || strings.Contains(spec, ",") {
+	rangeText := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if strings.Contains(rangeText, ",") {
 		return 0, 0, false
 	}
 
-	left, right, ok := strings.Cut(spec, "-")
+	startText, endText, ok := strings.Cut(rangeText, "-")
 	if !ok {
 		return 0, 0, false
 	}
 
-	var start int64
-	var end int64
-
-	if left != "" {
-		parsedStart, err := strconv.ParseInt(left, 10, 64)
-		if err != nil {
+	startText = strings.TrimSpace(startText)
+	endText = strings.TrimSpace(endText)
+	if startText == "" {
+		suffix, err := strconv.ParseInt(endText, 10, 64)
+		if err != nil || suffix <= 0 {
 			return 0, 0, false
 		}
-		start = parsedStart
-
-		if right == "" {
-			end = totalLength - 1
-		} else {
-			parsedEnd, err := strconv.ParseInt(right, 10, 64)
-			if err != nil {
-				return 0, 0, false
-			}
-			end = parsedEnd
+		if suffix > totalLength {
+			suffix = totalLength
 		}
-	} else {
-		suffixLength, err := strconv.ParseInt(right, 10, 64)
-		if err != nil || suffixLength <= 0 {
-			return 0, 0, false
-		}
-		if suffixLength > totalLength {
-			suffixLength = totalLength
-		}
-		start = totalLength - suffixLength
-		end = totalLength - 1
+		return totalLength - suffix, totalLength - 1, true
 	}
 
-	if start < 0 || end < start || start >= totalLength {
+	start, err := strconv.ParseInt(startText, 10, 64)
+	if err != nil || start < 0 || start >= totalLength {
 		return 0, 0, false
 	}
-	if end >= totalLength {
-		end = totalLength - 1
+
+	end := totalLength - 1
+	if endText != "" {
+		parsedEnd, err := strconv.ParseInt(endText, 10, 64)
+		if err != nil || parsedEnd < start {
+			return 0, 0, false
+		}
+		if parsedEnd < end {
+			end = parsedEnd
+		}
 	}
 
 	return start, end, true
-}
-
-func parseSegmentIndex(value string) (int, error) {
-	value = strings.TrimPrefix(value, "/")
-	value = strings.TrimSuffix(value, ".m4s")
-	if value == "" || strings.Contains(value, "/") {
-		return 0, errors.New("invalid segment index")
-	}
-	index, err := strconv.Atoi(value)
-	if err != nil || index < 0 {
-		return 0, errors.New("invalid segment index")
-	}
-	return index, nil
-}
-
-func parseQueryInt(c *gin.Context, key string, fallback int) int {
-	value := c.Query(key)
-	if value == "" {
-		return fallback
-	}
-	parsed, err := strconv.Atoi(value)
-	if err != nil {
-		return fallback
-	}
-	return parsed
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-	return ""
-}
-
-func startSegmentIndex(seconds int, segmentSeconds int, count int) int {
-	if seconds <= 0 || segmentSeconds <= 0 {
-		return 0
-	}
-
-	index := seconds / segmentSeconds
-	if count > 0 && index > count {
-		return count
-	}
-	return index
-}
-
-func abortWithSourceError(c *gin.Context, err error) {
-	if errors.Is(err, context.DeadlineExceeded) {
-		c.String(http.StatusGatewayTimeout, err.Error())
-		return
-	}
-	c.String(http.StatusBadGateway, err.Error())
-}
-
-func noCache(c *gin.Context) {
-	c.Header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
-	c.Header("Pragma", "no-cache")
-	c.Header("Expires", "0")
 }

--- a/server/gstreamer/handlers.go
+++ b/server/gstreamer/handlers.go
@@ -17,8 +17,11 @@ func (s *Service) SetupRoute(route gin.IRouter) {
 	route.GET("/gst/:hash/heartbeat", s.heartbeat)
 	route.GET("/gst/:hash/probe", s.probe)
 	route.GET("/gst/:hash/master.m3u8", s.master)
+	route.GET("/gst/:hash/video.m3u8", s.video)
 	route.GET("/gst/:hash/init.mp4", s.initMP4)
 	route.GET("/gst/:hash/seg/*segment", s.segment)
+	route.GET("/gst/:hash/subs/:subtitle", s.subtitlePlaylist)
+	route.GET("/gst/:hash/subs/:subtitle/:segment", s.subtitleSegment)
 }
 
 func (s *Service) remove(c *gin.Context) {
@@ -83,20 +86,27 @@ func (s *Service) master(c *gin.Context) {
 		return
 	}
 
-	segmentSeconds := task.Config.SegmentSeconds
-	rawDuration := task.Probe.DurationSeconds()
-	duration, fallbackDuration := playlistDurationSeconds(rawDuration, segmentSeconds)
-	if fallbackDuration {
-		gstDebugf("HTTP master duration fallback task=%s file=%s audio=%d seconds=%d rawDuration=%d segmentSeconds=%d playlistDuration=%d", task.ID, task.FileID, audio, seconds, rawDuration, segmentSeconds, duration)
+	if len(subtitleTracksForPlaylist(task.Probe)) == 0 {
+		segmentSeconds := task.Config.SegmentSeconds
+		rawDuration := task.Probe.DurationSeconds()
+		duration, fallbackDuration := playlistDurationSeconds(rawDuration, segmentSeconds)
+		if fallbackDuration {
+			gstDebugf("HTTP master duration fallback task=%s file=%s audio=%d seconds=%d rawDuration=%d segmentSeconds=%d playlistDuration=%d", task.ID, task.FileID, audio, seconds, rawDuration, segmentSeconds, duration)
+		}
+
+		count := duration / segmentSeconds
+		startIndex := startSegmentIndex(seconds, segmentSeconds, count)
+		startSeconds := startIndex * segmentSeconds
+
+		playlist := buildMediaPlaylist(segmentSeconds, startIndex, startSeconds, count, audio)
+		c.Data(http.StatusOK, "application/vnd.apple.mpegurl; charset=utf-8", []byte(playlist))
+		gstDebugf("HTTP master media completed task=%s file=%s audio=%d startIndex=%d seconds=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, startIndex, seconds, c.Writer.Status(), len(playlist), time.Since(started))
+		return
 	}
 
-	count := duration / segmentSeconds
-	startIndex := startSegmentIndex(seconds, segmentSeconds, count)
-	startSeconds := startIndex * segmentSeconds
-
-	playlist := buildMasterPlaylist(segmentSeconds, startIndex, startSeconds, count, audio)
+	playlist := buildMasterPlaylist(hash, task.Probe, task.Config, audio, seconds)
 	c.Data(http.StatusOK, "application/vnd.apple.mpegurl; charset=utf-8", []byte(playlist))
-	gstDebugf("HTTP master completed task=%s file=%s audio=%d startIndex=%d seconds=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, startIndex, seconds, c.Writer.Status(), len(playlist), time.Since(started))
+	gstDebugf("HTTP master completed task=%s file=%s audio=%d seconds=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, seconds, c.Writer.Status(), len(playlist), time.Since(started))
 }
 
 func playlistDurationSeconds(rawDuration int, segmentSeconds int) (int, bool) {
@@ -106,7 +116,7 @@ func playlistDurationSeconds(rawDuration int, segmentSeconds int) (int, bool) {
 	return rawDuration, false
 }
 
-func buildMasterPlaylist(segmentSeconds int, startIndex int, startSeconds int, count int, audio int) string {
+func buildMediaPlaylist(segmentSeconds int, startIndex int, startSeconds int, count int, audio int) string {
 	var playlist strings.Builder
 	playlist.WriteString("#EXTM3U\n")
 	playlist.WriteString("#EXT-X-PLAYLIST-TYPE:VOD\n")
@@ -318,4 +328,182 @@ func parseSingleRange(header string, totalLength int64) (int64, int64, bool) {
 	}
 
 	return start, end, true
+}
+
+func (s *Service) video(c *gin.Context) {
+	started := time.Now()
+	noCache(c)
+
+	hash := c.Param("hash")
+	fileID := firstNonEmpty(c.Query("index"), c.Query("id"), c.Query("fileID"))
+	audio := parseQueryInt(c, "audio", 0)
+	seconds := parseQueryInt(c, "seconds", 0)
+
+	task := s.Get(hash)
+	var err error
+	if task == nil && fileID != "" {
+		task, err = s.GetOrAdd(hash, fileID, audio)
+	}
+	if err != nil {
+		logHTTPError("HTTP video", hash, fileID, audio, -1, err, started)
+		abortWithSourceError(c, err)
+		return
+	}
+	if task == nil {
+		c.Status(http.StatusNotFound)
+		return
+	}
+
+	segmentSeconds := task.Config.normalized().SegmentSeconds
+	rawDuration := task.Probe.DurationSeconds()
+	duration, fallbackDuration := playlistDurationSeconds(rawDuration, segmentSeconds)
+	if fallbackDuration {
+		gstDebugf("HTTP video duration fallback task=%s file=%s audio=%d seconds=%d rawDuration=%d segmentSeconds=%d playlistDuration=%d", task.ID, task.FileID, audio, seconds, rawDuration, segmentSeconds, duration)
+	}
+
+	count := duration / segmentSeconds
+	startIndex := startSegmentIndex(seconds, segmentSeconds, count)
+	startSeconds := startIndex * segmentSeconds
+
+	playlist := buildMediaPlaylist(segmentSeconds, startIndex, startSeconds, count, audio)
+	c.Data(http.StatusOK, "application/vnd.apple.mpegurl; charset=utf-8", []byte(playlist))
+	gstDebugf("HTTP video completed task=%s file=%s audio=%d startIndex=%d seconds=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, audio, startIndex, seconds, c.Writer.Status(), len(playlist), time.Since(started))
+}
+
+func (s *Service) subtitlePlaylist(c *gin.Context) {
+	noCache(c)
+
+	task := s.Get(c.Param("hash"))
+	if task == nil {
+		c.Status(http.StatusNotFound)
+		return
+	}
+
+	subtitle, err := parseSubtitleIndex(c.Param("subtitle"))
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	track := task.Probe.SubtitleTrack(subtitle)
+	if track == nil || !track.IsSupportedSubtitle() {
+		c.Status(http.StatusNotFound)
+		return
+	}
+
+	segmentSeconds := task.Config.normalized().SegmentSeconds
+	duration, _ := playlistDurationSeconds(task.Probe.DurationSeconds(), segmentSeconds)
+	playlist := buildSubtitlePlaylist(segmentSeconds, duration/segmentSeconds, subtitle)
+	c.Data(http.StatusOK, "application/vnd.apple.mpegurl; charset=utf-8", []byte(playlist))
+}
+
+func (s *Service) subtitleSegment(c *gin.Context) {
+	started := time.Now()
+	noCache(c)
+
+	task := s.Get(c.Param("hash"))
+	if task == nil {
+		c.Status(http.StatusNotFound)
+		return
+	}
+
+	subtitle, err := parseSubtitleIndex(c.Param("subtitle"))
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	segment, err := parseSubtitleSegmentIndex(c.Param("segment"))
+	if err != nil {
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	data, err := task.SubtitleSegment(c.Request.Context(), subtitle, segment)
+	if err != nil {
+		logHTTPError("HTTP subtitle segment", task.ID, task.FileID, task.Audio, segment, err, started)
+		if errors.Is(err, ErrSubtitleNotFound) {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, ErrUnsupportedSubtitle) {
+			c.AbortWithError(http.StatusBadRequest, err)
+			return
+		}
+		data = emptyWebVTTSegment()
+		c.Data(http.StatusOK, "text/vtt; charset=utf-8", data)
+		gstDebugf("HTTP subtitle segment fallback empty task=%s file=%s subtitle=%d segment=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, subtitle, segment, c.Writer.Status(), len(data), time.Since(started))
+		return
+	}
+
+	c.Data(http.StatusOK, "text/vtt; charset=utf-8", data)
+	gstDebugf("HTTP subtitle segment completed task=%s file=%s subtitle=%d segment=%d status=%d bytes=%d duration=%s", task.ID, task.FileID, subtitle, segment, c.Writer.Status(), len(data), time.Since(started))
+}
+
+func buildMasterPlaylist(hash string, probe ProbeInfo, conf Config, audio int, seconds int) string {
+	tracks := subtitleTracksForPlaylist(probe)
+	bandwidth := conf.normalized().VideoBitrate*1000 + conf.normalized().AACBitrateKbps*1000
+	if bandwidth <= 0 {
+		bandwidth = 4_000_000
+	}
+
+	var playlist strings.Builder
+	playlist.WriteString("#EXTM3U\n")
+	playlist.WriteString("#EXT-X-VERSION:7\n")
+	playlist.WriteByte('\n')
+
+	for _, track := range tracks {
+		playlist.WriteString("#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID=\"subs\",NAME=\"")
+		playlist.WriteString(hlsQuote(subtitleTrackName(track)))
+		playlist.WriteString("\",LANGUAGE=\"")
+		playlist.WriteString(hlsQuote(subtitleTrackLanguage(track)))
+		playlist.WriteString("\",DEFAULT=NO,AUTOSELECT=NO,FORCED=NO,URI=\"/gst/")
+		playlist.WriteString(hlsQuote(hash))
+		playlist.WriteString("/subs/")
+		playlist.WriteString(strconv.Itoa(track.Index))
+		playlist.WriteString(".m3u8\"\n")
+	}
+	if len(tracks) > 0 {
+		playlist.WriteByte('\n')
+	}
+
+	playlist.WriteString("#EXT-X-STREAM-INF:BANDWIDTH=")
+	playlist.WriteString(strconv.Itoa(bandwidth))
+	if video := probe.Video(); video != nil && video.Width > 0 && video.Height > 0 {
+		playlist.WriteString(",RESOLUTION=")
+		playlist.WriteString(strconv.Itoa(video.Width))
+		playlist.WriteByte('x')
+		playlist.WriteString(strconv.Itoa(video.Height))
+	}
+	if codecs := hlsMasterCodecs(probe, conf); codecs != "" {
+		playlist.WriteString(",CODECS=\"")
+		playlist.WriteString(codecs)
+		playlist.WriteByte('"')
+	}
+	if len(tracks) > 0 {
+		playlist.WriteString(",SUBTITLES=\"subs\"")
+	}
+
+	playlist.WriteByte('\n')
+	playlist.WriteString("/gst/")
+	playlist.WriteString(hlsQuote(hash))
+	playlist.WriteString("/video.m3u8?audio=")
+	playlist.WriteString(strconv.Itoa(audio))
+	if seconds > 0 {
+		playlist.WriteString("&seconds=")
+		playlist.WriteString(strconv.Itoa(seconds))
+	}
+	playlist.WriteByte('\n')
+	return playlist.String()
+}
+
+func hlsMasterCodecs(probe ProbeInfo, conf Config) string {
+	conf = conf.normalized()
+	videoIsH264 := probe.IsH264() ||
+		(probe.IsH265() && conf.TranscodeH265) ||
+		(probe.IsAV1() && conf.TranscodeAV1) ||
+		(probe.IsVP9() && conf.TranscodeVP9)
+	if videoIsH264 {
+		return "avc1.640028,mp4a.40.2"
+	}
+
+	return ""
 }

--- a/server/gstreamer/handlers_helpers.go
+++ b/server/gstreamer/handlers_helpers.go
@@ -23,6 +23,31 @@ func parseSegmentIndex(value string) (int, error) {
 	return index, nil
 }
 
+func parseSubtitleIndex(value string) (int, error) {
+	value = strings.TrimSuffix(value, ".m3u8")
+	if value == "" || strings.Contains(value, "/") {
+		return 0, errors.New("invalid subtitle index")
+	}
+	index, err := strconv.Atoi(value)
+	if err != nil || index < 0 {
+		return 0, errors.New("invalid subtitle index")
+	}
+	return index, nil
+}
+
+func parseSubtitleSegmentIndex(value string) (int, error) {
+	value = strings.TrimPrefix(value, "/")
+	value = strings.TrimSuffix(value, ".vtt")
+	if value == "" || strings.Contains(value, "/") {
+		return 0, errors.New("invalid subtitle segment index")
+	}
+	index, err := strconv.Atoi(value)
+	if err != nil || index < 0 {
+		return 0, errors.New("invalid subtitle segment index")
+	}
+	return index, nil
+}
+
 func parseQueryInt(c *gin.Context, key string, fallback int) int {
 	value := c.Query(key)
 	if value == "" {

--- a/server/gstreamer/handlers_helpers.go
+++ b/server/gstreamer/handlers_helpers.go
@@ -1,0 +1,71 @@
+package gstreamer
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func parseSegmentIndex(value string) (int, error) {
+	value = strings.TrimPrefix(value, "/")
+	value = strings.TrimSuffix(value, ".m4s")
+	if value == "" || strings.Contains(value, "/") {
+		return 0, errors.New("invalid segment index")
+	}
+	index, err := strconv.Atoi(value)
+	if err != nil || index < 0 {
+		return 0, errors.New("invalid segment index")
+	}
+	return index, nil
+}
+
+func parseQueryInt(c *gin.Context, key string, fallback int) int {
+	value := c.Query(key)
+	if value == "" {
+		return fallback
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func startSegmentIndex(seconds int, segmentSeconds int, count int) int {
+	if seconds <= 0 || segmentSeconds <= 0 {
+		return 0
+	}
+
+	index := seconds / segmentSeconds
+	if count > 0 && index > count {
+		return count
+	}
+	return index
+}
+
+func abortWithSourceError(c *gin.Context, err error) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		c.String(http.StatusGatewayTimeout, err.Error())
+		return
+	}
+	c.String(http.StatusBadGateway, err.Error())
+}
+
+func noCache(c *gin.Context) {
+	c.Header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	c.Header("Pragma", "no-cache")
+	c.Header("Expires", "0")
+}

--- a/server/gstreamer/log.go
+++ b/server/gstreamer/log.go
@@ -1,0 +1,18 @@
+package gstreamer
+
+import (
+	"fmt"
+
+	"server/log"
+	"server/settings"
+)
+
+func gstDebugf(format string, args ...any) {
+	if settings.IsDebug() {
+		log.TLogln("[GST]", fmt.Sprintf(format, args...))
+	}
+}
+
+func gstErrorf(format string, args ...any) {
+	log.TLogln("[GST ERROR]", fmt.Sprintf(format, args...))
+}

--- a/server/gstreamer/mp4box.go
+++ b/server/gstreamer/mp4box.go
@@ -177,6 +177,9 @@ type mp4BoxReader struct {
 	sequence          uint32
 
 	emittedVideoSegment bool
+	videoTimelineStart  uint64
+	videoTimelineSet    bool
+	videoSegmentNumber  uint64
 }
 
 func Mp4BoxReader(onInit func([]byte), onSegment func(Segment), segmentSeconds float64) *mp4BoxReader {
@@ -700,54 +703,77 @@ func (r *mp4BoxReader) selectVideoCount() (int, error) {
 		return 0, fmt.Errorf("video segment starts with a non-sync sample at %.6fs", float64(r.video[0].decodeTime)/float64(r.videoTrack.timescale))
 	}
 
-	target, err := toUnits(r.segmentSeconds, r.videoTrack.timescale)
+	if !r.videoTimelineSet {
+		r.videoTimelineStart = r.video[0].decodeTime
+		r.videoTimelineSet = true
+	}
+
+	targetOffset, err := toNearestUnits(
+		r.segmentSeconds*float64(r.videoSegmentNumber+1),
+		r.videoTrack.timescale,
+	)
 	if err != nil {
 		return 0, err
 	}
+	if math.MaxUint64-r.videoTimelineStart < targetOffset {
+		return 0, errors.New("video segment timeline overflow")
+	}
+	target := r.videoTimelineStart + targetOffset
 
-	var duration uint64
 	for i := range r.video {
 		fragment := &r.video[i]
-		if math.MaxUint64-duration < fragment.duration {
-			return 0, errors.New("video timeline overflow")
+		fragmentEnd := fragment.endTime()
+		if fragmentEnd < target {
+			continue
 		}
-		end := duration + fragment.duration
-		if end >= target {
-			if end == target {
-				return i + 1, nil
-			}
-
-			splitSamples, reached, err := findVideoSplitSampleCount(fragment, target-duration)
-			if err != nil {
-				return 0, err
-			}
-			if !reached {
-				return 0, errors.New("video split target was not reached")
-			}
-
-			totalSamples, err := fragmentSampleCount(*fragment)
-			if err != nil {
-				return 0, err
-			}
-			if splitSamples <= 0 || splitSamples > totalSamples {
-				return 0, errors.New("invalid video split sample count")
-			}
-
-			if splitSamples < totalSamples {
-				left, right, err := splitFragmentAtSample(*fragment, splitSamples)
-				if err != nil {
-					return 0, err
-				}
-
-				r.video[i] = left
-				r.video = append(r.video, mp4Fragment{})
-				copy(r.video[i+2:], r.video[i+1:])
-				r.video[i+1] = right
-			}
-
+		if fragmentEnd == target {
 			return i + 1, nil
 		}
-		duration = end
+		if target <= fragment.decodeTime {
+			if i > 0 {
+				return i, nil
+			}
+			return 0, errors.New("video segment target precedes the first sample")
+		}
+
+		splitSamples, reached, err := findVideoSplitSampleCount(
+			fragment,
+			target-fragment.decodeTime,
+		)
+		if err != nil {
+			return 0, err
+		}
+		if !reached {
+			return 0, errors.New("video split target was not reached")
+		}
+
+		totalSamples, err := fragmentSampleCount(*fragment)
+		if err != nil {
+			return 0, err
+		}
+		if splitSamples == 0 {
+			if i > 0 {
+				return i, nil
+			}
+			splitSamples = 1
+		}
+		if splitSamples < 0 || splitSamples > totalSamples {
+			return 0, errors.New("invalid video split sample count")
+		}
+
+		if splitSamples < totalSamples {
+			left, right, err := splitFragmentAtSample(*fragment, splitSamples)
+			if err != nil {
+				return 0, err
+			}
+
+			r.video[i] = left
+			r.video = append(r.video, mp4Fragment{})
+			copy(r.video[i+2:], r.video[i+1:])
+			r.video[i+1] = right
+		}
+
+		return i + 1, nil
 	}
 
 	return 0, nil
@@ -763,6 +789,7 @@ func findVideoSplitSampleCount(fragment *mp4Fragment, target uint64) (int, bool,
 
 	videoEnd := uint64(0)
 	sampleCount := 0
+	previousEnd := uint64(0)
 
 	for _, run := range fragment.runs {
 		if len(run.samples) == 0 {
@@ -778,8 +805,13 @@ func findVideoSplitSampleCount(fragment *mp4Fragment, target uint64) (int, bool,
 			sampleCount++
 
 			if videoEnd >= target {
+				if videoEnd > target &&
+					target-previousEnd < videoEnd-target {
+					return sampleCount - 1, true, nil
+				}
 				return sampleCount, true, nil
 			}
+			previousEnd = videoEnd
 		}
 	}
 
@@ -1173,6 +1205,7 @@ func (r *mp4BoxReader) buildSegment(videoCount int, audioCount int, allowSingleT
 	})
 	if hasVideo {
 		r.emittedVideoSegment = true
+		r.videoSegmentNumber++
 	}
 
 	if hasVideo {
@@ -2111,6 +2144,18 @@ func toUnits(seconds float64, timescale uint32) (uint64, error) {
 	return uint64(math.Ceil(value)), nil
 }
 
+func toNearestUnits(seconds float64, timescale uint32) (uint64, error) {
+	value := seconds * float64(timescale)
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > float64(math.MaxUint64) {
+		return 0, errors.New("invalid timeline value")
+	}
+	units := uint64(math.Round(value))
+	if seconds > 0 && units == 0 {
+		units = 1
+	}
+	return units, nil
+}
+
 func addTfdtOffset(value uint64, timescale uint32, seconds float64) (uint64, error) {
 	if seconds <= 0 {
 		return value, nil
@@ -2221,6 +2266,9 @@ func (r *mp4BoxReader) clearFragments() {
 	r.video = r.video[:0]
 	r.audio = r.audio[:0]
 	r.emittedVideoSegment = false
+	r.videoTimelineStart = 0
+	r.videoTimelineSet = false
+	r.videoSegmentNumber = 0
 }
 
 func (r *mp4BoxReader) ReclaimPayloads() {

--- a/server/gstreamer/mp4box.go
+++ b/server/gstreamer/mp4box.go
@@ -175,6 +175,8 @@ type mp4BoxReader struct {
 
 	tfdtOffsetSeconds float64
 	sequence          uint32
+
+	emittedVideoSegment bool
 }
 
 func Mp4BoxReader(onInit func([]byte), onSegment func(Segment), segmentSeconds float64) *mp4BoxReader {
@@ -219,6 +221,7 @@ func (r *mp4BoxReader) SeekReset(seconds float64) {
 	r.clearFragments()
 	r.resetPrefix()
 	r.resetBoxState()
+
 }
 
 func (r *mp4BoxReader) Push(data []byte) error {
@@ -290,7 +293,7 @@ func (r *mp4BoxReader) TryBuildEndOfStreamRemainder() (bool, error) {
 		return false, nil
 	}
 
-	if videoCount > 0 && !r.video[0].startsWithSync {
+	if videoCount > 0 && !r.emittedVideoSegment && !r.video[0].startsWithSync {
 		return false, r.undecodableEOSRemainderError()
 	}
 
@@ -693,7 +696,7 @@ func (r *mp4BoxReader) selectVideoCount() (int, error) {
 		return 0, nil
 	}
 
-	if !r.video[0].startsWithSync {
+	if !r.emittedVideoSegment && !r.video[0].startsWithSync {
 		return 0, fmt.Errorf("video segment starts with a non-sync sample at %.6fs", float64(r.video[0].decodeTime)/float64(r.videoTrack.timescale))
 	}
 
@@ -703,14 +706,88 @@ func (r *mp4BoxReader) selectVideoCount() (int, error) {
 	}
 
 	var duration uint64
-	for i := 0; i+1 < len(r.video); i++ {
-		duration += r.video[i].duration
-		if duration >= target && r.video[i+1].startsWithSync {
+	for i := range r.video {
+		fragment := &r.video[i]
+		if math.MaxUint64-duration < fragment.duration {
+			return 0, errors.New("video timeline overflow")
+		}
+		end := duration + fragment.duration
+		if end >= target {
+			if end == target {
+				return i + 1, nil
+			}
+
+			splitSamples, reached, err := findVideoSplitSampleCount(fragment, target-duration)
+			if err != nil {
+				return 0, err
+			}
+			if !reached {
+				return 0, errors.New("video split target was not reached")
+			}
+
+			totalSamples, err := fragmentSampleCount(*fragment)
+			if err != nil {
+				return 0, err
+			}
+			if splitSamples <= 0 || splitSamples > totalSamples {
+				return 0, errors.New("invalid video split sample count")
+			}
+
+			if splitSamples < totalSamples {
+				left, right, err := splitFragmentAtSample(*fragment, splitSamples)
+				if err != nil {
+					return 0, err
+				}
+
+				r.video[i] = left
+				r.video = append(r.video, mp4Fragment{})
+				copy(r.video[i+2:], r.video[i+1:])
+				r.video[i+1] = right
+			}
+
 			return i + 1, nil
 		}
+		duration = end
 	}
 
 	return 0, nil
+}
+
+func findVideoSplitSampleCount(fragment *mp4Fragment, target uint64) (int, bool, error) {
+	if fragment == nil {
+		return 0, false, errors.New("video fragment is nil")
+	}
+	if target == 0 {
+		return 0, false, errors.New("video split target is zero")
+	}
+
+	videoEnd := uint64(0)
+	sampleCount := 0
+
+	for _, run := range fragment.runs {
+		if len(run.samples) == 0 {
+			return 0, false, errors.New("video trun has no parsed samples")
+		}
+
+		for _, sample := range run.samples {
+			if math.MaxUint64-videoEnd < uint64(sample.duration) {
+				return 0, false, errors.New("video sample timeline overflow")
+			}
+
+			videoEnd += uint64(sample.duration)
+			sampleCount++
+
+			if videoEnd >= target {
+				return sampleCount, true, nil
+			}
+		}
+	}
+
+	if videoEnd != fragment.duration {
+		return 0, false, errors.New("video sample durations do not match fragment duration")
+	}
+
+	return sampleCount, false, nil
 }
 
 func (r *mp4BoxReader) selectAudioCount(videoEnd uint64) (int, error) {
@@ -875,7 +952,7 @@ func splitFragmentAtSample(
 			leftRun, err := buildExplicitRun(
 				sourceRun,
 				sourceRun.samples[:take],
-				false,
+				true,
 			)
 			if err != nil {
 				return mp4Fragment{}, mp4Fragment{}, err
@@ -1094,6 +1171,9 @@ func (r *mp4BoxReader) buildSegment(videoCount int, audioCount int, allowSingleT
 		StartSeconds: startSeconds,
 		EndSeconds:   endSeconds,
 	})
+	if hasVideo {
+		r.emittedVideoSegment = true
+	}
 
 	if hasVideo {
 		r.video = removeFragments(r.video, videoCount)
@@ -1337,7 +1417,7 @@ func parseTraf(traf []byte, trafHeader int, videoTrack trackInfo, audioTrack tra
 			continue
 		}
 
-		keepSamples := parsedTfhd.trackID == audioTrack.id && audioTrack.id != 0
+		keepSamples := parsedTfhd.trackID == videoTrack.id || (parsedTfhd.trackID == audioTrack.id && audioTrack.id != 0)
 		run, err := normalizeTrun(box, headerSize, defaultDuration, defaultSize, defaultFlags, keepSamples)
 		if err != nil {
 			return nil, err
@@ -2140,6 +2220,7 @@ func (r *mp4BoxReader) clearFragments() {
 	}
 	r.video = r.video[:0]
 	r.audio = r.audio[:0]
+	r.emittedVideoSegment = false
 }
 
 func (r *mp4BoxReader) ReclaimPayloads() {

--- a/server/gstreamer/pipeline_gst.go
+++ b/server/gstreamer/pipeline_gst.go
@@ -54,6 +54,7 @@ type gstRunner struct {
 	pipeline uintptr
 	bus      uintptr
 	sink     uintptr
+	subtitleSinks map[int]uintptr
 	probes   *gstPipelineProbes
 
 	frozen atomic.Bool
@@ -427,6 +428,8 @@ func (r *gstRunner) createPipelineArgs() string {
 		}
 	}
 
+	r.writeSubtitleBranches(&sb)
+
 	sb.WriteString("mp4mux name=mux fragment-duration=")
 	sb.WriteString(strconv.Itoa(conf.SegmentSeconds * 1000))
 	r.writeAppSink(&sb, conf, gstVersion)
@@ -654,6 +657,7 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 		}
 	}
 
+	r.drainSubtitleSinks()
 	if r.task.hasInitMP4() {
 		if r.readySegment.complete {
 			r.completeReadySegment(startIndex)
@@ -673,6 +677,7 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 			return err
 		}
 
+		r.drainSubtitleSinks()
 		if err := r.pollPipelineError(); err != nil {
 			r.freezeAtSegment(startIndex)
 			return err
@@ -708,6 +713,7 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 			r.freezeAtSegment(startIndex)
 			return err
 		}
+		r.drainSubtitleSinks()
 
 		if err := r.pollPipelineError(); err != nil {
 			r.freezeAtSegment(startIndex)
@@ -774,6 +780,7 @@ func (r *gstRunner) getSegmentWithTimeout(ctx context.Context, index int, audio 
 		}
 	}
 
+	r.drainSubtitleSinks()
 	if r.readySegment.index == index && r.readySegment.complete {
 		seg := r.readySegment.segment
 		return seg, nil
@@ -793,6 +800,7 @@ func (r *gstRunner) getSegmentWithTimeout(ctx context.Context, index int, audio 
 			return Segment{}, err
 		}
 
+		r.drainSubtitleSinks()
 		if err := r.pollPipelineError(); err != nil {
 			r.freezeAtSegment(index)
 			return Segment{}, err
@@ -806,6 +814,7 @@ func (r *gstRunner) getSegmentWithTimeout(ctx context.Context, index int, audio 
 			}
 
 			if gstRuntime.appSinkIsEOS(r.sink) {
+				r.drainSubtitleSinks()
 				gstDebugf("runner GetSegment EOS task=%s file=%s audio=%d segment=%d samples=%d bytes=%d elapsed=%s", r.task.ID, r.task.FileID, audio, index, samples, bytes, time.Since(started))
 				seg, err := r.drainEndOfStream(index)
 				if err != nil {
@@ -833,6 +842,7 @@ func (r *gstRunner) getSegmentWithTimeout(ctx context.Context, index int, audio 
 			r.freezeAtSegment(index)
 			return Segment{}, err
 		}
+		r.drainSubtitleSinks()
 
 		if err := r.pollPipelineError(); err != nil {
 			r.freezeAtSegment(index)
@@ -841,6 +851,7 @@ func (r *gstRunner) getSegmentWithTimeout(ctx context.Context, index int, audio 
 
 		if r.readySegment.complete {
 			seg := r.completeReadySegment(index)
+			r.drainSubtitleSinks()
 			gstDebugf("runner GetSegment ready task=%s file=%s audio=%d segment=%d samples=%d bytes=%d size=%d duration=%s", r.task.ID, r.task.FileID, audio, index, samples, bytes, seg.Len(), time.Since(started))
 			return seg, nil
 		}
@@ -870,6 +881,7 @@ func (r *gstRunner) pollPipelineError() error {
 func (r *gstRunner) drainEndOfStream(index int) (Segment, error) {
 	started := time.Now()
 	gstDebugf("drainEndOfStream start task=%s file=%s audio=%d segment=%d", r.task.ID, r.task.FileID, r.audioIndex, index)
+	r.drainSubtitleSinks()
 	if r.reader == nil {
 		gstErrorf("drainEndOfStream failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, ErrSegmentNotReady, time.Since(started))
 		return Segment{}, ErrSegmentNotReady
@@ -892,6 +904,7 @@ func (r *gstRunner) drainEndOfStream(index int) (Segment, error) {
 			return Segment{}, err
 		}
 		seg := r.completeReadySegment(index)
+		r.drainSubtitleSinks()
 		gstDebugf("drainEndOfStream completed deferred task=%s file=%s audio=%d segment=%d size=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, seg.Len(), time.Since(started))
 		return seg, nil
 	}
@@ -908,6 +921,7 @@ func (r *gstRunner) drainEndOfStream(index int) (Segment, error) {
 			return Segment{}, err
 		}
 		seg := r.completeReadySegment(index)
+		r.drainSubtitleSinks()
 		gstDebugf("drainEndOfStream completed remainder task=%s file=%s audio=%d segment=%d size=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, seg.Len(), time.Since(started))
 		return seg, nil
 	}
@@ -959,6 +973,10 @@ func (r *gstRunner) discardReadySegment() {
 	}
 }
 
+func (r *gstRunner) DiscardSegment() {
+	r.discardReadySegment()
+}
+
 func (r *gstRunner) freezeAtSegment(index int) {
 	position := r.position()
 	virtualSeconds := position
@@ -993,7 +1011,8 @@ func (r *gstRunner) freezeAtPosition(seconds float64) {
 
 func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 	started := time.Now()
-	gstDebugf("startPipeline start task=%s file=%s audio=%d requested=%.3f", r.task.ID, r.task.FileID, r.audioIndex, seconds)
+	timelineGeneration := r.task.resetSubtitleTimeline(seconds)
+	gstDebugf("startPipeline start task=%s file=%s audio=%d requested=%.3f subtitleGeneration=%d", r.task.ID, r.task.FileID, r.audioIndex, seconds, timelineGeneration)
 	stageStarted := time.Now()
 	pipeline, err := gstRuntime.parseLaunch(r.createPipelineArgs())
 	if err != nil {
@@ -1024,6 +1043,7 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 	gstDebugf("startPipeline bus acquired task=%s file=%s audio=%d bus=%t duration=%s", r.task.ID, r.task.FileID, r.audioIndex, bus != 0, time.Since(stageStarted))
 	actualStartSeconds := seconds
 	var demux uintptr
+	var subtitleSinks map[int]uintptr
 
 	cleanup := func() {
 		probes.release()
@@ -1031,10 +1051,21 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 		if demux != 0 {
 			gstRuntime.objectUnref(demux)
 		}
+		for _, subtitleSink := range subtitleSinks {
+			gstRuntime.objectUnref(subtitleSink)
+		}
 		gstRuntime.objectUnref(sink)
 		gstRuntime.objectUnref(pipeline)
 		gstRuntime.objectUnref(bus)
 	}
+
+	subtitleSinks, err = r.lookupSubtitleSinks(pipeline)
+	if err != nil {
+		cleanup()
+		gstErrorf("startPipeline subtitle appsink lookup failed task=%s file=%s audio=%d err=%v", r.task.ID, r.task.FileID, r.audioIndex, err)
+		return 0, err
+	}
+	gstDebugf("startPipeline subtitle appsinks acquired task=%s file=%s audio=%d count=%d", r.task.ID, r.task.FileID, r.audioIndex, len(subtitleSinks))
 
 	if seconds > 0 {
 		stageStarted = time.Now()
@@ -1125,8 +1156,10 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 	r.pipeline = pipeline
 	r.bus = bus
 	r.sink = sink
+	r.subtitleSinks = subtitleSinks
 	r.probes = probes
-	gstDebugf("startPipeline completed task=%s file=%s audio=%d requested=%.3f actual=%.3f delta=%.3f duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualStartSeconds, actualStartSeconds-seconds, time.Since(started))
+	r.task.setSubtitleTimelineOrigin(timelineGeneration, seconds, actualStartSeconds)
+	gstDebugf("startPipeline completed task=%s file=%s audio=%d requested=%.3f actual=%.3f delta=%.3f subtitleGeneration=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualStartSeconds, actualStartSeconds-seconds, timelineGeneration, time.Since(started))
 	return actualStartSeconds, nil
 }
 
@@ -1177,6 +1210,13 @@ func (r *gstRunner) stopPipeline() {
 	if r.pipeline != 0 {
 		_ = gstRuntime.elementSetState(r.pipeline, gstStateNull)
 	}
+	for subtitleIndex, subtitleSink := range r.subtitleSinks {
+		if subtitleSink != 0 {
+			gstRuntime.objectUnref(subtitleSink)
+		}
+		delete(r.subtitleSinks, subtitleIndex)
+	}
+	r.subtitleSinks = nil
 	if r.sink != 0 {
 		gstRuntime.objectUnref(r.sink)
 		r.sink = 0

--- a/server/gstreamer/pipeline_gst.go
+++ b/server/gstreamer/pipeline_gst.go
@@ -54,6 +54,7 @@ type gstRunner struct {
 	pipeline uintptr
 	bus      uintptr
 	sink     uintptr
+	probes   *gstPipelineProbes
 
 	frozen atomic.Bool
 }
@@ -345,9 +346,12 @@ func appendUniqueEnvPath(paths []string, path string) []string {
 }
 
 func (r *gstRunner) createPipelineArgs() string {
+	started := time.Now()
 	conf := r.task.Config.normalized()
 	probe := r.task.Probe
 	gstVersion := effectiveGStreamerVersion(conf)
+	audioTrack := probe.AudioTrack(r.audioIndex)
+	video := probe.Video()
 
 	var sb strings.Builder
 
@@ -393,7 +397,7 @@ func (r *gstRunner) createPipelineArgs() string {
 		}
 	}
 
-	if audioTrack := probe.AudioTrack(r.audioIndex); audioTrack != nil {
+	if audioTrack != nil {
 		sb.WriteString("d.audio_")
 		sb.WriteString(strconv.Itoa(audioTrack.Index))
 		sb.WriteString(" ! mq.sink_1 mq.src_1 ! ")
@@ -404,7 +408,8 @@ func (r *gstRunner) createPipelineArgs() string {
 			aacChannels := effectiveAACChannels(conf, audioTrack)
 			aacSampleRate := effectiveAACSampleRate(conf, audioTrack)
 
-			sb.WriteString("decodebin ! audioconvert dithering=none noise-shaping=none ! audioresample quality=2 sinc-filter-mode=full ! audio/x-raw,format=")
+			sb.WriteString("decodebin ! audioconvert dithering=none noise-shaping=none ! ")
+			sb.WriteString("audioresample quality=2 sinc-filter-mode=full ! audio/x-raw,format=")
 			sb.WriteString(aacRawFormat())
 			sb.WriteString(",layout=interleaved,rate=")
 			sb.WriteString(strconv.Itoa(aacSampleRate))
@@ -426,7 +431,38 @@ func (r *gstRunner) createPipelineArgs() string {
 	sb.WriteString(strconv.Itoa(conf.SegmentSeconds * 1000))
 	r.writeAppSink(&sb, conf, gstVersion)
 
-	return sb.String()
+	args := sb.String()
+	videoCodec := ""
+	if video != nil {
+		videoCodec = firstNonEmpty(video.Codec, video.CapsName)
+	}
+	audioCodec := ""
+	audioChannels := 0
+	audioRate := 0
+	if audioTrack != nil {
+		audioCodec = firstNonEmpty(audioTrack.Codec, audioTrack.CapsName)
+		audioChannels = audioTrack.Channels
+		audioRate = audioTrack.Rate
+	}
+	gstDebugf("create pipeline task=%s file=%s audio=%d selectedAudio=%d videoCodec=%q audioCodec=%q audioChannels=%d audioRate=%d segmentSeconds=%d appsinkBuffers=%d tempfs=%t tempfsRing=%d source=%s transcodeVideo=%t aacChannels=%d aacRate=%d aacBitrate=%d duration=%s",
+		r.task.ID, r.task.FileID, r.audioIndex, r.audioIndex, videoCodec, audioCodec, audioChannels, audioRate, conf.SegmentSeconds, conf.AppSinkBuffers, conf.TempFS, conf.TempFSRing, conf.Source, r.transcodesVideo(conf, probe), effectiveAACChannels(conf, audioTrack), effectiveAACSampleRate(conf, audioTrack), conf.AACBitrateKbps, time.Since(started))
+	gstDebugf("create pipeline args task=%s file=%s audio=%d pipeline=%s", r.task.ID, r.task.FileID, r.audioIndex, args)
+	return args
+}
+
+func (r *gstRunner) transcodesVideo(conf Config, probe ProbeInfo) bool {
+	switch {
+	case probe.IsH264():
+		return conf.TranscodeH264
+	case probe.IsH265():
+		return conf.TranscodeH265
+	case probe.IsAV1():
+		return conf.TranscodeAV1
+	case probe.IsVP9():
+		return conf.TranscodeVP9
+	default:
+		return false
+	}
 }
 
 func (r *gstRunner) writeAppSink(sb *strings.Builder, conf Config, gstVersion gstVersionInfo) {
@@ -553,7 +589,11 @@ func (r *gstRunner) transcodeToH264(sb *strings.Builder) {
 	sb.WriteString(" bframes=0 byte-stream=false ! video/x-h264,profile=main,stream-format=avc,alignment=au ! h264parse config-interval=0 ! h264timestamper ! video/x-h264,profile=main,stream-format=avc,alignment=au ! mux.video_0 ")
 }
 
-func (r *gstRunner) Seek(seconds float64) bool {
+func (r *gstRunner) Seek(seconds float64) error {
+	started := time.Now()
+	oldPosition := r.position()
+	gstDebugf("Seek start task=%s file=%s audio=%d requested=%.3f oldPosition=%.3f", r.task.ID, r.task.FileID, r.audioIndex, seconds, oldPosition)
+	gstDebugf("Seek stopping old pipeline task=%s file=%s audio=%d requested=%.3f", r.task.ID, r.task.FileID, r.audioIndex, seconds)
 	r.stopPipeline()
 
 	r.discardReadySegment()
@@ -562,7 +602,9 @@ func (r *gstRunner) Seek(seconds float64) bool {
 	actualSeconds, err := r.startPipeline(seconds)
 	if err != nil {
 		r.freezeAtPosition(seconds)
-		return false
+		err = fmt.Errorf("seek to %.3fs: %w", seconds, err)
+		gstErrorf("Seek failed task=%s file=%s audio=%d requested=%.3f actual=%.3f err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualSeconds, err, time.Since(started))
+		return err
 	}
 	r.reader.SeekReset(actualSeconds)
 
@@ -570,7 +612,8 @@ func (r *gstRunner) Seek(seconds float64) bool {
 	r.setPosition(actualSeconds)
 	r.positionSeekSeconds = actualSeconds
 	r.statePlaying = true
-	return true
+	gstDebugf("Seek completed task=%s file=%s audio=%d requested=%.3f actual=%.3f delta=%.3f duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualSeconds, actualSeconds-seconds, time.Since(started))
+	return nil
 }
 
 func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) error {
@@ -584,8 +627,8 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 	}
 
 	if r.IsFrozen() {
-		if !r.Seek(startSeconds) {
-			return ErrSegmentNotReady
+		if err := r.Seek(startSeconds); err != nil {
+			return err
 		}
 	} else if !r.statePlaying {
 		r.statePlaying = true
@@ -606,8 +649,8 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 			r.setPosition(actualSeconds)
 		}
 	} else if startIndex > 0 && math.Abs(r.position()-startSeconds) > 0.001 {
-		if !r.Seek(startSeconds) {
-			return ErrSegmentNotReady
+		if err := r.Seek(startSeconds); err != nil {
+			return err
 		}
 	}
 
@@ -618,9 +661,15 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 		return nil
 	}
 
+	started := time.Now()
 	deadline := time.Now().Add(20 * time.Second)
+	lastWaitLog := time.Time{}
+	samples := 0
+	bytes := 0
+	gstDebugf("runner EnsureInit wait start task=%s file=%s audio=%d startIndex=%d position=%.3f deadline=%s", r.task.ID, r.task.FileID, audio, startIndex, r.position(), deadline.Format(time.RFC3339Nano))
 	for time.Now().Before(deadline) {
 		if err := ctx.Err(); err != nil {
+			gstErrorf("runner EnsureInit context canceled task=%s file=%s audio=%d startIndex=%d err=%v duration=%s", r.task.ID, r.task.FileID, audio, startIndex, err, time.Since(started))
 			return err
 		}
 
@@ -636,19 +685,26 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 				return err
 			}
 			if gstRuntime.appSinkIsEOS(r.sink) {
+				gstDebugf("runner EnsureInit EOS task=%s file=%s audio=%d startIndex=%d samples=%d bytes=%d duration=%s", r.task.ID, r.task.FileID, audio, startIndex, samples, bytes, time.Since(started))
 				return ErrSegmentNotReady
 			}
+			r.logWaitSummary("EnsureInit", started, &lastWaitLog, samples, bytes)
 			continue
 		}
 
+		samples++
+		sampleBytes := 0
 		err := gstRuntime.withSampleBytes(sample, func(data []byte) error {
+			sampleBytes = len(data)
 			if len(data) == 0 {
 				return nil
 			}
 			return r.reader.Push(data)
 		})
 		gstRuntime.sampleUnref(sample)
+		bytes += sampleBytes
 		if err != nil {
+			gstErrorf("runner EnsureInit MP4 reader failed task=%s file=%s audio=%d startIndex=%d err=%v samples=%d bytes=%d duration=%s", r.task.ID, r.task.FileID, audio, startIndex, err, samples, bytes, time.Since(started))
 			r.freezeAtSegment(startIndex)
 			return err
 		}
@@ -662,8 +718,10 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 			if r.readySegment.complete {
 				r.completeReadySegment(startIndex)
 			}
+			gstDebugf("runner EnsureInit init MP4 ready task=%s file=%s audio=%d startIndex=%d samples=%d bytes=%d duration=%s", r.task.ID, r.task.FileID, audio, startIndex, samples, bytes, time.Since(started))
 			return nil
 		}
+		r.logWaitSummary("EnsureInit", started, &lastWaitLog, samples, bytes)
 	}
 
 	if err := r.pollPipelineError(); err != nil {
@@ -671,13 +729,28 @@ func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) e
 		return err
 	}
 
+	gstErrorf("runner EnsureInit timeout task=%s file=%s audio=%d startIndex=%d samples=%d bytes=%d deadline=%s duration=%s", r.task.ID, r.task.FileID, audio, startIndex, samples, bytes, deadline.Format(time.RFC3339Nano), time.Since(started))
 	return ErrSegmentNotReady
 }
 
 func (r *gstRunner) GetSegment(ctx context.Context, index int, audio int) (Segment, error) {
+	return r.getSegmentWithTimeout(ctx, index, audio, 20*time.Second)
+}
+
+func (r *gstRunner) GetSegmentWithTimeout(ctx context.Context, index int, audio int, timeout time.Duration) (Segment, error) {
+	return r.getSegmentWithTimeout(ctx, index, audio, timeout)
+}
+
+func (r *gstRunner) getSegmentWithTimeout(ctx context.Context, index int, audio int, timeout time.Duration) (Segment, error) {
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+
 	if r.IsFrozen() {
-		if !r.Seek(r.position()) {
-			return Segment{}, ErrSegmentNotReady
+		conf := r.task.Config.normalized()
+		startSeconds := float64(index * conf.SegmentSeconds)
+		if err := r.Seek(startSeconds); err != nil {
+			return Segment{}, err
 		}
 	} else if !r.statePlaying {
 		r.statePlaying = true
@@ -702,14 +775,21 @@ func (r *gstRunner) GetSegment(ctx context.Context, index int, audio int) (Segme
 	}
 
 	if r.readySegment.index == index && r.readySegment.complete {
-		return r.readySegment.segment, nil
+		seg := r.readySegment.segment
+		return seg, nil
 	}
 
 	r.discardReadySegment()
 
-	deadline := time.Now().Add(20 * time.Second)
+	started := time.Now()
+	deadline := time.Now().Add(timeout)
+	lastWaitLog := time.Time{}
+	samples := 0
+	bytes := 0
+	gstDebugf("runner GetSegment wait start task=%s file=%s audio=%d segment=%d position=%.3f timeout=%s deadline=%s", r.task.ID, r.task.FileID, audio, index, r.position(), timeout, deadline.Format(time.RFC3339Nano))
 	for time.Now().Before(deadline) {
 		if err := ctx.Err(); err != nil {
+			gstErrorf("runner GetSegment context canceled task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, audio, index, err, time.Since(started))
 			return Segment{}, err
 		}
 
@@ -726,23 +806,30 @@ func (r *gstRunner) GetSegment(ctx context.Context, index int, audio int) (Segme
 			}
 
 			if gstRuntime.appSinkIsEOS(r.sink) {
+				gstDebugf("runner GetSegment EOS task=%s file=%s audio=%d segment=%d samples=%d bytes=%d elapsed=%s", r.task.ID, r.task.FileID, audio, index, samples, bytes, time.Since(started))
 				seg, err := r.drainEndOfStream(index)
 				if err != nil {
 					return Segment{}, err
 				}
 				return seg, nil
 			}
+			r.logWaitSummary("GetSegment", started, &lastWaitLog, samples, bytes)
 			continue
 		}
 
+		samples++
+		sampleBytes := 0
 		err := gstRuntime.withSampleBytes(sample, func(data []byte) error {
+			sampleBytes = len(data)
 			if len(data) == 0 {
 				return nil
 			}
 			return r.reader.Push(data)
 		})
 		gstRuntime.sampleUnref(sample)
+		bytes += sampleBytes
 		if err != nil {
+			gstErrorf("runner GetSegment MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v samples=%d bytes=%d duration=%s", r.task.ID, r.task.FileID, audio, index, err, samples, bytes, time.Since(started))
 			r.freezeAtSegment(index)
 			return Segment{}, err
 		}
@@ -753,8 +840,11 @@ func (r *gstRunner) GetSegment(ctx context.Context, index int, audio int) (Segme
 		}
 
 		if r.readySegment.complete {
-			return r.completeReadySegment(index), nil
+			seg := r.completeReadySegment(index)
+			gstDebugf("runner GetSegment ready task=%s file=%s audio=%d segment=%d samples=%d bytes=%d size=%d duration=%s", r.task.ID, r.task.FileID, audio, index, samples, bytes, seg.Len(), time.Since(started))
+			return seg, nil
 		}
+		r.logWaitSummary("GetSegment", started, &lastWaitLog, samples, bytes)
 	}
 
 	if err := r.pollPipelineError(); err != nil {
@@ -762,6 +852,7 @@ func (r *gstRunner) GetSegment(ctx context.Context, index int, audio int) (Segme
 		return Segment{}, err
 	}
 
+	gstErrorf("runner GetSegment timeout task=%s file=%s audio=%d segment=%d samples=%d bytes=%d timeout=%s deadline=%s duration=%s", r.task.ID, r.task.FileID, audio, index, samples, bytes, timeout, deadline.Format(time.RFC3339Nano), time.Since(started))
 	return Segment{}, ErrSegmentNotReady
 }
 
@@ -769,52 +860,79 @@ func (r *gstRunner) pollPipelineError() error {
 	if r.bus == 0 || gstRuntime == nil {
 		return nil
 	}
-	return gstRuntime.popBusError(r.bus, 0)
+	err := gstRuntime.popBusError(r.bus, 0)
+	if err != nil {
+		gstErrorf("GStreamer bus error task=%s file=%s audio=%d err=%v", r.task.ID, r.task.FileID, r.audioIndex, err)
+	}
+	return err
 }
 
 func (r *gstRunner) drainEndOfStream(index int) (Segment, error) {
+	started := time.Now()
+	gstDebugf("drainEndOfStream start task=%s file=%s audio=%d segment=%d", r.task.ID, r.task.FileID, r.audioIndex, index)
 	if r.reader == nil {
+		gstErrorf("drainEndOfStream failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, ErrSegmentNotReady, time.Since(started))
 		return Segment{}, ErrSegmentNotReady
 	}
 
 	completed, err := r.reader.TryProcessDeferred()
 	if err != nil {
 		if len(r.reader.video) > 0 && !r.reader.video[0].startsWithSync {
-			return Segment{}, r.reader.undecodableEOSRemainderError()
+			err = r.reader.undecodableEOSRemainderError()
+			gstErrorf("drainEndOfStream MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, err, time.Since(started))
+			return Segment{}, err
 		}
+		gstErrorf("drainEndOfStream MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, err, time.Since(started))
 		return Segment{}, err
 	}
 	if completed {
 		if !r.readySegment.complete {
-			return Segment{}, errors.New("mp4 reader completed a segment without onSegment callback")
+			err := errors.New("mp4 reader completed a segment without onSegment callback")
+			gstErrorf("drainEndOfStream MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, err, time.Since(started))
+			return Segment{}, err
 		}
-		return r.completeReadySegment(index), nil
+		seg := r.completeReadySegment(index)
+		gstDebugf("drainEndOfStream completed deferred task=%s file=%s audio=%d segment=%d size=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, seg.Len(), time.Since(started))
+		return seg, nil
 	}
 
 	completed, err = r.reader.TryBuildEndOfStreamRemainder()
 	if err != nil {
+		gstErrorf("drainEndOfStream MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, err, time.Since(started))
 		return Segment{}, err
 	}
 	if completed {
 		if !r.readySegment.complete {
-			return Segment{}, errors.New("mp4 reader completed EOS remainder without onSegment callback")
+			err := errors.New("mp4 reader completed EOS remainder without onSegment callback")
+			gstErrorf("drainEndOfStream MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, err, time.Since(started))
+			return Segment{}, err
 		}
-		return r.completeReadySegment(index), nil
+		seg := r.completeReadySegment(index)
+		gstDebugf("drainEndOfStream completed remainder task=%s file=%s audio=%d segment=%d size=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, seg.Len(), time.Since(started))
+		return seg, nil
 	}
 
 	if err := r.reader.EndOfStreamError(); err != nil {
+		gstErrorf("drainEndOfStream MP4 reader failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, err, time.Since(started))
 		return Segment{}, err
 	}
 
+	gstErrorf("drainEndOfStream exhausted task=%s file=%s audio=%d segment=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, index, ErrEndOfStreamExhausted, time.Since(started))
 	return Segment{}, ErrEndOfStreamExhausted
 }
 
 func (r *gstRunner) completeReadySegment(index int) Segment {
+	requestedIndex := index
 	if index > 0 {
 		r.readySegment.index = index
 	} else {
 		r.readySegment.index = 0
 	}
+	assignedIndex := r.readySegment.index
+	seg := r.readySegment.segment
+	absoluteStart := seg.StartSeconds + r.positionSeekSeconds
+	absoluteEnd := seg.EndSeconds + r.positionSeekSeconds
+	gstDebugf("completeReadySegment task=%s file=%s audio=%d requestedIndex=%d assignedIndex=%d size=%d start=%.3f end=%.3f positionSeek=%.3f absoluteStart=%.3f absoluteEnd=%.3f runnerPosition=%.3f", r.task.ID, r.task.FileID, r.audioIndex, requestedIndex, assignedIndex, seg.Len(), seg.StartSeconds, seg.EndSeconds, r.positionSeekSeconds, absoluteStart, absoluteEnd, r.position())
 	return r.readySegment.segment
 }
 
@@ -826,6 +944,7 @@ func (r *gstRunner) acceptSegment(seg Segment) {
 	} else if seg.StartSeconds >= 0 {
 		r.setPosition(seg.StartSeconds + r.positionSeekSeconds)
 	}
+	gstDebugf("acceptSegment task=%s file=%s audio=%d StartSeconds=%.3f EndSeconds=%.3f duration=%.3f size=%d payloads=%d positionSeek=%.3f absoluteStart=%.3f absoluteEnd=%.3f position=%.3f readyIndex=%d", r.task.ID, r.task.FileID, r.audioIndex, seg.StartSeconds, seg.EndSeconds, seg.EndSeconds-seg.StartSeconds, seg.Len(), len(seg.Payloads), r.positionSeekSeconds, seg.StartSeconds+r.positionSeekSeconds, seg.EndSeconds+r.positionSeekSeconds, r.position(), r.readySegment.index)
 }
 
 func (r *gstRunner) discardReadySegment() {
@@ -841,15 +960,28 @@ func (r *gstRunner) discardReadySegment() {
 }
 
 func (r *gstRunner) freezeAtSegment(index int) {
-	seconds := r.position()
+	position := r.position()
+	virtualSeconds := position
 	if index > 0 {
-		seconds = float64(index * r.task.Config.SegmentSeconds)
+		conf := r.task.Config.normalized()
+		virtualSeconds = float64(index * conf.SegmentSeconds)
 	}
 
+	seconds := position
+	action := "freeze-current-position"
+	if index > 0 {
+		seconds = virtualSeconds
+		action = "freeze-segment-position"
+	} else if seconds <= 0 {
+		seconds = virtualSeconds
+	}
+
+	gstDebugf("freezeAtSegment task=%s file=%s audio=%d segment=%d position=%.3f virtual=%.3f freezeAt=%.3f action=%s", r.task.ID, r.task.FileID, r.audioIndex, index, position, virtualSeconds, seconds, action)
 	r.freezeAtPosition(seconds)
 }
 
 func (r *gstRunner) freezeAtPosition(seconds float64) {
+	gstDebugf("freezeAtPosition task=%s file=%s audio=%d position=%.3f", r.task.ID, r.task.FileID, r.audioIndex, seconds)
 	r.stopPipeline()
 	r.discardReadySegment()
 	r.reader.SeekReset(seconds)
@@ -860,82 +992,148 @@ func (r *gstRunner) freezeAtPosition(seconds float64) {
 }
 
 func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
+	started := time.Now()
+	gstDebugf("startPipeline start task=%s file=%s audio=%d requested=%.3f", r.task.ID, r.task.FileID, r.audioIndex, seconds)
+	stageStarted := time.Now()
 	pipeline, err := gstRuntime.parseLaunch(r.createPipelineArgs())
 	if err != nil {
+		gstErrorf("startPipeline parseLaunch failed task=%s file=%s audio=%d requested=%.3f err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, err, time.Since(stageStarted))
 		return 0, err
 	}
+	gstDebugf("startPipeline parseLaunch completed task=%s file=%s audio=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, time.Since(stageStarted))
 
+	stageStarted = time.Now()
 	sink := gstRuntime.binGetByName(pipeline, "out")
 	if sink == 0 {
 		gstRuntime.elementSetState(pipeline, gstStateNull)
 		gstRuntime.objectUnref(pipeline)
-		return 0, errors.New("appsink element is not available")
+		err := errors.New("appsink element is not available")
+		gstErrorf("startPipeline appsink lookup failed task=%s file=%s audio=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, err, time.Since(stageStarted))
+		return 0, err
 	}
+	gstDebugf("startPipeline appsink lookup completed task=%s file=%s audio=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, time.Since(stageStarted))
 
+	conf := r.task.Config.normalized()
+	fragmentDuration := time.Duration(conf.SegmentSeconds) * time.Second
+	pipelineGen := nextPipelineGen.Add(1)
+	filterHEVCLeadingPictures := seconds > 0 && r.task.Probe.IsH265() && !r.transcodesVideo(conf, r.task.Probe)
+	probes := newGSTPipelineProbes(r, pipeline, pipelineGen, filterHEVCLeadingPictures, fragmentDuration)
+
+	stageStarted = time.Now()
 	bus := gstRuntime.pipelineGetBus(pipeline)
+	gstDebugf("startPipeline bus acquired task=%s file=%s audio=%d bus=%t duration=%s", r.task.ID, r.task.FileID, r.audioIndex, bus != 0, time.Since(stageStarted))
 	actualStartSeconds := seconds
+	var demux uintptr
 
 	cleanup := func() {
+		probes.release()
 		gstRuntime.elementSetState(pipeline, gstStateNull)
+		if demux != 0 {
+			gstRuntime.objectUnref(demux)
+		}
 		gstRuntime.objectUnref(sink)
 		gstRuntime.objectUnref(pipeline)
 		gstRuntime.objectUnref(bus)
 	}
 
 	if seconds > 0 {
-		if err := r.setPipelineState(pipeline, bus, gstStatePaused); err != nil {
+		stageStarted = time.Now()
+		demux = gstRuntime.binGetByName(pipeline, "d")
+		if demux == 0 {
 			cleanup()
+			err := errors.New("matroskademux element is not available")
+			gstErrorf("startPipeline demux lookup failed task=%s file=%s audio=%d err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, err, time.Since(stageStarted))
 			return 0, err
 		}
+		gstDebugf("startPipeline demux lookup completed task=%s file=%s audio=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, time.Since(stageStarted))
 
-		if !gstRuntime.elementSeekSimple(pipeline, gstFormatTime, gstSeekFlagFlush|gstSeekFlagKeyUnit|gstSeekFlagSnapAfter, int64(math.Round(seconds*1_000_000_000))) {
+		stageStarted = time.Now()
+		if err := r.setPipelineState(pipeline, bus, gstStatePaused); err != nil {
 			cleanup()
-			return 0, errors.New("gstreamer seek failed")
+			gstErrorf("startPipeline PAUSED failed task=%s file=%s audio=%d requested=%.3f err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, err, time.Since(stageStarted))
+			return 0, err
 		}
+		gstDebugf("startPipeline PAUSED completed task=%s file=%s audio=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, time.Since(stageStarted))
 
+		probes.resetForSeek()
+
+		stageStarted = time.Now()
+		gstDebugf("startPipeline seek send task=%s file=%s audio=%d target=demux snap=before requested=%.3f flags=%d", r.task.ID, r.task.FileID, r.audioIndex, seconds, gstSeekFlagFlush|gstSeekFlagKeyUnit|gstSeekFlagSnapBefore)
+		if !gstRuntime.elementSeekSimple(demux, gstFormatTime, gstSeekFlagFlush|gstSeekFlagKeyUnit|gstSeekFlagSnapBefore, int64(math.Round(seconds*1_000_000_000))) {
+			cleanup()
+			err := errors.New("gstreamer seek failed")
+			gstErrorf("startPipeline seek send failed task=%s file=%s audio=%d requested=%.3f err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, err, time.Since(stageStarted))
+			return 0, err
+		}
+		gstDebugf("startPipeline seek sent task=%s file=%s audio=%d requested=%.3f duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, time.Since(stageStarted))
+
+		stageStarted = time.Now()
 		waitResult := gstRuntime.elementGetState(pipeline, 5*time.Second)
+		gstDebugf("startPipeline seek wait result task=%s file=%s audio=%d requested=%.3f GstStateChangeReturn=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, waitResult, time.Since(stageStarted))
 		switch waitResult {
 		case gstStateChangeSuccess, gstStateChangeNoPreroll:
 		case gstStateChangeAsync:
 			if err := gstRuntime.popBusError(bus, 0); err != nil {
 				cleanup()
+				gstErrorf("startPipeline seek wait bus error task=%s file=%s audio=%d requested=%.3f err=%v", r.task.ID, r.task.FileID, r.audioIndex, seconds, err)
 				return 0, err
 			}
 			cleanup()
-			return 0, fmt.Errorf("gstreamer seek to %.3fs timed out", seconds)
+			err := fmt.Errorf("gstreamer seek to %.3fs timed out", seconds)
+			gstErrorf("startPipeline seek wait timeout task=%s file=%s audio=%d requested=%.3f err=%v", r.task.ID, r.task.FileID, r.audioIndex, seconds, err)
+			return 0, err
 		case gstStateChangeFailure:
 			if err := gstRuntime.popBusError(bus, 0); err != nil {
 				cleanup()
+				gstErrorf("startPipeline seek wait bus error task=%s file=%s audio=%d requested=%.3f err=%v", r.task.ID, r.task.FileID, r.audioIndex, seconds, err)
 				return 0, err
 			}
 			cleanup()
-			return 0, fmt.Errorf("gstreamer seek to %.3fs failed", seconds)
+			err := fmt.Errorf("gstreamer seek to %.3fs failed", seconds)
+			gstErrorf("startPipeline seek wait failed task=%s file=%s audio=%d requested=%.3f err=%v", r.task.ID, r.task.FileID, r.audioIndex, seconds, err)
+			return 0, err
 		default:
 			cleanup()
-			return 0, fmt.Errorf("unexpected GstStateChangeReturn=%d after seek", waitResult)
+			err := fmt.Errorf("unexpected GstStateChangeReturn=%d after seek", waitResult)
+			gstErrorf("startPipeline seek wait unexpected task=%s file=%s audio=%d requested=%.3f err=%v", r.task.ID, r.task.FileID, r.audioIndex, seconds, err)
+			return 0, err
 		}
 
+		stageStarted = time.Now()
 		positionNS, ok := gstRuntime.elementQueryPosition(pipeline)
-		if !ok {
-			cleanup()
-			return 0, errors.New("gstreamer position query failed after seek")
+		if ok {
+			actualStartSeconds = float64(positionNS) / 1_000_000_000.0
+			gstDebugf("startPipeline position query completed task=%s file=%s audio=%d requested=%.3f actual=%.3f delta=%.3f duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualStartSeconds, actualStartSeconds-seconds, time.Since(stageStarted))
+		} else {
+			gstDebugf("startPipeline position query unavailable task=%s file=%s audio=%d requested=%.3f fallback=%.3f duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualStartSeconds, time.Since(stageStarted))
 		}
-		actualStartSeconds = float64(positionNS) / 1_000_000_000.0
 	}
 
+	stageStarted = time.Now()
 	if err := r.setPipelineState(pipeline, bus, gstStatePlaying); err != nil {
 		cleanup()
+		gstErrorf("startPipeline PLAYING failed task=%s file=%s audio=%d requested=%.3f err=%v duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, err, time.Since(stageStarted))
 		return 0, err
+	}
+	gstDebugf("startPipeline PLAYING completed task=%s file=%s audio=%d duration=%s", r.task.ID, r.task.FileID, r.audioIndex, time.Since(stageStarted))
+
+	if demux != 0 {
+		gstRuntime.objectUnref(demux)
+		demux = 0
 	}
 
 	r.pipeline = pipeline
 	r.bus = bus
 	r.sink = sink
+	r.probes = probes
+	gstDebugf("startPipeline completed task=%s file=%s audio=%d requested=%.3f actual=%.3f delta=%.3f duration=%s", r.task.ID, r.task.FileID, r.audioIndex, seconds, actualStartSeconds, actualStartSeconds-seconds, time.Since(started))
 	return actualStartSeconds, nil
 }
 
 func (r *gstRunner) setPipelineState(pipeline uintptr, bus uintptr, state int32) error {
+	started := time.Now()
 	setResult := gstRuntime.elementSetState(pipeline, state)
+	gstDebugf("setPipelineState state=%d setResult=%d", state, setResult)
 	if setResult == gstStateChangeFailure {
 		if err := gstRuntime.popBusError(bus, 0); err != nil {
 			return err
@@ -943,7 +1141,10 @@ func (r *gstRunner) setPipelineState(pipeline uintptr, bus uintptr, state int32)
 		return fmt.Errorf("gstreamer failed to request state change to %d", state)
 	}
 
+	waitStarted := time.Now()
 	waitResult := gstRuntime.elementGetState(pipeline, 5*time.Second)
+	waitDuration := time.Since(waitStarted)
+	gstDebugf("setPipelineState state=%d waitResult=%d GstStateChangeReturn=%d waitDuration=%s duration=%s", state, waitResult, waitResult, waitDuration, time.Since(started))
 	switch waitResult {
 	case gstStateChangeSuccess, gstStateChangeNoPreroll:
 		return nil
@@ -966,6 +1167,13 @@ func (r *gstRunner) setPipelineState(pipeline uintptr, bus uintptr, state int32)
 }
 
 func (r *gstRunner) stopPipeline() {
+	if r.pipeline != 0 || r.sink != 0 || r.bus != 0 {
+		gstDebugf("stopPipeline task=%s file=%s audio=%d pipeline=%t sink=%t bus=%t", r.task.ID, r.task.FileID, r.audioIndex, r.pipeline != 0, r.sink != 0, r.bus != 0)
+	}
+	if r.probes != nil {
+		r.probes.release()
+		r.probes = nil
+	}
 	if r.pipeline != 0 {
 		_ = gstRuntime.elementSetState(r.pipeline, gstStateNull)
 	}
@@ -984,6 +1192,7 @@ func (r *gstRunner) stopPipeline() {
 }
 
 func (r *gstRunner) Dispose() {
+	gstDebugf("Dispose task=%s file=%s audio=%d position=%.3f", r.task.ID, r.task.FileID, r.audioIndex, r.position())
 	r.stopPipeline()
 	r.discardReadySegment()
 	if r.reader != nil {
@@ -993,11 +1202,25 @@ func (r *gstRunner) Dispose() {
 }
 
 func (r *gstRunner) Frozen() {
+	gstDebugf("Frozen task=%s file=%s audio=%d position=%.3f", r.task.ID, r.task.FileID, r.audioIndex, r.position())
 	r.freezeAtPosition(r.position())
+}
+
+func (r *gstRunner) logWaitSummary(operation string, started time.Time, last *time.Time, samples int, bytes int) {
+	now := time.Now()
+	if !last.IsZero() && now.Sub(*last) < time.Second {
+		return
+	}
+	*last = now
+	gstDebugf("%s waiting: task=%s file=%s audio=%d elapsed=%s samples=%d bytes=%d position=%.3f", operation, r.task.ID, r.task.FileID, r.audioIndex, now.Sub(started), samples, bytes, r.position())
 }
 
 func (r *gstRunner) IsFrozen() bool {
 	return r.frozen.Load()
+}
+
+func (r *gstRunner) Position() float64 {
+	return r.position()
 }
 
 func (r *gstRunner) setPosition(seconds float64) {

--- a/server/gstreamer/pipeline_stub.go
+++ b/server/gstreamer/pipeline_stub.go
@@ -2,7 +2,10 @@
 
 package gstreamer
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type disabledRunner struct{}
 
@@ -18,7 +21,12 @@ func (disabledRunner) GetSegment(context.Context, int, int) (Segment, error) {
 	return Segment{}, ErrPipelineDisabled
 }
 
-func (disabledRunner) Seek(float64) bool { return false }
-func (disabledRunner) Frozen()           {}
-func (disabledRunner) Dispose()          {}
-func (disabledRunner) IsFrozen() bool    { return false }
+func (r disabledRunner) GetSegmentWithTimeout(ctx context.Context, index int, audio int, timeout time.Duration) (Segment, error) {
+	return r.GetSegment(ctx, index, audio)
+}
+
+func (disabledRunner) Seek(float64) error { return ErrPipelineDisabled }
+func (disabledRunner) Frozen()            {}
+func (disabledRunner) Dispose()           {}
+func (disabledRunner) IsFrozen() bool     { return false }
+func (disabledRunner) Position() float64  { return 0 }

--- a/server/gstreamer/pipeline_stub.go
+++ b/server/gstreamer/pipeline_stub.go
@@ -25,6 +25,7 @@ func (r disabledRunner) GetSegmentWithTimeout(ctx context.Context, index int, au
 	return r.GetSegment(ctx, index, audio)
 }
 
+func (disabledRunner) DiscardSegment()       {}
 func (disabledRunner) Seek(float64) error { return ErrPipelineDisabled }
 func (disabledRunner) Frozen()            {}
 func (disabledRunner) Dispose()           {}

--- a/server/gstreamer/probe.go
+++ b/server/gstreamer/probe.go
@@ -19,7 +19,7 @@ const gstProbeTimeout = 30 * time.Second
 var (
 	discovererDurationRe  = regexp.MustCompile(`(?i)Duration:\s*(\d+):(\d+):(\d+)(?:\.(\d+))?`)
 	discovererContainerRe = regexp.MustCompile(`(?i)^container(?:\s+#\d+)?:\s*(.+)$`)
-	discovererStreamRe    = regexp.MustCompile(`(?i)^(video|audio)(?:\s+#(\d+))?:\s*(.+)$`)
+	discovererStreamRe    = regexp.MustCompile(`(?i)^(video|audio|subtitle|subtitles)(?:\s+#(\d+))?:\s*(.+)$`)
 	discovererIntRe       = regexp.MustCompile(`-?\d+`)
 	discovererRateRe      = regexp.MustCompile(`(\d+)\s*/\s*(\d+)`)
 )
@@ -108,6 +108,25 @@ func (p ProbeInfo) AudioTrack(index int) *TrackInfo {
 	return nil
 }
 
+func (p ProbeInfo) SubtitleTrack(index int) *TrackInfo {
+	for i := range p.Tracks {
+		if p.Tracks[i].Type == "subtitle" && p.Tracks[i].Index == index {
+			return &p.Tracks[i]
+		}
+	}
+	return nil
+}
+
+func (p ProbeInfo) SubtitleTracks() []TrackInfo {
+	tracks := make([]TrackInfo, 0)
+	for _, track := range p.Tracks {
+		if track.Type == "subtitle" {
+			tracks = append(tracks, track)
+		}
+	}
+	return tracks
+}
+
 func (p ProbeInfo) HasAudio() bool {
 	return p.Audio() != nil
 }
@@ -122,6 +141,31 @@ func (t TrackInfo) IsAACAudio() bool {
 		strings.Contains(codec, "mpeg-4") ||
 		strings.Contains(codec, "mpegversion=(int)4") ||
 		strings.Contains(codec, "mpegversion=4")
+}
+
+func (t TrackInfo) IsSupportedSubtitle() bool {
+	if t.Type != "subtitle" {
+		return false
+	}
+	codec := strings.ToLower(strings.Join([]string{t.Codec, t.CapsName}, " "))
+	switch {
+	case strings.Contains(codec, "subrip"):
+		return true
+	case strings.Contains(codec, "srt"):
+		return true
+	case strings.Contains(codec, "utf8") || strings.Contains(codec, "utf-8"):
+		return true
+	case strings.Contains(codec, "webvtt") || strings.Contains(codec, "vtt"):
+		return true
+	case strings.Contains(codec, "text/x-raw") || strings.Contains(codec, "application/x-subtitle"):
+		return true
+	case strings.Contains(codec, "timed text") || strings.Contains(codec, "tx3g") || strings.Contains(codec, " text") || strings.HasPrefix(codec, "text"):
+		return true
+	case strings.Contains(codec, "ssa") || strings.Contains(codec, "ass"):
+		return true
+	default:
+		return false
+	}
 }
 
 func (p ProbeInfo) IsMatroskaContainer() bool {
@@ -489,17 +533,15 @@ func probeFromDiscoverer(text string) ProbeInfo {
 			continue
 		}
 
-		lower := strings.ToLower(line)
-		if strings.HasPrefix(lower, "subtitle") ||
-			strings.HasPrefix(lower, "subtitles") ||
-			strings.HasPrefix(lower, "properties:") {
-			current = nil
-			continue
-		}
-
 		if stream := parseDiscovererStreamHeader(line); stream != nil {
 			probe.Tracks = append(probe.Tracks, *stream)
 			current = &probe.Tracks[len(probe.Tracks)-1]
+			continue
+		}
+
+		lower := strings.ToLower(line)
+		if strings.HasPrefix(lower, "properties:") {
+			current = nil
 			continue
 		}
 
@@ -511,6 +553,7 @@ func probeFromDiscoverer(text string) ProbeInfo {
 
 	videoIndex := 0
 	audioIndex := 0
+	subtitleIndex := 0
 	for i := range probe.Tracks {
 		switch probe.Tracks[i].Type {
 		case "video":
@@ -521,6 +564,10 @@ func probeFromDiscoverer(text string) ProbeInfo {
 			probe.Tracks[i].Index = audioIndex
 			probe.Tracks[i].PadName = "audio_" + strconv.Itoa(audioIndex)
 			audioIndex++
+		case "subtitle":
+			probe.Tracks[i].Index = subtitleIndex
+			probe.Tracks[i].PadName = "subtitle_" + strconv.Itoa(subtitleIndex)
+			subtitleIndex++
 		}
 	}
 
@@ -534,6 +581,9 @@ func parseDiscovererStreamHeader(line string) *TrackInfo {
 	}
 
 	trackType := strings.ToLower(match[1])
+	if trackType == "subtitles" {
+		trackType = "subtitle"
+	}
 	codec := strings.TrimSpace(match[3])
 	return &TrackInfo{
 		Type:     trackType,
@@ -568,6 +618,13 @@ func parseDiscovererTrackLine(track *TrackInfo, line string) {
 			track.CapsName = codecToCapsName(track.Type, track.Codec)
 		}
 	case startsWithFold(line, "video codec:"):
+		if track.Codec == "" {
+			track.Codec = valueAfterColon(line)
+		}
+		if track.CapsName == "" {
+			track.CapsName = codecToCapsName(track.Type, track.Codec)
+		}
+	case startsWithFold(line, "subtitle codec:"):
 		if track.Codec == "" {
 			track.Codec = valueAfterColon(line)
 		}
@@ -636,6 +693,27 @@ func codecToCapsName(kind string, values ...string) string {
 			return "audio/x-flac"
 		case strings.Contains(codec, "mpeg") || strings.Contains(codec, "mp3"):
 			return "audio/mpeg"
+		}
+	}
+
+	if kind == "subtitle" {
+		switch {
+		case strings.Contains(codec, "subrip") || strings.Contains(codec, "srt"):
+			return "application/x-subtitle"
+		case strings.Contains(codec, "utf8") || strings.Contains(codec, "utf-8"):
+			return "text/x-raw"
+		case strings.Contains(codec, "webvtt") || strings.Contains(codec, "vtt"):
+			return "text/vtt"
+		case strings.Contains(codec, "timed text") || strings.Contains(codec, "tx3g") || strings.Contains(codec, "text/x-raw"):
+			return "text/x-raw"
+		case strings.Contains(codec, "text"):
+			return "text/x-raw"
+		case strings.Contains(codec, "ass") || strings.Contains(codec, "ssa"):
+			return "application/x-ass"
+		case strings.Contains(codec, "pgs"):
+			return "subpicture/x-pgs"
+		case strings.Contains(codec, "dvd") || strings.Contains(codec, "vobsub"):
+			return "subpicture/x-dvd"
 		}
 	}
 

--- a/server/gstreamer/probe_gst.go
+++ b/server/gstreamer/probe_gst.go
@@ -1,0 +1,648 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"server/settings"
+
+	"github.com/ebitengine/purego"
+)
+
+const (
+	gstPadProbeDrop int32 = 0
+	gstPadProbeOK   int32 = 1
+
+	gstPadProbeTypeBuffer          int32 = 1 << 4
+	gstPadProbeTypeEventDownstream int32 = 1 << 6
+	gstPadProbeTypeEventUpstream   int32 = 1 << 7
+	gstPadProbeTypeEventFlush      int32 = 1 << 8
+
+	gstClockTimeNone uint64 = ^uint64(0)
+
+	gstMiniObjectFlagsOffset = uintptr(16)
+	gstMiniObjectSize        = uintptr(64)
+
+	gstBufferPoolOffset      = gstMiniObjectSize
+	gstBufferPtsOffset       = gstBufferPoolOffset + unsafe.Sizeof(uintptr(0))
+	gstBufferDtsOffset       = gstBufferPtsOffset + 8
+	gstBufferDurationOffset  = gstBufferDtsOffset + 8
+	gstBufferOffsetOffset    = gstBufferDurationOffset + 8
+	gstBufferOffsetEndOffset = gstBufferOffsetOffset + 8
+
+	gstEventTypeOffset = gstMiniObjectSize
+
+	gstBufferFlagDiscont   uint32 = 1 << 6
+	gstBufferFlagCorrupted uint32 = 1 << 8
+	gstBufferFlagHeader    uint32 = 1 << 10
+	gstBufferFlagGap       uint32 = 1 << 11
+	gstBufferFlagDroppable uint32 = 1 << 12
+	gstBufferFlagDeltaUnit uint32 = 1 << 13
+
+	gstProbeBranchVideoIn = "branch=video-in"
+	gstProbeBranchAudioIn = "branch=audio-in"
+	gstProbeBranchMuxOut  = "branch=mux-out"
+
+	gstProbePhasePreroll  uint32 = 0
+	gstProbePhasePostSeek uint32 = 1
+)
+
+var (
+	nextPipelineGen atomic.Uint64
+	nextProbeHandle atomic.Uint64
+
+	gstProbeRegistryMu sync.RWMutex
+	gstProbeRegistry   = make(map[uintptr]*gstPadProbeRef)
+
+	gstProbeCallbackOnce    sync.Once
+	gstProbeCallbackAddress uintptr
+
+	probeLogOnce  sync.Once
+	probeLogQueue = make(chan string, 1024)
+)
+
+type gstPipelineProbes struct {
+	pipelineGen           uint64
+	debug                 bool
+	refs                  []*gstPadProbeRef
+	released              atomic.Bool
+	dropped               atomic.Uint64
+	droppedLeadingBuffers atomic.Uint64
+}
+
+type gstPadProbeRef struct {
+	pipelineGen               uint64
+	branch                    string
+	debug                     bool
+	filterHEVCLeadingPictures bool
+	pad                       uintptr
+	id                        uintptr
+	handle                    uintptr
+	dropped                   *atomic.Uint64
+	droppedLeadingBuffers     *atomic.Uint64
+
+	bufferCount atomic.Uint64
+	phase       atomic.Uint32
+	released    atomic.Bool
+
+	segmentMu  sync.RWMutex
+	segment    gstSegmentSnapshot
+	hasSegment bool
+
+	filterMu                       sync.Mutex
+	fragmentDurationNS             int64
+	fragmentStartDecodeRunningTime int64
+	fragmentStartSet               bool
+	leadingBoundaryPTSRunningTime  int64
+	leadingWindow                  bool
+	fragmentBoundaryCount          uint64
+}
+
+type gstSegmentSnapshot struct {
+	format      int32
+	flags       uint32
+	rate        float64
+	appliedRate float64
+	start       uint64
+	stop        uint64
+	time        uint64
+	base        uint64
+	offset      uint64
+	duration    uint64
+}
+
+type gstBufferSnapshot struct {
+	size      uintptr
+	pts       uint64
+	dts       uint64
+	duration  uint64
+	offset    uint64
+	offsetEnd uint64
+	flags     uint32
+}
+
+func newGSTPipelineProbes(r *gstRunner, pipeline uintptr, pipelineGen uint64, filterHEVCLeadingPictures bool, fragmentDuration time.Duration) *gstPipelineProbes {
+	debug := settings.IsDebug()
+	if !debug && !filterHEVCLeadingPictures {
+		return nil
+	}
+	if debug {
+		startProbeLogger()
+	}
+
+	probes := &gstPipelineProbes{pipelineGen: pipelineGen, debug: debug}
+	if gstRuntime == nil || pipeline == 0 {
+		return probes
+	}
+
+	mux := gstRuntime.binGetByName(pipeline, "mux")
+	if mux == 0 {
+		gstDebugf("pad probe mux lookup failed task=%s file=%s audio=%d pipelineGen=%d err=mp4mux element is not available", r.task.ID, r.task.FileID, r.audioIndex, pipelineGen)
+		return probes
+	}
+	defer gstRuntime.objectUnref(mux)
+
+	if debug || filterHEVCLeadingPictures {
+		probes.add(r, mux, "video_0", gstProbeBranchVideoIn, filterHEVCLeadingPictures, fragmentDuration)
+	}
+	if debug {
+		probes.add(r, mux, "audio_0", gstProbeBranchAudioIn, false, 0)
+		probes.add(r, mux, "src", gstProbeBranchMuxOut, false, 0)
+	}
+	return probes
+}
+
+func (p *gstPipelineProbes) add(r *gstRunner, mux uintptr, padName string, branch string, filterHEVCLeadingPictures bool, fragmentDuration time.Duration) {
+	pad := gstRuntime.elementGetStaticPad(mux, padName)
+	if pad == 0 {
+		gstDebugf("pad probe unavailable task=%s file=%s audio=%d pipelineGen=%d %s pad=%s", r.task.ID, r.task.FileID, r.audioIndex, p.pipelineGen, branch, padName)
+		return
+	}
+
+	ref := &gstPadProbeRef{
+		pipelineGen:               p.pipelineGen,
+		branch:                    branch,
+		debug:                     p.debug,
+		filterHEVCLeadingPictures: filterHEVCLeadingPictures,
+		pad:                       pad,
+		handle:                    uintptr(nextProbeHandle.Add(1)),
+		dropped:                   &p.dropped,
+		droppedLeadingBuffers:     &p.droppedLeadingBuffers,
+		fragmentDurationNS:        fragmentDuration.Nanoseconds(),
+	}
+	ref.phase.Store(gstProbePhasePreroll)
+
+	gstProbeRegistryMu.Lock()
+	gstProbeRegistry[ref.handle] = ref
+	gstProbeRegistryMu.Unlock()
+
+	mask := gstPadProbeTypeBuffer |
+		gstPadProbeTypeEventDownstream |
+		gstPadProbeTypeEventFlush
+	ref.id = gstRuntime.padAddProbe(ref.pad, mask, gstPadProbeCallbackAddress(), ref.handle)
+	if ref.id == 0 {
+		ref.release()
+		gstDebugf("pad probe install failed task=%s file=%s audio=%d pipelineGen=%d %s pad=%s", r.task.ID, r.task.FileID, r.audioIndex, p.pipelineGen, branch, padName)
+		return
+	}
+
+	p.refs = append(p.refs, ref)
+	gstDebugf("pad probe installed task=%s file=%s audio=%d pipelineGen=%d %s pad=%s probeID=%d", r.task.ID, r.task.FileID, r.audioIndex, p.pipelineGen, branch, padName, ref.id)
+}
+
+func (p *gstPipelineProbes) release() {
+	if p == nil || !p.released.CompareAndSwap(false, true) {
+		return
+	}
+	for _, ref := range p.refs {
+		ref.release()
+	}
+	if p.debug {
+		fragmentBoundaries := uint64(0)
+		for _, ref := range p.refs {
+			fragmentBoundaries += ref.fragmentBoundaryCountValue()
+		}
+		if droppedLeading := p.droppedLeadingBuffers.Load(); droppedLeading > 0 {
+			gstDebugf("pad probe leading video buffers dropped pipelineGen=%d droppedLeadingBuffers=%d fragmentBoundaries=%d", p.pipelineGen, droppedLeading, fragmentBoundaries)
+		} else if fragmentBoundaries > 0 {
+			gstDebugf("pad probe HEVC fragment boundaries pipelineGen=%d fragmentBoundaries=%d droppedLeadingBuffers=0", p.pipelineGen, fragmentBoundaries)
+		}
+		if dropped := p.dropped.Load(); dropped > 0 {
+			gstDebugf("pad probe diagnostic lines dropped pipelineGen=%d dropped=%d", p.pipelineGen, dropped)
+		}
+	}
+	p.refs = nil
+}
+
+func (p *gstPipelineProbes) resetForSeek() {
+	if p == nil || p.released.Load() {
+		return
+	}
+	for _, ref := range p.refs {
+		ref.bufferCount.Store(0)
+		ref.phase.Store(gstProbePhasePostSeek)
+		ref.segmentMu.Lock()
+		ref.segment = gstSegmentSnapshot{}
+		ref.hasSegment = false
+		ref.segmentMu.Unlock()
+		ref.resetFilterState()
+	}
+}
+
+func (p *gstPadProbeRef) release() {
+	if p == nil || !p.released.CompareAndSwap(false, true) {
+		return
+	}
+
+	gstProbeRegistryMu.Lock()
+	delete(gstProbeRegistry, p.handle)
+	gstProbeRegistryMu.Unlock()
+
+	if gstRuntime != nil {
+		gstRuntime.padRemoveProbe(p.pad, p.id)
+		gstRuntime.objectUnref(p.pad)
+	}
+	p.id = 0
+	p.pad = 0
+}
+
+func gstPadProbeCallbackAddress() uintptr {
+	gstProbeCallbackOnce.Do(func() {
+		gstProbeCallbackAddress = purego.NewCallback(func(pad uintptr, info uintptr, userData uintptr) int32 {
+			return gstPadProbeCallback(pad, info, userData)
+		})
+	})
+	return gstProbeCallbackAddress
+}
+
+func gstPadProbeCallback(_ uintptr, info uintptr, userData uintptr) int32 {
+	gstProbeRegistryMu.RLock()
+	ref := gstProbeRegistry[userData]
+	gstProbeRegistryMu.RUnlock()
+	if ref == nil || ref.released.Load() || gstRuntime == nil {
+		return gstPadProbeOK
+	}
+
+	probeType := readGstPadProbeInfoType(info)
+	if probeType&gstPadProbeTypeBuffer != 0 {
+		if buffer := gstRuntime.padProbeInfoBuffer(info); buffer != 0 {
+			if ref.shouldDropLeadingBuffer(buffer) {
+				return gstPadProbeDrop
+			}
+			ref.logBuffer(buffer)
+		}
+	}
+	if probeType&gstPadProbeTypeEventDownstream != 0 {
+		if event := gstRuntime.padProbeInfoEvent(info); event != 0 {
+			ref.logEvent(event)
+		}
+	}
+	return gstPadProbeOK
+}
+
+func readGstPadProbeInfoType(info uintptr) int32 {
+	if info == 0 {
+		return 0
+	}
+	return int32(readUint32AtAddress(info))
+}
+
+func (p *gstPadProbeRef) logEvent(event uintptr) {
+	eventType := readGstEventType(event)
+	name := gstRuntime.eventTypeName(eventType)
+	if !isLoggedPadEvent(name) {
+		return
+	}
+
+	label := eventLogLabel(name)
+	if strings.EqualFold(name, "segment") {
+		if segment, ok := gstRuntime.eventSegment(event); ok {
+			p.segmentMu.Lock()
+			p.segment = segment
+			p.hasSegment = true
+			p.segmentMu.Unlock()
+			if !p.debug {
+				return
+			}
+			p.probeLog(fmt.Sprintf("pad probe event pipelineGen=%d %s phase=%s event=%s format=%d flags=%d rate=%.6f appliedRate=%.6f start=%d stop=%d time=%d base=%d offset=%d duration=%d",
+				p.pipelineGen, p.branch, p.phaseLabel(), label, segment.format, segment.flags, segment.rate, segment.appliedRate, segment.start, segment.stop, segment.time, segment.base, segment.offset, segment.duration))
+			return
+		}
+	}
+
+	if !p.debug {
+		return
+	}
+	if strings.EqualFold(name, "caps") {
+		p.probeLog(fmt.Sprintf("pad probe event pipelineGen=%d %s phase=%s event=%s caps=%q", p.pipelineGen, p.branch, p.phaseLabel(), label, gstRuntime.eventCapsString(event)))
+		return
+	}
+	p.probeLog(fmt.Sprintf("pad probe event pipelineGen=%d %s phase=%s event=%s", p.pipelineGen, p.branch, p.phaseLabel(), label))
+}
+
+func (p *gstPadProbeRef) logBuffer(buffer uintptr) {
+	if !p.debug {
+		return
+	}
+
+	index := p.bufferCount.Add(1)
+	if index > 30 {
+		return
+	}
+
+	info := readGstBuffer(buffer)
+	ptsRunningTime := p.runningTime(info.pts)
+	dtsRunningTime := p.runningTime(info.dts)
+
+	message := fmt.Sprintf("pad probe buffer pipelineGen=%d %s phase=%s index=%d size=%d PTS=%d DTS=%d duration=%d offset=%d offsetEnd=%d flags=%d DISCONT=%t DELTA_UNIT=%t HEADER=%t GAP=%t DROPPABLE=%t CORRUPTED=%t ptsValid=%t dtsValid=%t durationValid=%t ptsRunningTime=%s dtsRunningTime=%s",
+		p.pipelineGen, p.branch, p.phaseLabel(), index, info.size, info.pts, info.dts, info.duration, info.offset, info.offsetEnd, info.flags,
+		info.flags&gstBufferFlagDiscont != 0,
+		info.flags&gstBufferFlagDeltaUnit != 0,
+		info.flags&gstBufferFlagHeader != 0,
+		info.flags&gstBufferFlagGap != 0,
+		info.flags&gstBufferFlagDroppable != 0,
+		info.flags&gstBufferFlagCorrupted != 0,
+		gstClockTimeIsValid(info.pts),
+		gstClockTimeIsValid(info.dts),
+		gstClockTimeIsValid(info.duration),
+		ptsRunningTime,
+		dtsRunningTime,
+	)
+
+	if p.branch == gstProbeBranchMuxOut && index <= 12 {
+		hexPrefix, fourCC := gstBufferPrefix(buffer)
+		if hexPrefix != "" {
+			message += " first16=" + hexPrefix
+		}
+		if fourCC != "" {
+			message += " fourCC=" + fourCC
+		}
+	}
+	p.probeLog(message)
+}
+
+func (p *gstPadProbeRef) shouldDropLeadingBuffer(buffer uintptr) bool {
+	if !p.filterHEVCLeadingPictures || p.phase.Load() != gstProbePhasePostSeek {
+		return false
+	}
+
+	info := readGstBuffer(buffer)
+	if !gstClockTimeIsValid(info.pts) {
+		return false
+	}
+
+	ptsRunningTime, ok := p.runningTimeValue(info.pts)
+	if !ok {
+		return false
+	}
+
+	dtsRunningTime, dtsOK := p.runningTimeValue(info.dts)
+	decodeRunningTime := ptsRunningTime
+	if dtsOK {
+		decodeRunningTime = dtsRunningTime
+	}
+
+	if info.flags&gstBufferFlagDeltaUnit == 0 {
+		p.updateHEVCFragmentBoundary(info, ptsRunningTime, dtsRunningTime, dtsOK, decodeRunningTime)
+		return false
+	}
+
+	drop, boundaryIndex, boundaryPTSRunningTime := p.consumeHEVCLeadingDelta(ptsRunningTime)
+	if !drop {
+		return false
+	}
+
+	if p.droppedLeadingBuffers != nil {
+		p.droppedLeadingBuffers.Add(1)
+	}
+	if p.debug {
+		p.probeLog(fmt.Sprintf("pad probe drop leading video pipelineGen=%d phase=%s boundaryIndex=%d PTS=%d DTS=%d ptsRunningTime=%d boundaryPTSRunningTime=%d flags=%d",
+			p.pipelineGen, p.phaseLabel(), boundaryIndex, info.pts, info.dts, ptsRunningTime, boundaryPTSRunningTime, info.flags))
+	}
+	return true
+}
+
+func (p *gstPadProbeRef) updateHEVCFragmentBoundary(info gstBufferSnapshot, ptsRunningTime int64, dtsRunningTime int64, dtsOK bool, decodeRunningTime int64) {
+	reason := ""
+	boundaryIndex := uint64(0)
+
+	p.filterMu.Lock()
+	if !p.fragmentStartSet {
+		p.fragmentStartDecodeRunningTime = decodeRunningTime
+		p.leadingBoundaryPTSRunningTime = ptsRunningTime
+		p.leadingWindow = true
+		p.fragmentStartSet = true
+		p.fragmentBoundaryCount++
+		boundaryIndex = p.fragmentBoundaryCount
+		reason = "initial"
+	} else if p.fragmentDurationNS > 0 && decodeRunningTime-p.fragmentStartDecodeRunningTime >= p.fragmentDurationNS {
+		p.fragmentStartDecodeRunningTime = decodeRunningTime
+		p.fragmentBoundaryCount++
+		boundaryIndex = p.fragmentBoundaryCount
+		reason = "fragment-duration"
+	}
+	p.filterMu.Unlock()
+
+	if reason == "" || !p.debug {
+		return
+	}
+
+	dtsText := "NONE"
+	if dtsOK {
+		dtsText = strconv.FormatInt(dtsRunningTime, 10)
+	}
+	p.probeLog(fmt.Sprintf("pad probe HEVC fragment boundary pipelineGen=%d phase=%s boundaryIndex=%d reason=%s PTS=%d DTS=%d ptsRunningTime=%d dtsRunningTime=%s fragmentDuration=%s",
+		p.pipelineGen, p.phaseLabel(), boundaryIndex, reason, info.pts, info.dts, ptsRunningTime, dtsText, time.Duration(p.fragmentDurationNS)))
+}
+
+func (p *gstPadProbeRef) consumeHEVCLeadingDelta(ptsRunningTime int64) (bool, uint64, int64) {
+	p.filterMu.Lock()
+	defer p.filterMu.Unlock()
+
+	if !p.leadingWindow {
+		return false, p.fragmentBoundaryCount, p.leadingBoundaryPTSRunningTime
+	}
+	if ptsRunningTime < p.leadingBoundaryPTSRunningTime {
+		return true, p.fragmentBoundaryCount, p.leadingBoundaryPTSRunningTime
+	}
+	p.leadingWindow = false
+	return false, p.fragmentBoundaryCount, p.leadingBoundaryPTSRunningTime
+}
+
+func (p *gstPadProbeRef) resetFilterState() {
+	p.filterMu.Lock()
+	p.fragmentStartDecodeRunningTime = 0
+	p.fragmentStartSet = false
+	p.leadingBoundaryPTSRunningTime = 0
+	p.leadingWindow = false
+	p.fragmentBoundaryCount = 0
+	p.filterMu.Unlock()
+}
+
+func (p *gstPadProbeRef) fragmentBoundaryCountValue() uint64 {
+	p.filterMu.Lock()
+	defer p.filterMu.Unlock()
+	return p.fragmentBoundaryCount
+}
+
+func (p *gstPadProbeRef) runningTime(position uint64) string {
+	runningTime, ok := p.runningTimeValue(position)
+	if !ok {
+		return "NONE"
+	}
+	return strconv.FormatInt(runningTime, 10)
+}
+
+func (p *gstPadProbeRef) runningTimeValue(position uint64) (int64, bool) {
+	if !gstClockTimeIsValid(position) {
+		return 0, false
+	}
+
+	p.segmentMu.RLock()
+	segment := p.segment
+	ok := p.hasSegment
+	p.segmentMu.RUnlock()
+	if !ok || segment.format != gstFormatTime || segment.rate == 0 {
+		return 0, false
+	}
+	start := int64(segment.start)
+	offset := int64(segment.offset)
+	base := int64(segment.base)
+	adjustedStart := start + offset
+	delta := int64(position) - adjustedStart
+	rate := math.Abs(segment.rate)
+	if rate == 0 {
+		return 0, false
+	}
+	return base + int64(float64(delta)/rate), true
+}
+
+func (p *gstPadProbeRef) phaseLabel() string {
+	if p.phase.Load() == gstProbePhasePostSeek {
+		return "post-seek"
+	}
+	return "preroll"
+}
+
+func (p *gstPadProbeRef) probeLog(message string) {
+	select {
+	case probeLogQueue <- message:
+	default:
+		if p.dropped != nil {
+			p.dropped.Add(1)
+		}
+	}
+}
+
+func startProbeLogger() {
+	probeLogOnce.Do(func() {
+		go func() {
+			for line := range probeLogQueue {
+				gstDebugf("%s", line)
+			}
+		}()
+	})
+}
+
+func readGstBuffer(buffer uintptr) gstBufferSnapshot {
+	return gstBufferSnapshot{
+		size:      gstRuntime.gstBufferGetSize(buffer),
+		pts:       readUint64AtAddress(buffer + gstBufferPtsOffset),
+		dts:       readUint64AtAddress(buffer + gstBufferDtsOffset),
+		duration:  readUint64AtAddress(buffer + gstBufferDurationOffset),
+		offset:    readUint64AtAddress(buffer + gstBufferOffsetOffset),
+		offsetEnd: readUint64AtAddress(buffer + gstBufferOffsetEndOffset),
+		flags:     readUint32AtAddress(buffer + gstMiniObjectFlagsOffset),
+	}
+}
+
+func readGstEventType(event uintptr) int32 {
+	return int32(readUint32AtAddress(event + gstEventTypeOffset))
+}
+
+func readGstSegment(segment uintptr) gstSegmentSnapshot {
+	return gstSegmentSnapshot{
+		flags:       readUint32AtAddress(segment),
+		rate:        readFloat64AtAddress(segment + 8),
+		appliedRate: readFloat64AtAddress(segment + 16),
+		format:      int32(readUint32AtAddress(segment + 24)),
+		base:        readUint64AtAddress(segment + 32),
+		offset:      readUint64AtAddress(segment + 40),
+		start:       readUint64AtAddress(segment + 48),
+		stop:        readUint64AtAddress(segment + 56),
+		time:        readUint64AtAddress(segment + 64),
+		duration:    readUint64AtAddress(segment + 80),
+	}
+}
+
+func gstBufferPrefix(buffer uintptr) (string, string) {
+	if buffer == 0 || gstRuntime == nil {
+		return "", ""
+	}
+	size := gstRuntime.gstBufferGetSize(buffer)
+	if size == 0 {
+		return "", ""
+	}
+
+	var mapInfo [128]byte
+	if gstRuntime.gstBufferMap(buffer, unsafe.Pointer(&mapInfo[0]), gstMapRead) == 0 {
+		return "", ""
+	}
+	defer gstRuntime.gstBufferUnmap(buffer, unsafe.Pointer(&mapInfo[0]))
+
+	dataPtr, mapSize := gstMapInfoData(&mapInfo)
+	if dataPtr == 0 || mapSize <= 0 {
+		return "", ""
+	}
+
+	limit := mapSize
+	if limit > 16 {
+		limit = 16
+	}
+	data := unsafe.Slice((*byte)(unsafe.Pointer(dataPtr)), limit)
+	return hexBytes(data), mp4FourCC(data)
+}
+
+func hexBytes(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, b := range data {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(fmt.Sprintf("%02x", b))
+	}
+	return sb.String()
+}
+
+func mp4FourCC(data []byte) string {
+	if len(data) < 8 {
+		return ""
+	}
+	fourCC := data[4:8]
+	for _, b := range fourCC {
+		if b < 0x20 || b > 0x7e {
+			return ""
+		}
+	}
+	return string(fourCC)
+}
+
+func isLoggedPadEvent(name string) bool {
+	switch strings.ToLower(name) {
+	case "stream-start", "caps", "segment", "flush-start", "flush-stop", "gap", "eos":
+		return true
+	default:
+		return false
+	}
+}
+
+func eventLogLabel(name string) string {
+	return strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+}
+
+func gstClockTimeIsValid(value uint64) bool {
+	return value != gstClockTimeNone
+}
+
+func readUint32AtAddress(address uintptr) uint32 {
+	return *(*uint32)(unsafe.Pointer(address))
+}
+
+func readUint64AtAddress(address uintptr) uint64 {
+	return *(*uint64)(unsafe.Pointer(address))
+}
+
+func readFloat64AtAddress(address uintptr) float64 {
+	return *(*float64)(unsafe.Pointer(address))
+}

--- a/server/gstreamer/segment.go
+++ b/server/gstreamer/segment.go
@@ -9,6 +9,15 @@ type Segment struct {
 	EndSeconds   float64
 }
 
+func (s Segment) Clone() Segment {
+	return Segment{
+		Header:       cloneBytes(s.Header),
+		Payloads:     clonePayloads(s.Payloads),
+		StartSeconds: s.StartSeconds,
+		EndSeconds:   s.EndSeconds,
+	}
+}
+
 func (s Segment) Len() int {
 	total := len(s.Header)
 	for _, payload := range s.Payloads {
@@ -84,5 +93,16 @@ func cloneBytes(src []byte) []byte {
 	}
 	dst := make([]byte, len(src))
 	copy(dst, src)
+	return dst
+}
+
+func clonePayloads(src [][]byte) [][]byte {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([][]byte, len(src))
+	for i := range src {
+		dst[i] = cloneBytes(src[i])
+	}
 	return dst
 }

--- a/server/gstreamer/service.go
+++ b/server/gstreamer/service.go
@@ -240,12 +240,12 @@ func logProbeInfo(prefix string, hash string, fileID string, probe ProbeInfo) {
 	if video := probe.Video(); video != nil {
 		videoCodec = firstNonEmpty(video.Codec, video.CapsName)
 	}
-	gstDebugf("%s hash=%s file=%s container=%q videoCodec=%q duration=%d fileSize=%d audioTracks=%d", prefix, hash, fileID, probe.Container, videoCodec, probe.DurationSeconds(), probe.FileSize, countAudioTracks(probe))
+	gstDebugf("%s hash=%s file=%s container=%q videoCodec=%q duration=%d fileSize=%d audioTracks=%d subtitleTracks=%d", prefix, hash, fileID, probe.Container, videoCodec, probe.DurationSeconds(), probe.FileSize, countAudioTracks(probe), countSubtitleTracks(probe))
 	for _, track := range probe.Tracks {
-		if track.Type != "audio" {
+		if track.Type != "audio" && track.Type != "subtitle" {
 			continue
 		}
-		gstDebugf("%s audio hash=%s file=%s index=%d codec=%q channels=%d rate=%d", prefix, hash, fileID, track.Index, firstNonEmpty(track.Codec, track.CapsName), track.Channels, track.Rate)
+		gstDebugf("%s %s hash=%s file=%s index=%d codec=%q caps=%q title=%q language=%q supported=%t channels=%d rate=%d", prefix, track.Type, hash, fileID, track.Index, track.Codec, track.CapsName, track.Title, track.Language, track.Type != "subtitle" || track.IsSupportedSubtitle(), track.Channels, track.Rate)
 	}
 }
 
@@ -253,6 +253,16 @@ func countAudioTracks(probe ProbeInfo) int {
 	count := 0
 	for _, track := range probe.Tracks {
 		if track.Type == "audio" {
+			count++
+		}
+	}
+	return count
+}
+
+func countSubtitleTracks(probe ProbeInfo) int {
+	count := 0
+	for _, track := range probe.Tracks {
+		if track.Type == "subtitle" {
 			count++
 		}
 	}

--- a/server/gstreamer/service.go
+++ b/server/gstreamer/service.go
@@ -81,7 +81,10 @@ func NewService(conf Config) *Service {
 }
 
 func (s *Service) GetOrAdd(hash string, fileID string, audio int) (*Task, error) {
+	started := time.Now()
+	gstDebugf("GetOrAdd start hash=%s file=%s audio=%d", hash, fileID, audio)
 	if hash == "" || fileID == "" {
+		gstErrorf("GetOrAdd failed hash=%s file=%s audio=%d err=%v duration=%s", hash, fileID, audio, ErrBadSource, time.Since(started))
 		return nil, ErrBadSource
 	}
 
@@ -94,17 +97,20 @@ func (s *Service) GetOrAdd(hash string, fileID string, audio int) (*Task, error)
 	s.mu.RUnlock()
 
 	if task != nil && task.FileID == fileID && task.Audio == audio && !task.IsDisposed() {
+		gstDebugf("GetOrAdd existing task task=%s hash=%s file=%s audio=%d duration=%s", task.ID, hash, fileID, audio, time.Since(started))
 		task.UpdateLastActive()
 		return task, nil
 	}
 
 	probe, err := s.Probe(hash, fileID)
 	if err != nil {
+		gstErrorf("GetOrAdd probe failed hash=%s file=%s audio=%d err=%v duration=%s", hash, fileID, audio, err, time.Since(started))
 		return nil, err
 	}
 
 	task, err = NewTask(id, hash, fileID, audio, sourceURL, probe, conf)
 	if err != nil {
+		gstErrorf("GetOrAdd task create failed hash=%s file=%s audio=%d err=%v duration=%s", hash, fileID, audio, err, time.Since(started))
 		return nil, err
 	}
 
@@ -121,6 +127,7 @@ func (s *Service) GetOrAdd(hash string, fileID string, audio int) (*Task, error)
 
 		task.Dispose()
 		existing.UpdateLastActive()
+		gstDebugf("GetOrAdd existing task after create task=%s hash=%s file=%s audio=%d duration=%s", existing.ID, hash, fileID, audio, time.Since(started))
 		return existing, nil
 	}
 
@@ -130,10 +137,12 @@ func (s *Service) GetOrAdd(hash string, fileID string, audio int) (*Task, error)
 	s.mu.Unlock()
 
 	if replaced != nil {
+		gstDebugf("GetOrAdd task replaced task=%s hash=%s file=%s audio=%d replacedFile=%s replacedAudio=%d", task.ID, hash, fileID, audio, replaced.FileID, replaced.Audio)
 		replaced.Dispose()
 	}
 	disposeTasks(evicted)
 
+	gstDebugf("GetOrAdd new task task=%s hash=%s file=%s audio=%d evicted=%d duration=%s", task.ID, hash, fileID, audio, len(evicted), time.Since(started))
 	return task, nil
 }
 
@@ -189,29 +198,65 @@ func disposeTasks(tasks []*Task) {
 }
 
 func (s *Service) Probe(hash string, fileID string) (ProbeInfo, error) {
+	started := time.Now()
+	gstDebugf("Probe start hash=%s file=%s", hash, fileID)
 	if hash == "" || fileID == "" {
+		gstErrorf("Probe failed hash=%s file=%s err=%v duration=%s", hash, fileID, ErrBadSource, time.Since(started))
 		return ProbeInfo{}, ErrBadSource
 	}
 
 	conf := s.currentConfig()
 	probe, ok := s.getCachedProbe(hash, fileID)
 	if !ok {
+		gstDebugf("Probe cache miss hash=%s file=%s", hash, fileID)
 		var err error
 		probe, err = probeSource(sourceURL(conf, hash, fileID), conf)
 		if err != nil {
+			gstErrorf("Probe source failed hash=%s file=%s err=%v duration=%s", hash, fileID, err, time.Since(started))
 			return ProbeInfo{}, err
 		}
 		probe = refreshProbeFileSize(probe, hash, fileID)
 		if err := validateProbe(probe); err != nil {
+			logProbeInfo("Probe invalid", hash, fileID, probe)
+			gstErrorf("Probe validation failed hash=%s file=%s err=%v duration=%s", hash, fileID, err, time.Since(started))
 			return ProbeInfo{}, err
 		}
 		s.setCachedProbe(hash, fileID, probe)
+		logProbeInfo("Probe completed", hash, fileID, probe)
+		gstDebugf("Probe completed hash=%s file=%s duration=%s", hash, fileID, time.Since(started))
 		return probe, nil
 	}
 
+	gstDebugf("Probe cache hit hash=%s file=%s", hash, fileID)
 	probe = refreshProbeFileSize(probe, hash, fileID)
 	s.setCachedProbe(hash, fileID, probe)
+	logProbeInfo("Probe completed", hash, fileID, probe)
+	gstDebugf("Probe completed hash=%s file=%s duration=%s", hash, fileID, time.Since(started))
 	return probe, nil
+}
+
+func logProbeInfo(prefix string, hash string, fileID string, probe ProbeInfo) {
+	videoCodec := ""
+	if video := probe.Video(); video != nil {
+		videoCodec = firstNonEmpty(video.Codec, video.CapsName)
+	}
+	gstDebugf("%s hash=%s file=%s container=%q videoCodec=%q duration=%d fileSize=%d audioTracks=%d", prefix, hash, fileID, probe.Container, videoCodec, probe.DurationSeconds(), probe.FileSize, countAudioTracks(probe))
+	for _, track := range probe.Tracks {
+		if track.Type != "audio" {
+			continue
+		}
+		gstDebugf("%s audio hash=%s file=%s index=%d codec=%q channels=%d rate=%d", prefix, hash, fileID, track.Index, firstNonEmpty(track.Codec, track.CapsName), track.Channels, track.Rate)
+	}
+}
+
+func countAudioTracks(probe ProbeInfo) int {
+	count := 0
+	for _, track := range probe.Tracks {
+		if track.Type == "audio" {
+			count++
+		}
+	}
+	return count
 }
 
 func validateProbe(probe ProbeInfo) error {

--- a/server/gstreamer/subtitle_pipeline_gst.go
+++ b/server/gstreamer/subtitle_pipeline_gst.go
@@ -1,0 +1,122 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func (r *gstRunner) writeSubtitleBranches(sb *strings.Builder) {
+	for _, track := range subtitleTracksForPlaylist(r.task.Probe) {
+		padName := track.PadName
+		if padName == "" {
+			padName = "subtitle_" + strconv.Itoa(track.Index)
+		}
+
+		sb.WriteString("d.")
+		sb.WriteString(padName)
+		sb.WriteString(" ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0 ")
+		if subtitleNeedsSSAParse(track) {
+			sb.WriteString("! ssaparse ")
+		}
+		sb.WriteString("! webvttenc ! appsink name=subs_")
+		sb.WriteString(strconv.Itoa(track.Index))
+		sb.WriteString(" emit-signals=false sync=false async=false max-buffers=256 drop=false wait-on-eos=false ")
+	}
+}
+
+func (r *gstRunner) lookupSubtitleSinks(pipeline uintptr) (map[int]uintptr, error) {
+	tracks := subtitleTracksForPlaylist(r.task.Probe)
+	if len(tracks) == 0 {
+		return nil, nil
+	}
+
+	sinks := make(map[int]uintptr, len(tracks))
+	for _, track := range tracks {
+		name := "subs_" + strconv.Itoa(track.Index)
+		sink := gstRuntime.binGetByName(pipeline, name)
+		if sink == 0 {
+			for _, acquired := range sinks {
+				gstRuntime.objectUnref(acquired)
+			}
+			return nil, fmt.Errorf("subtitle appsink %s is not available", name)
+		}
+		sinks[track.Index] = sink
+	}
+	return sinks, nil
+}
+
+func (r *gstRunner) drainSubtitleSinks() {
+	if len(r.subtitleSinks) == 0 || gstRuntime == nil {
+		return
+	}
+
+	for subtitleIndex, sink := range r.subtitleSinks {
+		track := r.task.Probe.SubtitleTrack(subtitleIndex)
+		if track == nil {
+			continue
+		}
+
+		samples := 0
+		cuesAdded := 0
+		var collected []subtitleCue
+		for {
+			sample := gstRuntime.appSinkTryPullSample(sink, 0)
+			if sample == 0 {
+				break
+			}
+			samples++
+
+			var sampleCues []subtitleCue
+			var rawCueStart time.Duration
+			var absoluteCueStart time.Duration
+			var cueDuration time.Duration
+			var hasTimestamp bool
+			var sampleBytes int
+			err := gstRuntime.withSampleBuffer(sample, func(meta gstBufferSnapshot, data []byte) error {
+				sampleBytes = len(data)
+				rawCueStart, hasTimestamp = subtitleBufferTime(meta)
+				if !hasTimestamp {
+					rawCueStart = time.Duration(r.position() * float64(time.Second))
+				}
+				absoluteCueStart = r.absoluteSubtitleTime(rawCueStart)
+				cueDuration = subtitleBufferDuration(meta)
+				sampleCues = subtitleCuesFromSample(*track, data, absoluteCueStart, cueDuration)
+				return nil
+			})
+			gstRuntime.sampleUnref(sample)
+			if err != nil {
+				gstErrorf("subtitle appsink sample failed task=%s file=%s subtitle=%d err=%v", r.task.ID, r.task.FileID, subtitleIndex, err)
+				continue
+			}
+			if len(sampleCues) > 0 {
+				collected = append(collected, sampleCues...)
+				cuesAdded += len(sampleCues)
+				gstDebugf("subtitle cue sample task=%s file=%s subtitle=%d timestamp=%t rawStart=%.3f absoluteStart=%.3f duration=%.3f cueStart=%.3f cueEnd=%.3f runnerPosition=%.3f seekBase=%.3f bytes=%d", r.task.ID, r.task.FileID, subtitleIndex, hasTimestamp, rawCueStart.Seconds(), absoluteCueStart.Seconds(), cueDuration.Seconds(), sampleCues[0].Start.Seconds(), sampleCues[0].End.Seconds(), r.position(), r.positionSeekSeconds, sampleBytes)
+			}
+		}
+
+		if len(collected) > 0 {
+			r.task.addSubtitleCues(subtitleIndex, collected)
+		}
+		if samples > 0 {
+			gstDebugf("subtitle appsink drained task=%s file=%s subtitle=%d samples=%d cues=%d", r.task.ID, r.task.FileID, subtitleIndex, samples, cuesAdded)
+		}
+	}
+}
+
+func (r *gstRunner) absoluteSubtitleTime(value time.Duration) time.Duration {
+	seekBase := time.Duration(r.positionSeekSeconds * float64(time.Second))
+	if seekBase <= 0 {
+		return value
+	}
+
+	tolerance := time.Duration(r.task.Config.normalized().SegmentSeconds*2) * time.Second
+	if value < seekBase-tolerance {
+		return value + seekBase
+	}
+	return value
+}

--- a/server/gstreamer/subtitle_store.go
+++ b/server/gstreamer/subtitle_store.go
@@ -1,0 +1,182 @@
+package gstreamer
+
+import (
+	"strings"
+	"time"
+)
+
+func (t *Task) subtitleNotifyLocked() chan struct{} {
+	if t.subtitleNotify == nil {
+		t.subtitleNotify = make(chan struct{})
+	}
+	return t.subtitleNotify
+}
+
+func (t *Task) notifySubtitleWaitersLocked() {
+	notify := t.subtitleNotifyLocked()
+	close(notify)
+	t.subtitleNotify = make(chan struct{})
+}
+
+func (t *Task) addSubtitleCues(subtitleIndex int, cues []subtitleCue) {
+	if len(cues) == 0 {
+		return
+	}
+
+	t.subtitleMu.Lock()
+	if t.subtitleTracks == nil {
+		t.subtitleTracks = make(map[int]*subtitleTrackState)
+	}
+	state := t.subtitleTracks[subtitleIndex]
+	if state == nil {
+		state = &subtitleTrackState{seen: make(map[subtitleCueKey]struct{})}
+		t.subtitleTracks[subtitleIndex] = state
+	}
+
+	added := 0
+	for _, cue := range cues {
+		cue.Text = strings.TrimSpace(cue.Text)
+		if cue.Text == "" || cue.End <= cue.Start {
+			continue
+		}
+		key := subtitleCueKey{Start: cue.Start, End: cue.End, Text: cue.Text}
+		if _, exists := state.seen[key]; exists {
+			continue
+		}
+		state.seen[key] = struct{}{}
+		state.cues = append(state.cues, cue)
+		added++
+	}
+	total := len(state.cues)
+	if added > 0 {
+		t.notifySubtitleWaitersLocked()
+	}
+	t.subtitleMu.Unlock()
+
+	if added > 0 {
+		gstDebugf("subtitle store cues task=%s file=%s subtitle=%d added=%d total=%d", t.ID, t.FileID, subtitleIndex, added, total)
+	}
+}
+
+func (t *Task) subtitleCuesForSegmentLocked(subtitleIndex int, start time.Duration, end time.Duration) []subtitleCue {
+	if t.subtitleTracks == nil {
+		return nil
+	}
+	state := t.subtitleTracks[subtitleIndex]
+	if state == nil {
+		return nil
+	}
+
+	cues := make([]subtitleCue, 0)
+	for _, cue := range state.cues {
+		if cue.End > start && cue.Start < end {
+			cues = append(cues, cue)
+		}
+	}
+	return cues
+}
+
+func (t *Task) resetSubtitleTimeline(requestedSeconds float64) uint64 {
+	generationStart := 0
+	segmentSeconds := t.Config.normalized().SegmentSeconds
+	if requestedSeconds > 0 && segmentSeconds > 0 {
+		generationStart = int(requestedSeconds / float64(segmentSeconds))
+	}
+
+	t.subtitleMu.Lock()
+	previousGeneration := t.subtitleGeneration
+	retainedSegments := len(t.subtitleSegments)
+	t.subtitleGeneration++
+	generation := t.subtitleGeneration
+	if t.subtitleSegments == nil {
+		t.subtitleSegments = make(map[int]subtitleSegmentTimeline)
+	}
+	t.subtitleGenerationStart = generationStart
+	t.subtitleFirstReady = -1
+	t.subtitleHighestReady = -1
+	t.notifySubtitleWaitersLocked()
+	t.subtitleMu.Unlock()
+
+	gstDebugf("subtitle timeline reset task=%s file=%s previousGeneration=%d generation=%d requested=%.3f generationStart=%d retainedSegments=%d", t.ID, t.FileID, previousGeneration, generation, requestedSeconds, generationStart, retainedSegments)
+	return generation
+}
+
+func (t *Task) subtitleSegmentUnavailableLocked(segmentIndex int) (bool, string) {
+	if t.subtitleFirstReady >= 0 {
+		if segmentIndex < t.subtitleFirstReady {
+			return true, "before-first-ready"
+		}
+		if segmentIndex <= t.subtitleHighestReady {
+			return true, "missing-before-highest-ready"
+		}
+	}
+	if t.subtitleGenerationStart >= 0 && segmentIndex < t.subtitleGenerationStart {
+		return true, "before-generation-start"
+	}
+	return false, ""
+}
+
+func (t *Task) setSubtitleTimelineOrigin(generation uint64, requestedSeconds float64, actualSeconds float64) {
+	t.subtitleMu.Lock()
+	currentGeneration := t.subtitleGeneration
+	t.subtitleMu.Unlock()
+	if generation != currentGeneration {
+		gstDebugf("subtitle timeline origin ignored task=%s file=%s generation=%d currentGeneration=%d requested=%.3f actual=%.3f delta=%.3f", t.ID, t.FileID, generation, currentGeneration, requestedSeconds, actualSeconds, actualSeconds-requestedSeconds)
+		return
+	}
+	gstDebugf("subtitle timeline origin task=%s file=%s generation=%d requested=%.3f actual=%.3f delta=%.3f", t.ID, t.FileID, generation, requestedSeconds, actualSeconds, actualSeconds-requestedSeconds)
+}
+
+func (t *Task) markSubtitleSegmentReady(segmentIndex int, seg Segment, absoluteEndSeconds float64) {
+	if segmentIndex < 0 {
+		return
+	}
+	localDurationSeconds := seg.EndSeconds - seg.StartSeconds
+	if localDurationSeconds <= 0 {
+		gstErrorf("subtitle timeline segment rejected task=%s file=%s segment=%d localStart=%.3f localEnd=%.3f absoluteEnd=%.3f reason=invalid-duration", t.ID, t.FileID, segmentIndex, seg.StartSeconds, seg.EndSeconds, absoluteEndSeconds)
+		return
+	}
+	if absoluteEndSeconds <= 0 {
+		absoluteEndSeconds = seg.EndSeconds
+	}
+	sourceStartSeconds := absoluteEndSeconds - localDurationSeconds
+	sourceEndSeconds := absoluteEndSeconds
+	playlistStart, playlistEnd := subtitleSegmentBounds(segmentIndex, t.Config.normalized().SegmentSeconds)
+	timeline := subtitleSegmentTimeline{
+		SourceStart:   time.Duration(sourceStartSeconds * float64(time.Second)),
+		SourceEnd:     time.Duration(sourceEndSeconds * float64(time.Second)),
+		PlaylistStart: playlistStart,
+		PlaylistEnd:   playlistEnd,
+	}
+
+	t.subtitleMu.Lock()
+	if t.subtitleSegments == nil {
+		t.subtitleSegments = make(map[int]subtitleSegmentTimeline)
+	}
+	timeline.Generation = t.subtitleGeneration
+	t.subtitleSegments[segmentIndex] = timeline
+	if t.subtitleFirstReady < 0 {
+		t.subtitleFirstReady = segmentIndex
+	}
+	if t.subtitleHighestReady < segmentIndex {
+		t.subtitleHighestReady = segmentIndex
+	}
+	t.notifySubtitleWaitersLocked()
+	t.subtitleMu.Unlock()
+
+	sourceDuration := timeline.SourceEnd - timeline.SourceStart
+	playlistDuration := timeline.PlaylistEnd - timeline.PlaylistStart
+	gstDebugf("subtitle timeline segment ready task=%s file=%s segment=%d generation=%d sourceStart=%.3f sourceEnd=%.3f sourceDuration=%.3f playlistStart=%.3f playlistEnd=%.3f playlistDuration=%.3f startDelta=%.3f endDelta=%.3f mode=source", t.ID, t.FileID, segmentIndex, timeline.Generation, timeline.SourceStart.Seconds(), timeline.SourceEnd.Seconds(), sourceDuration.Seconds(), timeline.PlaylistStart.Seconds(), timeline.PlaylistEnd.Seconds(), playlistDuration.Seconds(), timeline.SourceStart.Seconds()-timeline.PlaylistStart.Seconds(), timeline.SourceEnd.Seconds()-timeline.PlaylistEnd.Seconds())
+}
+
+func (t *Task) closeSubtitleStore() {
+	t.subtitleMu.Lock()
+	t.subtitleTracks = nil
+	t.subtitleSegments = nil
+	t.subtitleGeneration++
+	t.subtitleGenerationStart = -1
+	t.subtitleFirstReady = -1
+	t.subtitleHighestReady = -1
+	t.notifySubtitleWaitersLocked()
+	t.subtitleMu.Unlock()
+}

--- a/server/gstreamer/subtitles.go
+++ b/server/gstreamer/subtitles.go
@@ -1,0 +1,378 @@
+package gstreamer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	ErrSubtitleNotFound        = errors.New("subtitle track not found")
+	ErrUnsupportedSubtitle     = errors.New("unsupported subtitle codec")
+	ErrSubtitleTimelineChanged = errors.New("subtitle timeline changed")
+	assOverrideTagRe          = regexp.MustCompile(`\{[^}]*\}`)
+	srtTimingLineRe           = regexp.MustCompile(`(?m)^\s*\d{1,2}:\d{2}:\d{2}[,.]\d{1,3}\s+-->\s+\d{1,2}:\d{2}:\d{2}[,.]\d{1,3}.*$`)
+	srtIndexLineRe            = regexp.MustCompile(`(?m)^\s*\d+\s*$`)
+)
+
+type subtitleCue struct {
+	Start time.Duration
+	End   time.Duration
+	Text  string
+}
+
+type subtitleCueKey struct {
+	Start time.Duration
+	End   time.Duration
+	Text  string
+}
+
+type subtitleTrackState struct {
+	cues []subtitleCue
+	seen map[subtitleCueKey]struct{}
+}
+
+type subtitleSegmentTimeline struct {
+	Generation    uint64
+	SourceStart   time.Duration
+	SourceEnd     time.Duration
+	PlaylistStart time.Duration
+	PlaylistEnd   time.Duration
+}
+
+func (t *Task) SubtitleSegment(ctx context.Context, subtitleIndex int, segmentIndex int) ([]byte, error) {
+	if segmentIndex < 0 {
+		return nil, errors.New("invalid subtitle segment index")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	track := t.Probe.SubtitleTrack(subtitleIndex)
+	if track == nil {
+		return nil, ErrSubtitleNotFound
+	}
+	if !track.IsSupportedSubtitle() {
+		return nil, ErrUnsupportedSubtitle
+	}
+
+	started := time.Now()
+	waits := 0
+	lastWaitLog := time.Time{}
+	var generation uint64
+	for {
+		t.subtitleMu.Lock()
+		currentGeneration := t.subtitleGeneration
+		if generation == 0 && currentGeneration > 0 {
+			generation = currentGeneration
+		}
+		timeline, ready := t.subtitleSegments[segmentIndex]
+		unavailable := false
+		unavailableReason := ""
+		if !ready {
+			unavailable, unavailableReason = t.subtitleSegmentUnavailableLocked(segmentIndex)
+		}
+		var cues []subtitleCue
+		if ready {
+			cues = t.subtitleCuesForSegmentLocked(subtitleIndex, timeline.SourceStart, timeline.SourceEnd)
+		}
+		generationStart := t.subtitleGenerationStart
+		firstReady := t.subtitleFirstReady
+		highestReady := t.subtitleHighestReady
+		notify := t.subtitleNotifyLocked()
+		disposed := t.disposed.Load()
+		t.subtitleMu.Unlock()
+
+		if disposed {
+			return nil, ErrTaskNotFound
+		}
+		if ready {
+			sourceCueStart, sourceCueEnd := subtitleCueRange(cues)
+			data := buildWebVTTSegment(cues, timeline.SourceStart, timeline.SourceEnd)
+			sourceDuration := timeline.SourceEnd - timeline.SourceStart
+			playlistDuration := timeline.PlaylistEnd - timeline.PlaylistStart
+			gstDebugf("subtitle timeline response task=%s file=%s subtitle=%d segment=%d generation=%d sourceStart=%.3f sourceEnd=%.3f sourceDuration=%.3f playlistStart=%.3f playlistEnd=%.3f playlistDuration=%.3f mode=source sourceCues=%d sourceCueStart=%.3f sourceCueEnd=%.3f bytes=%d waits=%d duration=%s", t.ID, t.FileID, subtitleIndex, segmentIndex, timeline.Generation, timeline.SourceStart.Seconds(), timeline.SourceEnd.Seconds(), sourceDuration.Seconds(), timeline.PlaylistStart.Seconds(), timeline.PlaylistEnd.Seconds(), playlistDuration.Seconds(), len(cues), sourceCueStart.Seconds(), sourceCueEnd.Seconds(), len(data), waits, time.Since(started))
+			return data, nil
+		}
+
+		if unavailable {
+			data := emptyWebVTTSegment()
+			gstDebugf("subtitle timeline skipped task=%s file=%s subtitle=%d segment=%d requestGeneration=%d currentGeneration=%d generationStart=%d firstReady=%d highestReady=%d reason=%s bytes=%d waits=%d duration=%s", t.ID, t.FileID, subtitleIndex, segmentIndex, generation, currentGeneration, generationStart, firstReady, highestReady, unavailableReason, len(data), waits, time.Since(started))
+			return data, nil
+		}
+		if generation > 0 && currentGeneration != generation {
+			gstDebugf("subtitle timeline request rebound task=%s file=%s subtitle=%d segment=%d previousGeneration=%d currentGeneration=%d waits=%d duration=%s", t.ID, t.FileID, subtitleIndex, segmentIndex, generation, currentGeneration, waits, time.Since(started))
+			generation = currentGeneration
+		}
+
+		waits++
+		now := time.Now()
+		if lastWaitLog.IsZero() || now.Sub(lastWaitLog) >= time.Second {
+			lastWaitLog = now
+			gstDebugf("subtitle timeline wait task=%s file=%s subtitle=%d segment=%d requestGeneration=%d currentGeneration=%d waits=%d elapsed=%s", t.ID, t.FileID, subtitleIndex, segmentIndex, generation, currentGeneration, waits, now.Sub(started))
+		}
+		select {
+		case <-ctx.Done():
+			gstDebugf("subtitle timeline request context done task=%s file=%s subtitle=%d segment=%d generation=%d waits=%d err=%v duration=%s", t.ID, t.FileID, subtitleIndex, segmentIndex, generation, waits, ctx.Err(), time.Since(started))
+			return nil, ctx.Err()
+		case <-notify:
+		}
+	}
+}
+
+func subtitleCueRange(cues []subtitleCue) (time.Duration, time.Duration) {
+	if len(cues) == 0 {
+		return 0, 0
+	}
+	start := cues[0].Start
+	end := cues[0].End
+	for _, cue := range cues[1:] {
+		if cue.Start < start {
+			start = cue.Start
+		}
+		if cue.End > end {
+			end = cue.End
+		}
+	}
+	return start, end
+}
+
+func subtitleSegmentBounds(segmentIndex int, segmentSeconds int) (time.Duration, time.Duration) {
+	if segmentSeconds <= 0 {
+		segmentSeconds = 6
+	}
+	start := time.Duration(segmentIndex*segmentSeconds) * time.Second
+	return start, start + time.Duration(segmentSeconds)*time.Second
+}
+
+func subtitleTracksForPlaylist(probe ProbeInfo) []TrackInfo {
+	var tracks []TrackInfo
+	for _, track := range probe.SubtitleTracks() {
+		if track.IsSupportedSubtitle() {
+			tracks = append(tracks, track)
+		}
+	}
+	return tracks
+}
+
+func subtitleTrackName(track TrackInfo) string {
+	name := strings.TrimSpace(track.Title)
+	if name == "" {
+		name = fmt.Sprintf("Subtitle %d", track.Index)
+	}
+
+	if language := subtitleTrackDisplayLanguage(track); language != "" {
+		name += " [" + language + "]"
+	}
+	return name
+}
+
+func subtitleTrackDisplayLanguage(track TrackInfo) string {
+	language := strings.TrimSpace(track.Language)
+	if language == "" || strings.EqualFold(language, "und") {
+		return ""
+	}
+	upper := strings.ToUpper(language)
+	if len([]rune(upper)) <= 8 {
+		return upper
+	}
+	return language
+}
+
+func subtitleTrackLanguage(track TrackInfo) string {
+	language := strings.TrimSpace(track.Language)
+	if language == "" {
+		return "und"
+	}
+	return language
+}
+
+func hlsQuote(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return value
+}
+
+func buildSubtitlePlaylist(segmentSeconds int, count int, subtitleIndex int) string {
+	if segmentSeconds <= 0 {
+		segmentSeconds = 6
+	}
+	if count < 0 {
+		count = 0
+	}
+
+	var playlist strings.Builder
+	playlist.WriteString("#EXTM3U\n")
+	playlist.WriteString("#EXT-X-PLAYLIST-TYPE:VOD\n")
+	playlist.WriteString("#EXT-X-VERSION:3\n")
+	playlist.WriteString("#EXT-X-TARGETDURATION:")
+	playlist.WriteString(strconv.Itoa(segmentSeconds))
+	playlist.WriteByte('\n')
+	playlist.WriteString("#EXT-X-MEDIA-SEQUENCE:0\n")
+
+	for i := 0; i < count; i++ {
+		playlist.WriteString("#EXTINF:")
+		playlist.WriteString(strconv.Itoa(segmentSeconds))
+		playlist.WriteString(".000,\n")
+		playlist.WriteString(strconv.Itoa(subtitleIndex))
+		playlist.WriteByte('/')
+		playlist.WriteString(strconv.Itoa(i))
+		playlist.WriteString(".vtt\n")
+	}
+
+	playlist.WriteString("#EXT-X-ENDLIST\n")
+	return playlist.String()
+}
+
+func emptyWebVTTSegment() []byte {
+	return []byte("WEBVTT\n\n")
+}
+
+func buildWebVTTSegment(cues []subtitleCue, segmentStart time.Duration, segmentEnd time.Duration) []byte {
+	sort.SliceStable(cues, func(i, j int) bool {
+		if cues[i].Start == cues[j].Start {
+			if cues[i].End == cues[j].End {
+				return cues[i].Text < cues[j].Text
+			}
+			return cues[i].End < cues[j].End
+		}
+		return cues[i].Start < cues[j].Start
+	})
+
+	var out strings.Builder
+	out.WriteString("WEBVTT\n\n")
+
+	seen := make(map[string]bool, len(cues))
+	for _, cue := range cues {
+		cue.Text = strings.TrimSpace(cue.Text)
+		if cue.Text == "" || cue.End <= segmentStart || cue.Start >= segmentEnd {
+			continue
+		}
+		key := fmt.Sprintf("%d:%d:%s", cue.Start, cue.End, cue.Text)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		out.WriteString(formatVTTTime(cue.Start))
+		out.WriteString(" --> ")
+		out.WriteString(formatVTTTime(cue.End))
+		out.WriteByte('\n')
+		out.WriteString(cue.Text)
+		out.WriteString("\n\n")
+	}
+
+	return []byte(out.String())
+}
+
+func subtitleCuesFromSample(track TrackInfo, data []byte, start time.Duration, duration time.Duration) []subtitleCue {
+	text := normalizeSubtitleSampleText(track, data)
+	if text == "" {
+		return nil
+	}
+
+	if duration <= 0 {
+		duration = 4 * time.Second
+	}
+	end := start + duration
+	if end <= start {
+		end = start + 4*time.Second
+	}
+
+	return []subtitleCue{{
+		Start: start,
+		End:   end,
+		Text:  text,
+	}}
+}
+
+func normalizeSubtitleSampleText(track TrackInfo, data []byte) string {
+	text := string(data)
+	text = strings.TrimPrefix(text, "\ufeff")
+	text = strings.ReplaceAll(text, "\x00", "")
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	text = strings.TrimSpace(text)
+
+	if strings.EqualFold(text, "WEBVTT") {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToUpper(text), "WEBVTT") {
+		lines := strings.Split(text, "\n")
+		for len(lines) > 0 && strings.TrimSpace(lines[0]) != "" {
+			lines = lines[1:]
+		}
+		text = strings.TrimSpace(strings.Join(lines, "\n"))
+	}
+
+	codec := strings.ToLower(track.Codec + " " + track.CapsName)
+	if strings.Contains(codec, "ass") || strings.Contains(codec, "ssa") {
+		text = cleanASSSubtitleText(text)
+	}
+
+	text = strings.ReplaceAll(text, `\N`, "\n")
+	text = strings.ReplaceAll(text, `\n`, "\n")
+	text = assOverrideTagRe.ReplaceAllString(text, "")
+	text = srtTimingLineRe.ReplaceAllString(text, "")
+	text = srtIndexLineRe.ReplaceAllString(text, "")
+	return strings.TrimSpace(compactSubtitleText(text))
+}
+
+func cleanASSSubtitleText(text string) string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToLower(trimmed), "dialogue:") {
+			trimmed = assDialogueText(trimmed)
+		}
+		if trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func assDialogueText(line string) string {
+	_, rest, ok := strings.Cut(line, ":")
+	if !ok {
+		return line
+	}
+	parts := strings.SplitN(strings.TrimSpace(rest), ",", 10)
+	if len(parts) < 10 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(parts[9])
+}
+
+func compactSubtitleText(text string) string {
+	var lines []string
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatVTTTime(value time.Duration) string {
+	if value < 0 {
+		value = 0
+	}
+	totalMilliseconds := value.Milliseconds()
+	hours := totalMilliseconds / 3_600_000
+	totalMilliseconds %= 3_600_000
+	minutes := totalMilliseconds / 60_000
+	totalMilliseconds %= 60_000
+	seconds := totalMilliseconds / 1_000
+	milliseconds := totalMilliseconds % 1_000
+
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds)
+}

--- a/server/gstreamer/subtitles_gst.go
+++ b/server/gstreamer/subtitles_gst.go
@@ -1,0 +1,202 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	subtitleExtractTimeout = 15 * time.Second
+	subtitleStateTimeout   = 5 * time.Second
+	subtitleSegmentOverlap = 500 * time.Millisecond
+)
+
+func extractSubtitleCues(ctx context.Context, task *Task, track TrackInfo, start time.Duration, end time.Duration) ([]subtitleCue, error) {
+	gstInitOnce.Do(func() {
+		initGStreamerRuntime(task.Config)
+	})
+	if gstInitErr != nil {
+		return nil, errors.Join(ErrPipelineDisabled, gstInitErr)
+	}
+	if gstRuntime == nil {
+		return nil, ErrPipelineDisabled
+	}
+
+	seekStart := start - subtitleSegmentOverlap
+	if seekStart < 0 {
+		seekStart = 0
+	}
+	readUntil := end + subtitleSegmentOverlap
+
+	pipeline, err := gstRuntime.parseLaunch(buildSubtitlePipeline(task, track))
+	if err != nil {
+		return nil, err
+	}
+
+	sink := gstRuntime.binGetByName(pipeline, "subout")
+	demux := gstRuntime.binGetByName(pipeline, "d")
+	bus := gstRuntime.pipelineGetBus(pipeline)
+
+	cleanup := func() {
+		gstRuntime.elementSetState(pipeline, gstStateNull)
+		if sink != 0 {
+			gstRuntime.objectUnref(sink)
+		}
+		if demux != 0 {
+			gstRuntime.objectUnref(demux)
+		}
+		if bus != 0 {
+			gstRuntime.objectUnref(bus)
+		}
+		gstRuntime.objectUnref(pipeline)
+	}
+	defer cleanup()
+
+	if sink == 0 {
+		return nil, errors.New("subtitle appsink element is not available")
+	}
+	if demux == 0 {
+		return nil, errors.New("subtitle matroskademux element is not available")
+	}
+
+	if err := setSubtitlePipelineState(pipeline, bus, gstStatePaused); err != nil {
+		return nil, err
+	}
+
+	seekNS := int64(math.Round(float64(seekStart.Nanoseconds())))
+	if !gstRuntime.elementSeekSimple(demux, gstFormatTime, gstSeekFlagFlush|gstSeekFlagSnapBefore, seekNS) {
+		return nil, errors.New("subtitle seek failed")
+	}
+
+	if err := setSubtitlePipelineState(pipeline, bus, gstStatePlaying); err != nil {
+		return nil, err
+	}
+
+	deadline := time.Now().Add(subtitleExtractTimeout)
+	var cues []subtitleCue
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := gstRuntime.popBusError(bus, 0); err != nil {
+			return nil, err
+		}
+
+		sample := gstRuntime.appSinkTryPullSample(sink, uint64(100*time.Millisecond))
+		if sample == 0 {
+			if gstRuntime.appSinkIsEOS(sink) {
+				return cues, nil
+			}
+			continue
+		}
+
+		var sampleCues []subtitleCue
+		err := gstRuntime.withSampleBuffer(sample, func(meta gstBufferSnapshot, data []byte) error {
+			cueStart, ok := subtitleBufferTime(meta)
+			if !ok {
+				cueStart = seekStart
+			}
+			duration := subtitleBufferDuration(meta)
+			sampleCues = subtitleCuesFromSample(track, data, cueStart, duration)
+			return nil
+		})
+		gstRuntime.sampleUnref(sample)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, cue := range sampleCues {
+			if cue.Start >= readUntil {
+				return cues, nil
+			}
+			if cue.End > start && cue.Start < end {
+				cues = append(cues, cue)
+			}
+		}
+	}
+
+	if err := gstRuntime.popBusError(bus, 0); err != nil {
+		return nil, err
+	}
+	return cues, nil
+}
+
+func buildSubtitlePipeline(task *Task, track TrackInfo) string {
+	conf := task.Config.normalized()
+	gstVersion := effectiveGStreamerVersion(conf)
+
+	var sb strings.Builder
+	sb.WriteString("souphttpsrc location=\"")
+	sb.WriteString(task.SourceURL)
+	sb.WriteString("\" is-live=false keep-alive=true timeout=60 retries=5 ")
+	if gstVersion.atLeast(1, 26) {
+		sb.WriteString("retry-backoff-factor=0.5 retry-backoff-max=10 ")
+	}
+	sb.WriteString("! matroskademux name=d ")
+	sb.WriteString("d.subtitle_")
+	sb.WriteString(strconv.Itoa(track.Index))
+	sb.WriteString(" ! queue max-size-buffers=0 max-size-bytes=0 max-size-time=0 ")
+	if subtitleNeedsSSAParse(track) {
+		sb.WriteString("! ssaparse ")
+	}
+	sb.WriteString("! webvttenc ")
+	sb.WriteString("! appsink name=subout emit-signals=false sync=false max-buffers=1000 drop=false wait-on-eos=false")
+	return sb.String()
+}
+
+func setSubtitlePipelineState(pipeline uintptr, bus uintptr, state int32) error {
+	setResult := gstRuntime.elementSetState(pipeline, state)
+	if setResult == gstStateChangeFailure {
+		if err := gstRuntime.popBusError(bus, 0); err != nil {
+			return err
+		}
+		return fmt.Errorf("gstreamer failed to request subtitle state %d", state)
+	}
+
+	waitResult := gstRuntime.elementGetState(pipeline, subtitleStateTimeout)
+	switch waitResult {
+	case gstStateChangeSuccess, gstStateChangeNoPreroll:
+		return nil
+	case gstStateChangeAsync:
+		if err := gstRuntime.popBusError(bus, 0); err != nil {
+			return err
+		}
+		return fmt.Errorf("gstreamer subtitle state %d timed out", state)
+	case gstStateChangeFailure:
+		if err := gstRuntime.popBusError(bus, 0); err != nil {
+			return err
+		}
+		return fmt.Errorf("gstreamer subtitle state %d failed", state)
+	default:
+		return fmt.Errorf("unexpected subtitle GstStateChangeReturn=%d for state=%d", waitResult, state)
+	}
+}
+
+func subtitleBufferTime(meta gstBufferSnapshot) (time.Duration, bool) {
+	if gstClockTimeIsValid(meta.pts) {
+		return time.Duration(meta.pts), true
+	}
+	if gstClockTimeIsValid(meta.dts) {
+		return time.Duration(meta.dts), true
+	}
+	return 0, false
+}
+
+func subtitleBufferDuration(meta gstBufferSnapshot) time.Duration {
+	if gstClockTimeIsValid(meta.duration) {
+		return time.Duration(meta.duration)
+	}
+	return 0
+}
+
+func subtitleNeedsSSAParse(track TrackInfo) bool {
+	codec := strings.ToLower(track.Codec + " " + track.CapsName)
+	return strings.Contains(codec, "ass") || strings.Contains(codec, "ssa")
+}

--- a/server/gstreamer/subtitles_stub.go
+++ b/server/gstreamer/subtitles_stub.go
@@ -1,0 +1,12 @@
+//go:build !gst || (!(windows && (amd64 || arm64)) && !(linux && (amd64 || arm64)) && !(darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"context"
+	"time"
+)
+
+func extractSubtitleCues(_ context.Context, _ *Task, _ TrackInfo, _ time.Duration, _ time.Duration) ([]subtitleCue, error) {
+	return nil, ErrPipelineDisabled
+}

--- a/server/gstreamer/task.go
+++ b/server/gstreamer/task.go
@@ -10,12 +10,15 @@ import (
 
 type pipelineRunner interface {
 	EnsureInit(ctx context.Context, audio int, startIndex int) error
-	GetSegment(ctx context.Context, index int, audio int) (Segment, error)
-	Seek(seconds float64) bool
+	GetSegmentWithTimeout(ctx context.Context, index int, audio int, timeout time.Duration) (Segment, error)
+	Position() float64
+	Seek(seconds float64) error
 	Frozen()
 	Dispose()
 	IsFrozen() bool
 }
+
+const forwardGapDrainSegmentLimit = 10
 
 type Task struct {
 	ID        string
@@ -26,10 +29,16 @@ type Task struct {
 	Probe     ProbeInfo
 	Config    Config
 
-	LastSentSegment int
+	LastSentSegment   int
+	LastSentSegmentAt time.Time
 
 	initMu  sync.RWMutex
 	initMP4 []byte
+
+	pendingSeek        bool
+	pendingSeekRequest float64
+	pendingSeekAudio   int
+	pendingSeekIndex   int
 
 	activeMu   sync.RWMutex
 	lastActive time.Time
@@ -100,22 +109,38 @@ func (t *Task) setInitMP4(data []byte) {
 }
 
 func (t *Task) EnsureInit(ctx context.Context, audio int, startIndex int) error {
+	started := time.Now()
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
 	if startIndex < 0 {
 		startIndex = 0
 	}
-	if t.hasInitMP4() && (startIndex == 0 || t.LastSentSegment != -1) {
+
+	hasInit := t.hasInitMP4()
+	gstDebugf("EnsureInit start task=%s file=%s audio=%d startIndex=%d hasInit=%t", t.ID, t.FileID, audio, startIndex, hasInit)
+	if hasInit && (startIndex == 0 || t.LastSentSegment != -1) {
+		if startIndex > 0 && t.LastSentSegment != -1 {
+			seconds := float64(startIndex * t.Config.normalized().SegmentSeconds)
+			t.beginPendingSeekLocked(startIndex, audio, seconds)
+			gstDebugf("EnsureInit pending explicit seek task=%s file=%s audio=%d startIndex=%d requested=%.3f LastSentSegment=%d", t.ID, t.FileID, audio, startIndex, seconds, t.LastSentSegment)
+		}
+		gstDebugf("EnsureInit early return task=%s file=%s audio=%d startIndex=%d duration=%s", t.ID, t.FileID, audio, startIndex, time.Since(started))
 		return nil
 	}
 	if t.runner == nil {
+		gstErrorf("EnsureInit failed task=%s file=%s audio=%d startIndex=%d err=%v duration=%s", t.ID, t.FileID, audio, startIndex, ErrTaskNotFound, time.Since(started))
 		return ErrTaskNotFound
 	}
 
 	err := t.runner.EnsureInit(ctx, audio, startIndex)
 	if err == nil && startIndex > 0 && t.LastSentSegment == -1 {
 		t.LastSentSegment = startIndex - 1
+	}
+	if err != nil {
+		gstErrorf("EnsureInit failed task=%s file=%s audio=%d startIndex=%d err=%v duration=%s", t.ID, t.FileID, audio, startIndex, err, time.Since(started))
+	} else {
+		gstDebugf("EnsureInit completed task=%s file=%s audio=%d startIndex=%d duration=%s", t.ID, t.FileID, audio, startIndex, time.Since(started))
 	}
 	return err
 }
@@ -126,64 +151,227 @@ func (t *Task) WithSegment(ctx context.Context, index int, audio int, consume fu
 	}
 
 	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	seg, err := t.segmentLocked(ctx, index, audio)
+	if err == nil {
+		seg = seg.Clone()
+	}
+	t.mu.Unlock()
+
 	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		gstDebugf("WithSegment context canceled after segment generation task=%s file=%s audio=%d segment=%d err=%v", t.ID, t.FileID, audio, index, err)
 		return err
 	}
 	return consume(seg)
 }
 
 func (t *Task) segmentLocked(ctx context.Context, index int, audio int) (Segment, error) {
+	started := time.Now()
+	conf := t.Config.normalized()
+	playlistStart := float64(index * conf.SegmentSeconds)
+	playlistEnd := playlistStart + float64(conf.SegmentSeconds)
+	runnerPosition := 0.0
+	if t.runner != nil {
+		runnerPosition = t.runner.Position()
+	}
+	lastSentAge := 0.0
+	if !t.LastSentSegmentAt.IsZero() {
+		lastSentAge = started.Sub(t.LastSentSegmentAt).Seconds()
+		if lastSentAge < 0 {
+			lastSentAge = 0
+		}
+	}
+	gstDebugf("segment request task=%s file=%s audio=%d segment=%d playlistStart=%.3f playlistEnd=%.3f LastSentSegment=%d lastSentAge=%.3f runnerPosition=%.3f pendingSeek=%t pendingIndex=%d pendingRequested=%.3f", t.ID, t.FileID, audio, index, playlistStart, playlistEnd, t.LastSentSegment, lastSentAge, runnerPosition, t.pendingSeek, t.pendingSeekIndex, t.pendingSeekRequest)
 	if t.runner == nil {
+		gstErrorf("segmentLocked failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", t.ID, t.FileID, audio, index, ErrTaskNotFound, time.Since(started))
 		return Segment{}, ErrTaskNotFound
+	}
+
+	if t.pendingSeek && t.pendingSeekAudio == audio {
+		if err := t.applyPendingSeekLocked(ctx, index, audio, started); err != nil {
+			return Segment{}, err
+		}
 	}
 
 	if t.LastSentSegment != -1 && t.LastSentSegment != index {
 		if index != t.LastSentSegment+1 {
-			conf := t.Config.normalized()
 			diff := index - t.LastSentSegment
-			cutoff := segmentCatchupCutoffSeconds(conf)
+			gstDebugf("segmentLocked non-sequential task=%s file=%s audio=%d segment=%d LastSentSegment=%d diff=%d", t.ID, t.FileID, audio, index, t.LastSentSegment, diff)
 
-			if diff > 0 && cutoff >= diff*conf.SegmentSeconds {
-				for i := 0; i < diff-1; i++ {
-					if ctx.Err() != nil {
-						return Segment{}, ctx.Err()
-					}
-
-					t.LastSentSegment++
-					if _, err := t.runner.GetSegment(ctx, t.LastSentSegment, audio); err != nil {
-						t.LastSentSegment--
+			if diff > 1 {
+				virtualTargetSeconds := float64(index * conf.SegmentSeconds)
+				currentPosition := t.runner.Position()
+				tolerance := float64(2 * conf.SegmentSeconds)
+				elapsedSinceLastSent := lastSentAge
+				targetAhead := virtualTargetSeconds - currentPosition
+				continueCurrentPipeline := false
+				continueReason := ""
+				if currentPosition > 0 && virtualTargetSeconds < currentPosition-tolerance {
+					continueCurrentPipeline = true
+					continueReason = "target-behind-current"
+				} else if currentPosition > 0 && targetAhead > 0 && elapsedSinceLastSent > 0 && elapsedSinceLastSent+tolerance >= targetAhead {
+					continueCurrentPipeline = true
+					continueReason = "playback-elapsed"
+				}
+				if continueCurrentPipeline {
+					gstDebugf("segmentLocked forward gap continue current pipeline task=%s file=%s audio=%d segment=%d LastSentSegment=%d diff=%d forwardGapLimit=%d virtualTarget=%.3f currentPosition=%.3f targetAhead=%.3f elapsedSinceLastSent=%.3f tolerance=%.3f reason=%s duration=%s", t.ID, t.FileID, audio, index, t.LastSentSegment, diff, forwardGapDrainSegmentLimit, virtualTargetSeconds, currentPosition, targetAhead, elapsedSinceLastSent, tolerance, continueReason, time.Since(started))
+				} else {
+					gstDebugf("segmentLocked forward gap request fallback to virtual seek task=%s file=%s audio=%d segment=%d LastSentSegment=%d diff=%d forwardGapLimit=%d virtualTarget=%.3f currentPosition=%.3f targetAhead=%.3f elapsedSinceLastSent=%.3f tolerance=%.3f duration=%s", t.ID, t.FileID, audio, index, t.LastSentSegment, diff, forwardGapDrainSegmentLimit, virtualTargetSeconds, currentPosition, targetAhead, elapsedSinceLastSent, tolerance, time.Since(started))
+					if err := t.seekVirtualSegmentLocked(index, audio, started); err != nil {
 						return Segment{}, err
 					}
 				}
-			} else {
-				if !t.runner.Seek(float64(index * conf.SegmentSeconds)) {
-					return Segment{}, ErrSegmentNotReady
+			} else if diff < 0 {
+				gstDebugf("segmentLocked backward request fallback to virtual seek task=%s file=%s audio=%d segment=%d LastSentSegment=%d diff=%d forwardGapLimit=%d runnerPosition=%.3f duration=%s", t.ID, t.FileID, audio, index, t.LastSentSegment, diff, forwardGapDrainSegmentLimit, t.runner.Position(), time.Since(started))
+				if err := t.seekVirtualSegmentLocked(index, audio, started); err != nil {
+					return Segment{}, err
 				}
+			} else {
+				gstErrorf("segmentLocked non-sequential without seek target task=%s file=%s audio=%d segment=%d LastSentSegment=%d diff=%d forwardGapLimit=%d duration=%s", t.ID, t.FileID, audio, index, t.LastSentSegment, diff, forwardGapDrainSegmentLimit, time.Since(started))
+				return Segment{}, ErrSegmentNotReady
 			}
+		} else {
+			gstDebugf("segmentLocked sequential task=%s file=%s audio=%d segment=%d LastSentSegment=%d", t.ID, t.FileID, audio, index, t.LastSentSegment)
 		}
 	}
 
-	seg, err := t.runner.GetSegment(ctx, index, audio)
+	gstDebugf("segment runner request task=%s file=%s audio=%d segment=%d playlistStart=%.3f playlistEnd=%.3f LastSentSegment=%d runnerPosition=%.3f pendingSeek=%t", t.ID, t.FileID, audio, index, playlistStart, playlistEnd, t.LastSentSegment, t.runner.Position(), t.pendingSeek)
+	seg, err := t.runner.GetSegmentWithTimeout(ctx, index, audio, 0)
 	if err != nil {
+		gstErrorf("segmentLocked failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", t.ID, t.FileID, audio, index, err, time.Since(started))
 		return Segment{}, err
 	}
 
-	t.LastSentSegment = index
+	runnerPosition = t.runner.Position()
+	t.logSegmentResultLocked("runner-result", index, audio, seg, runnerPosition, started)
+	if t.isStaleSegmentLocked(index, seg, runnerPosition) {
+		gstErrorf("segmentLocked stale segment task=%s file=%s audio=%d segment=%d playlistStart=%.3f runnerPosition=%.3f action=virtual-seek-retry duration=%s", t.ID, t.FileID, audio, index, playlistStart, runnerPosition, time.Since(started))
+		if err := t.seekVirtualSegmentLocked(index, audio, started); err != nil {
+			return Segment{}, err
+		}
+
+		seg, err = t.runner.GetSegmentWithTimeout(ctx, index, audio, 0)
+		if err != nil {
+			gstErrorf("segmentLocked stale retry failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", t.ID, t.FileID, audio, index, err, time.Since(started))
+			return Segment{}, err
+		}
+		runnerPosition = t.runner.Position()
+		t.logSegmentResultLocked("runner-result-retry", index, audio, seg, runnerPosition, started)
+		if t.isStaleSegmentLocked(index, seg, runnerPosition) {
+			gstErrorf("segmentLocked stale retry rejected task=%s file=%s audio=%d segment=%d playlistStart=%.3f runnerPosition=%.3f duration=%s", t.ID, t.FileID, audio, index, playlistStart, runnerPosition, time.Since(started))
+			return Segment{}, ErrSegmentNotReady
+		}
+	}
+	t.markSegmentSentLocked(index)
+	gstDebugf("segmentLocked completed task=%s file=%s audio=%d segment=%d size=%d duration=%s", t.ID, t.FileID, audio, index, seg.Len(), time.Since(started))
 	return seg, nil
 }
 
-func segmentCatchupCutoffSeconds(conf Config) int {
-	conf = conf.normalized()
-	if !conf.TempFS {
-		return 60
+func (t *Task) isStaleSegmentLocked(index int, seg Segment, absoluteEnd float64) bool {
+	if index <= 0 {
+		return false
 	}
-	if conf.TempFSRing > 0 {
-		return 90 + conf.TempFSRing*25
+
+	conf := t.Config.normalized()
+	playlistStart := float64(index * conf.SegmentSeconds)
+	if absoluteEnd <= 0 {
+		absoluteEnd = seg.EndSeconds
 	}
-	return 90
+	return absoluteEnd < playlistStart-float64(conf.SegmentSeconds*2)
+}
+
+func (t *Task) logSegmentResultLocked(source string, index int, audio int, seg Segment, absoluteEndSeconds float64, started time.Time) {
+	conf := t.Config.normalized()
+	playlistStart := float64(index * conf.SegmentSeconds)
+	playlistEnd := playlistStart + float64(conf.SegmentSeconds)
+	localDuration := seg.EndSeconds - seg.StartSeconds
+	if localDuration < 0 {
+		localDuration = 0
+	}
+	absoluteStart := absoluteEndSeconds - localDuration
+	if absoluteEndSeconds <= 0 {
+		absoluteStart = seg.StartSeconds
+		absoluteEndSeconds = seg.EndSeconds
+	}
+	absoluteDuration := absoluteEndSeconds - absoluteStart
+	startDelta := absoluteStart - playlistStart
+	endDelta := absoluteEndSeconds - playlistEnd
+	gstDebugf("segment result source=%s task=%s file=%s audio=%d segment=%d playlistStart=%.3f playlistEnd=%.3f localStart=%.3f localEnd=%.3f localDuration=%.3f absoluteStart=%.3f absoluteEnd=%.3f absoluteDuration=%.3f startDelta=%.3f endDelta=%.3f runnerPosition=%.3f LastSentSegment=%d pendingSeek=%t size=%d elapsed=%s", source, t.ID, t.FileID, audio, index, playlistStart, playlistEnd, seg.StartSeconds, seg.EndSeconds, localDuration, absoluteStart, absoluteEndSeconds, absoluteDuration, startDelta, endDelta, absoluteEndSeconds, t.LastSentSegment, t.pendingSeek, seg.Len(), time.Since(started))
+}
+
+func (t *Task) markSegmentSentLocked(index int) {
+	t.LastSentSegment = index
+	t.LastSentSegmentAt = time.Now().UTC()
+}
+
+func (t *Task) applyPendingSeekLocked(ctx context.Context, index int, audio int, started time.Time) error {
+	seekIndex := t.pendingSeekIndex
+	seekGap := index - seekIndex
+	if seekGap < 0 || seekGap > forwardGapDrainSegmentLimit {
+		gstErrorf("segmentLocked explicit seek segment mismatch task=%s file=%s audio=%d segment=%d pendingSegment=%d gap=%d forwardGapLimit=%d duration=%s", t.ID, t.FileID, audio, index, seekIndex, seekGap, forwardGapDrainSegmentLimit, time.Since(started))
+		return ErrSegmentNotReady
+	}
+
+	seconds := t.pendingSeekRequest
+	gstDebugf("segmentLocked explicit seek selected task=%s file=%s audio=%d segment=%d pendingSegment=%d requested=%.3f", t.ID, t.FileID, audio, index, seekIndex, seconds)
+	if err := t.runner.Seek(seconds); err != nil {
+		gstErrorf("segmentLocked explicit seek failed task=%s file=%s audio=%d segment=%d pendingSegment=%d requested=%.3f err=%v duration=%s", t.ID, t.FileID, audio, index, seekIndex, seconds, err, time.Since(started))
+		return err
+	}
+
+	t.pendingSeek = false
+	t.LastSentSegment = seekIndex - 1
+	gstDebugf("segmentLocked explicit seek position fixed task=%s file=%s audio=%d segment=%d pendingSegment=%d LastSentSegment=%d", t.ID, t.FileID, audio, index, seekIndex, t.LastSentSegment)
+
+	if index != t.LastSentSegment+1 {
+		if err := t.drainForwardGapLocked(ctx, index, audio, started); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Task) drainForwardGapLocked(ctx context.Context, targetIndex int, audio int, started time.Time) error {
+	for nextIndex := t.LastSentSegment + 1; nextIndex < targetIndex; nextIndex++ {
+		gstDebugf("segmentLocked forward gap drain start task=%s file=%s audio=%d segment=%d target=%d LastSentSegment=%d", t.ID, t.FileID, audio, nextIndex, targetIndex, t.LastSentSegment)
+
+		seg, err := t.runner.GetSegmentWithTimeout(ctx, nextIndex, audio, 0)
+		if err != nil {
+			gstErrorf("segmentLocked forward gap drain failed task=%s file=%s audio=%d segment=%d target=%d err=%v duration=%s", t.ID, t.FileID, audio, nextIndex, targetIndex, err, time.Since(started))
+			return err
+		}
+
+		t.logSegmentResultLocked("forward-gap-drain", nextIndex, audio, seg, t.runner.Position(), started)
+		t.markSegmentSentLocked(nextIndex)
+		gstDebugf("segmentLocked forward gap drain completed task=%s file=%s audio=%d segment=%d target=%d size=%d LastSentSegment=%d duration=%s", t.ID, t.FileID, audio, nextIndex, targetIndex, seg.Len(), t.LastSentSegment, time.Since(started))
+	}
+	return nil
+}
+
+func (t *Task) seekVirtualSegmentLocked(index int, audio int, started time.Time) error {
+	conf := t.Config.normalized()
+	seconds := float64(index * conf.SegmentSeconds)
+	currentPosition := t.runner.Position()
+	virtualDelta := currentPosition - seconds
+	gstDebugf("segmentLocked virtual seek selected task=%s file=%s audio=%d segment=%d requested=%.3f currentPosition=%.3f delta=%.3f LastSentSegment=%d pendingSeek=%t", t.ID, t.FileID, audio, index, seconds, currentPosition, virtualDelta, t.LastSentSegment, t.pendingSeek)
+	if err := t.runner.Seek(seconds); err != nil {
+		gstErrorf("segmentLocked virtual seek failed task=%s file=%s audio=%d segment=%d requested=%.3f err=%v duration=%s", t.ID, t.FileID, audio, index, seconds, err, time.Since(started))
+		return err
+	}
+
+	t.pendingSeek = false
+	t.LastSentSegment = index - 1
+	gstDebugf("segmentLocked virtual seek position fixed task=%s file=%s audio=%d segment=%d LastSentSegment=%d requested=%.3f", t.ID, t.FileID, audio, index, t.LastSentSegment, seconds)
+	return nil
+}
+
+func (t *Task) beginPendingSeekLocked(index int, audio int, requestedSeek float64) {
+	t.pendingSeek = true
+	t.pendingSeekRequest = requestedSeek
+	t.pendingSeekAudio = audio
+	t.pendingSeekIndex = index
 }
 
 func (t *Task) Frozen() {

--- a/server/gstreamer/task.go
+++ b/server/gstreamer/task.go
@@ -11,6 +11,7 @@ import (
 type pipelineRunner interface {
 	EnsureInit(ctx context.Context, audio int, startIndex int) error
 	GetSegmentWithTimeout(ctx context.Context, index int, audio int, timeout time.Duration) (Segment, error)
+	DiscardSegment()
 	Position() float64
 	Seek(seconds float64) error
 	Frozen()
@@ -18,7 +19,10 @@ type pipelineRunner interface {
 	IsFrozen() bool
 }
 
-const forwardGapDrainSegmentLimit = 10
+const (
+	forwardGapDrainSegmentLimit = 10
+	seekPrerollDrainSegmentLimit = 10
+)
 
 type Task struct {
 	ID        string
@@ -34,6 +38,15 @@ type Task struct {
 
 	initMu  sync.RWMutex
 	initMP4 []byte
+
+	subtitleMu         sync.Mutex
+	subtitleTracks     map[int]*subtitleTrackState
+	subtitleSegments   map[int]subtitleSegmentTimeline
+	subtitleNotify     chan struct{}
+	subtitleGeneration uint64
+	subtitleGenerationStart int
+	subtitleFirstReady      int
+	subtitleHighestReady    int
 
 	pendingSeek        bool
 	pendingSeekRequest float64
@@ -60,6 +73,10 @@ func NewTask(id string, hash string, fileID string, audio int, sourceURL string,
 		Config:          conf.normalized(),
 		LastSentSegment: -1,
 		lastActive:      time.Now().UTC(),
+		subtitleNotify:  make(chan struct{}),
+		subtitleGenerationStart: -1,
+		subtitleFirstReady:      -1,
+		subtitleHighestReady:    -1,
 	}
 
 	runner, err := newPipelineRunner(task, audio)
@@ -238,48 +255,44 @@ func (t *Task) segmentLocked(ctx context.Context, index int, audio int) (Segment
 	}
 
 	gstDebugf("segment runner request task=%s file=%s audio=%d segment=%d playlistStart=%.3f playlistEnd=%.3f LastSentSegment=%d runnerPosition=%.3f pendingSeek=%t", t.ID, t.FileID, audio, index, playlistStart, playlistEnd, t.LastSentSegment, t.runner.Position(), t.pendingSeek)
-	seg, err := t.runner.GetSegmentWithTimeout(ctx, index, audio, 0)
-	if err != nil {
-		gstErrorf("segmentLocked failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", t.ID, t.FileID, audio, index, err, time.Since(started))
-		return Segment{}, err
-	}
-
-	runnerPosition = t.runner.Position()
-	t.logSegmentResultLocked("runner-result", index, audio, seg, runnerPosition, started)
-	if t.isStaleSegmentLocked(index, seg, runnerPosition) {
-		gstErrorf("segmentLocked stale segment task=%s file=%s audio=%d segment=%d playlistStart=%.3f runnerPosition=%.3f action=virtual-seek-retry duration=%s", t.ID, t.FileID, audio, index, playlistStart, runnerPosition, time.Since(started))
-		if err := t.seekVirtualSegmentLocked(index, audio, started); err != nil {
-			return Segment{}, err
-		}
-
+	var seg Segment
+	for discarded := 0; ; discarded++ {
+		var err error
 		seg, err = t.runner.GetSegmentWithTimeout(ctx, index, audio, 0)
 		if err != nil {
-			gstErrorf("segmentLocked stale retry failed task=%s file=%s audio=%d segment=%d err=%v duration=%s", t.ID, t.FileID, audio, index, err, time.Since(started))
+			gstErrorf("segmentLocked failed task=%s file=%s audio=%d segment=%d prerollDiscarded=%d err=%v duration=%s", t.ID, t.FileID, audio, index, discarded, err, time.Since(started))
 			return Segment{}, err
 		}
+
 		runnerPosition = t.runner.Position()
-		t.logSegmentResultLocked("runner-result-retry", index, audio, seg, runnerPosition, started)
-		if t.isStaleSegmentLocked(index, seg, runnerPosition) {
-			gstErrorf("segmentLocked stale retry rejected task=%s file=%s audio=%d segment=%d playlistStart=%.3f runnerPosition=%.3f duration=%s", t.ID, t.FileID, audio, index, playlistStart, runnerPosition, time.Since(started))
+		source := "runner-result"
+		if discarded > 0 {
+			source = "preroll-drain"
+		}
+		t.logSegmentResultLocked(source, index, audio, seg, runnerPosition, started)
+
+		absoluteEnd := runnerPosition
+		if absoluteEnd <= 0 {
+			absoluteEnd = seg.EndSeconds
+		}
+		if index <= 0 || absoluteEnd > playlistStart {
+			break
+		}
+
+		localDuration := seg.EndSeconds - seg.StartSeconds
+		absoluteStart := absoluteEnd - localDuration
+		if discarded >= seekPrerollDrainSegmentLimit {
+			gstErrorf("segmentLocked preroll drain limit reached task=%s file=%s audio=%d segment=%d playlistStart=%.3f absoluteStart=%.3f absoluteEnd=%.3f discarded=%d limit=%d duration=%s", t.ID, t.FileID, audio, index, playlistStart, absoluteStart, absoluteEnd, discarded, seekPrerollDrainSegmentLimit, time.Since(started))
 			return Segment{}, ErrSegmentNotReady
 		}
+
+		gstDebugf("segmentLocked preroll discard task=%s file=%s audio=%d segment=%d playlistStart=%.3f absoluteStart=%.3f absoluteEnd=%.3f discard=%d limit=%d duration=%s", t.ID, t.FileID, audio, index, playlistStart, absoluteStart, absoluteEnd, discarded+1, seekPrerollDrainSegmentLimit, time.Since(started))
+		t.runner.DiscardSegment()
 	}
+	t.markSubtitleSegmentReady(index, seg, runnerPosition)
 	t.markSegmentSentLocked(index)
 	gstDebugf("segmentLocked completed task=%s file=%s audio=%d segment=%d size=%d duration=%s", t.ID, t.FileID, audio, index, seg.Len(), time.Since(started))
 	return seg, nil
-}
-
-func (t *Task) isStaleSegmentLocked(index int, seg Segment, absoluteEnd float64) bool {
-	if index <= 0 {
-		return false
-	}
-
-	conf := t.Config.normalized()
-	playlistStart := float64(index * conf.SegmentSeconds)
-	if absoluteEnd <= 0 {
-		absoluteEnd = seg.EndSeconds
-	}
-	return absoluteEnd < playlistStart-float64(conf.SegmentSeconds*2)
 }
 
 func (t *Task) logSegmentResultLocked(source string, index int, audio int, seg Segment, absoluteEndSeconds float64, started time.Time) {
@@ -344,6 +357,7 @@ func (t *Task) drainForwardGapLocked(ctx context.Context, targetIndex int, audio
 		}
 
 		t.logSegmentResultLocked("forward-gap-drain", nextIndex, audio, seg, t.runner.Position(), started)
+		t.markSubtitleSegmentReady(nextIndex, seg, t.runner.Position())
 		t.markSegmentSentLocked(nextIndex)
 		gstDebugf("segmentLocked forward gap drain completed task=%s file=%s audio=%d segment=%d target=%d size=%d LastSentSegment=%d duration=%s", t.ID, t.FileID, audio, nextIndex, targetIndex, seg.Len(), t.LastSentSegment, time.Since(started))
 	}
@@ -395,6 +409,7 @@ func (t *Task) Dispose() {
 		t.runner = nil
 	}
 	t.setInitMP4(nil)
+	t.closeSubtitleStore()
 }
 
 func (t *Task) IsDisposed() bool {

--- a/server/web/api/gstreamer_settings.go
+++ b/server/web/api/gstreamer_settings.go
@@ -21,6 +21,14 @@ type gstreamerSettingsRequest struct {
 	Config *gstreamer.Config `json:"config,omitempty"`
 }
 
+// GetGStreamerSettings godoc
+// @Summary Get GStreamer configuration
+// @Description Retrieves current GStreamer settings and platform defaults
+// @Tags API
+// @Produce json
+// @Success 200 {object} gstreamerSettingsResponse "GStreamer settings"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Router /gst/settings [get]
 func GetGStreamerSettings(c *gin.Context) {
 	c.JSON(http.StatusOK, gstreamerSettingsResponse{
 		BuiltIn:  true,
@@ -29,6 +37,19 @@ func GetGStreamerSettings(c *gin.Context) {
 	})
 }
 
+// UpdateGStreamerSettings godoc
+// @Summary Update GStreamer configuration
+// @Description Updates GStreamer settings in settings.json and applies them to the running server
+// @Tags API
+// @Accept json
+// @Produce json
+// @Param request body gstreamerSettingsRequest true "GStreamer settings request"
+// @Success 200 {object} map[string]string "Update successful"
+// @Failure 400 {object} map[string]string "Invalid input data"
+// @Failure 401 {object} map[string]string "Unauthorized"
+// @Failure 403 {object} map[string]string "Read-only mode"
+// @Failure 500 {object} map[string]string "Internal server error"
+// @Router /gst/settings [post]
 func UpdateGStreamerSettings(c *gin.Context) {
 	var req gstreamerSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {


### PR DESCRIPTION
GStreamer: added subtitles.
GStreamer: fix fMP4 HLS seeking, segmenting
- Added fixed VOD fMP4 HLS playlist generation with stable EXTINF, ENDLIST and seg/N.m4s URLs.
- Reworked GStreamer seek handling:
  - seek is sent to matroskademux instead of the whole pipeline;
  - uses snap-before keyframe seeking;
  - position query after seek is best-effort and no longer fatal.
- Fixed fMP4 segment drift:
  - split video fragments at MP4 sample boundaries;
  - keep exact target segment duration;
  - allow non-keyframe fMP4 continuation after the first sync segment.
- Added HEVC post-seek leading-picture filtering to avoid broken frames after seek without forcing video transcode.
- Improved segment/task flow:
  - stopped generating segments after request cancellation;
  - avoided holding task lock while writing HTTP response.
- Added GStreamer diagnostics seek/error logs.