### PR TITLE
GStreamer video probe

### DIFF
--- a/server/gstreamer/config_test.go
+++ b/server/gstreamer/config_test.go
@@ -1,0 +1,107 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"server/settings"
+)
+
+func TestNormalizedConfigDefaultsToGStreamer122(t *testing.T) {
+	conf := Config{}.normalized()
+
+	if conf.GSTVersion != 1.22 {
+		t.Fatalf("GSTVersion=%v, want 1.22", conf.GSTVersion)
+	}
+	if conf.MaxTasks != 0 {
+		t.Fatalf("MaxTasks=%v, want 0 unlimited", conf.MaxTasks)
+	}
+	if conf.AACChannels != 0 {
+		t.Fatalf("AACChannels=%v, want 0 auto", conf.AACChannels)
+	}
+	if conf.AACSamplerate != 0 {
+		t.Fatalf("AACSamplerate=%v, want 0 auto", conf.AACSamplerate)
+	}
+}
+
+func TestPlatformDefaultsUseReleasePipelinePolicy(t *testing.T) {
+	conf := defaultConfigWithoutSettings().normalized()
+	if conf.SegmentDiff != 20 || !conf.Subtitles || !conf.HardwareAcceleration || !conf.UseGPU {
+		t.Fatalf("unexpected release defaults: %#v", conf)
+	}
+}
+
+func TestDefaultConfigReadsGstSettingsJSON(t *testing.T) {
+	oldPath := settings.Path
+	settings.Path = t.TempDir()
+	t.Cleanup(func() {
+		settings.Path = oldPath
+	})
+
+	data := []byte(`{
+  "gst": {
+    "gstVersion": 1.28,
+    "gstPath": "D:\\gst",
+    "source": "play",
+    "maxTasks": 3,
+    "inactiveMinutes": 3,
+    "aacBitrateKbps": 192,
+    "AACChannels": 6,
+    "AACSamplerate": 44100,
+    "segmentSeconds": 4,
+    "transcodeH264": true,
+    "videoBitrate": 8000
+  }
+}`)
+
+	if err := os.WriteFile(filepath.Join(settings.Path, "settings.json"), data, 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	conf := DefaultConfig()
+
+	if conf.GSTVersion != 1.28 ||
+		conf.GSTPath != `D:\gst` ||
+		conf.Source != "play" ||
+		conf.MaxTasks != 3 ||
+		conf.InactiveMinutes != 3 ||
+		conf.AACBitrateKbps != 192 ||
+		conf.AACChannels != 6 ||
+		conf.AACSamplerate != 44100 ||
+		conf.SegmentSeconds != 4 ||
+		!conf.TranscodeH264 ||
+		conf.VideoBitrate != 8000 {
+		t.Fatalf("DefaultConfig() did not read gst settings: %#v", conf)
+	}
+}
+
+func TestSourceURLDefaultsToStream(t *testing.T) {
+	oldPort := settings.Port
+	settings.Port = "8090"
+	t.Cleanup(func() {
+		settings.Port = oldPort
+	})
+
+	got := sourceURL(Config{}.normalized(), "abc def", "1")
+	want := "http://127.0.0.1:8090/stream/?link=abc+def&index=1&play"
+	if got != want {
+		t.Fatalf("sourceURL(default) = %q, want %q", got, want)
+	}
+}
+
+func TestSourceURLCanUsePlayEndpoint(t *testing.T) {
+	oldPort := settings.Port
+	settings.Port = "8090"
+	t.Cleanup(func() {
+		settings.Port = oldPort
+	})
+
+	got := sourceURL(Config{Source: "play"}.normalized(), "abc def", "1")
+	want := "http://127.0.0.1:8090/play/abc%20def/1"
+	if got != want {
+		t.Fatalf("sourceURL(play) = %q, want %q", got, want)
+	}
+}

--- a/server/gstreamer/gst_api.go
+++ b/server/gstreamer/gst_api.go
@@ -34,7 +34,9 @@ const (
 
 	gstMapRead int32 = 1
 
-	gstMessageError int32 = 1 << 1
+	gstMessageEOS       int32 = 1 << 0
+	gstMessageError     int32 = 1 << 1
+	gstMessageAsyncDone int32 = 1 << 21
 )
 
 const maxGStreamerSampleBytes = 128 * 1024 * 1024
@@ -85,6 +87,9 @@ type gstAPI struct {
 	gstElementGetStaticPad  func(element uintptr, name string) uintptr
 	gstElementQueryPosition func(element uintptr, format int32, cur unsafe.Pointer) int32
 	gstEventNewSeek         func(rate float64, format int32, flags int32, startType int32, start int64, stopType int32, stop int64) uintptr
+	gstEventParseSegment    func(event uintptr, segment unsafe.Pointer)
+	gstPadAddProbe          func(pad uintptr, mask uint32, callback uintptr, userData uintptr, destroyData uintptr) uintptr
+	gstPadRemoveProbe       func(pad uintptr, id uintptr)
 	gstPadSendEvent         func(pad uintptr, event uintptr) int32
 	gstPipelineGetBus       func(pipeline uintptr) uintptr
 	gstBusTimedPopFiltered  func(bus uintptr, timeout uint64, types int32) uintptr
@@ -122,6 +127,9 @@ func (g *gstAPI) bind(gstHandle uintptr, gstAppHandle uintptr, glibHandle uintpt
 	purego.RegisterLibFunc(&g.gstElementGetStaticPad, gstHandle, "gst_element_get_static_pad")
 	purego.RegisterLibFunc(&g.gstElementQueryPosition, gstHandle, "gst_element_query_position")
 	purego.RegisterLibFunc(&g.gstEventNewSeek, gstHandle, "gst_event_new_seek")
+	purego.RegisterLibFunc(&g.gstEventParseSegment, gstHandle, "gst_event_parse_segment")
+	purego.RegisterLibFunc(&g.gstPadAddProbe, gstHandle, "gst_pad_add_probe")
+	purego.RegisterLibFunc(&g.gstPadRemoveProbe, gstHandle, "gst_pad_remove_probe")
 	purego.RegisterLibFunc(&g.gstPadSendEvent, gstHandle, "gst_pad_send_event")
 	purego.RegisterLibFunc(&g.gstPipelineGetBus, gstHandle, "gst_pipeline_get_bus")
 	purego.RegisterLibFunc(&g.gstBusTimedPopFiltered, gstHandle, "gst_bus_timed_pop_filtered")
@@ -204,7 +212,7 @@ func (g *gstAPI) objectUnref(obj uintptr) {
 }
 
 func (g *gstAPI) miniObjectUnref(obj uintptr) {
-	if obj != 0 {
+	if obj != 0 && g.gstMiniObjectUnref != nil {
 		g.gstMiniObjectUnref(obj)
 	}
 }
@@ -347,7 +355,7 @@ func validateGStreamerSampleSize(bufferSize uintptr, mapSize int) error {
 }
 
 func (g *gstAPI) popBusError(bus uintptr, timeout time.Duration) error {
-	if bus == 0 {
+	if bus == 0 || g.gstBusTimedPopFiltered == nil {
 		return nil
 	}
 
@@ -362,6 +370,59 @@ func (g *gstAPI) popBusError(bus uintptr, timeout time.Duration) error {
 		message = "gstreamer bus error"
 	}
 	return errors.New(message)
+}
+
+func (g *gstAPI) drainBusMessages(bus uintptr, messageTypes int32) {
+	for g.popBusMessage(bus, 0, messageTypes) {
+	}
+}
+
+func (g *gstAPI) waitForSeekDone(bus uintptr, timeout time.Duration) (bool, error) {
+	if bus == 0 || g.gstBusTimedPopFiltered == nil {
+		return false, errors.New("gstreamer bus is not available while waiting for seek")
+	}
+	if timeout <= 0 {
+		return false, errors.New("invalid gstreamer seek timeout")
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := g.popBusError(bus, 0); err != nil {
+			return false, err
+		}
+		if g.popBusMessage(bus, 0, gstMessageEOS) {
+			return false, errors.New("gstreamer reached EOS while completing seek")
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		wait := min(remaining, 100*time.Millisecond)
+		if g.popBusMessage(bus, wait, gstMessageAsyncDone) {
+			return true, nil
+		}
+	}
+
+	if err := g.popBusError(bus, 0); err != nil {
+		return false, err
+	}
+	if g.popBusMessage(bus, 0, gstMessageEOS) {
+		return false, errors.New("gstreamer reached EOS while completing seek")
+	}
+	return false, nil
+}
+
+func (g *gstAPI) popBusMessage(bus uintptr, timeout time.Duration, messageTypes int32) bool {
+	if bus == 0 || messageTypes == 0 || g.gstBusTimedPopFiltered == nil {
+		return false
+	}
+	msg := g.gstBusTimedPopFiltered(bus, uint64(timeout), messageTypes)
+	if msg == 0 {
+		return false
+	}
+	g.miniObjectUnref(msg)
+	return true
 }
 
 func (g *gstAPI) parseMessageError(msg uintptr) string {

--- a/server/gstreamer/gst_api.go
+++ b/server/gstreamer/gst_api.go
@@ -39,7 +39,7 @@ const (
 	gstMessageAsyncDone int32 = 1 << 21
 )
 
-const maxGStreamerSampleBytes = 128 * 1024 * 1024
+const maxGStreamerSampleBytes = 256 * 1024 * 1024
 
 type gstVersionInfo struct {
 	major uint32

--- a/server/gstreamer/gst_api_test.go
+++ b/server/gstreamer/gst_api_test.go
@@ -1,0 +1,188 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"math"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestGSTVersionInfoFormatting(t *testing.T) {
+	version := gstVersionInfo{major: 1, minor: 26, micro: 2}
+	if got := version.String(); got != "1.26.2" {
+		t.Fatalf("String()=%q, want 1.26.2", got)
+	}
+	if got := version.configValue(); math.Abs(got-1.26) > 0.000001 {
+		t.Fatalf("configValue()=%v, want 1.26", got)
+	}
+}
+
+func TestLoadGStreamerRuntimeIfAvailable(t *testing.T) {
+	conf := DefaultConfig()
+	setupGStreamer(conf)
+
+	api, err := loadGST(conf)
+	if err != nil {
+		t.Skipf("gstreamer runtime is not available: %v", err)
+	}
+	if err := api.init(); err != nil {
+		t.Fatalf("gst init failed: %v", err)
+	}
+
+	pipeline, err := api.parseLaunch("fakesrc num-buffers=1 ! fakesink")
+	if err != nil {
+		t.Fatalf("parse launch failed: %v", err)
+	}
+	defer api.objectUnref(pipeline)
+
+	if ret := api.elementSetState(pipeline, gstStateNull); ret == gstStateChangeFailure {
+		t.Fatal("failed to set test pipeline to NULL")
+	}
+}
+
+func TestParseLaunchRejectsPartialPipeline(t *testing.T) {
+	message := append([]byte("partial pipeline parse error"), 0)
+	gerror := make([]byte, 16)
+	*(*uintptr)(unsafe.Pointer(&gerror[8])) = uintptr(unsafe.Pointer(&message[0]))
+
+	var unrefed uintptr
+	api := &gstAPI{
+		gstParseLaunch: func(_ string, errOut unsafe.Pointer) uintptr {
+			*(*uintptr)(errOut) = uintptr(unsafe.Pointer(&gerror[0]))
+			return 123
+		},
+		gstObjectUnref: func(value uintptr) {
+			unrefed = value
+		},
+		gErrorFree: func(uintptr) {},
+	}
+
+	pipeline, err := api.parseLaunch("broken ! pipeline")
+	if err == nil {
+		t.Fatal("partial parse error was ignored")
+	}
+	if pipeline != 0 {
+		t.Fatalf("pipeline=%d, want 0", pipeline)
+	}
+	if unrefed != 123 {
+		t.Fatalf("partial pipeline was not unrefed")
+	}
+
+	runtime.KeepAlive(message)
+	runtime.KeepAlive(gerror)
+}
+
+func TestWithSampleBytesReturnsMapError(t *testing.T) {
+	api := &gstAPI{
+		gstSampleGetBuffer: func(uintptr) uintptr { return 2 },
+		gstBufferGetSize:   func(uintptr) uintptr { return 10 },
+		gstBufferMap:       func(uintptr, unsafe.Pointer, int32) int32 { return 0 },
+	}
+
+	err := api.withSampleBytes(1, func([]byte) error {
+		t.Fatal("consume must not be called")
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "gst_buffer_map failed") {
+		t.Fatalf("error=%v, want gst_buffer_map failed", err)
+	}
+}
+
+func TestValidateGStreamerSampleSizeOK(t *testing.T) {
+	if err := validateGStreamerSampleSize(1024, 1024); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGStreamerSampleSafetyLimit(t *testing.T) {
+	const want = 256 * 1024 * 1024
+	if maxGStreamerSampleBytes != want {
+		t.Fatalf("maxGStreamerSampleBytes=%d, want %d", maxGStreamerSampleBytes, want)
+	}
+	if err := validateGStreamerSampleSize(want, want); err != nil {
+		t.Fatalf("sample at safety limit was rejected: %v", err)
+	}
+}
+
+func TestValidateGStreamerSampleSizeRejectsHugeBuffer(t *testing.T) {
+	err := validateGStreamerSampleSize(uintptr(maxGStreamerSampleBytes+1), 1024)
+	if err == nil || !strings.Contains(err.Error(), "gst buffer exceeds safety limit") {
+		t.Fatalf("error=%v, want safety limit error", err)
+	}
+}
+
+func TestValidateGStreamerSampleSizeRejectsHugeMap(t *testing.T) {
+	err := validateGStreamerSampleSize(1024, maxGStreamerSampleBytes+1)
+	if err == nil || !strings.Contains(err.Error(), "gst map size exceeds safety limit") {
+		t.Fatalf("error=%v, want map safety limit error", err)
+	}
+}
+
+func TestValidateGStreamerSampleSizeRejectsMapLargerThanBuffer(t *testing.T) {
+	err := validateGStreamerSampleSize(1024, 2048)
+	if err == nil || !strings.Contains(err.Error(), "gst map size exceeds buffer size") {
+		t.Fatalf("error=%v, want map larger than buffer error", err)
+	}
+}
+
+func TestValidateGStreamerSampleSizeRejectsNegativeMap(t *testing.T) {
+	err := validateGStreamerSampleSize(1024, -1)
+	if err == nil || !strings.Contains(err.Error(), "gst map size is negative") {
+		t.Fatalf("error=%v, want negative map error", err)
+	}
+}
+
+func TestWaitForSeekDoneConsumesAsyncDone(t *testing.T) {
+	var filters []int32
+	var unrefed uintptr
+	api := &gstAPI{
+		gstBusTimedPopFiltered: func(_ uintptr, _ uint64, filter int32) uintptr {
+			filters = append(filters, filter)
+			if filter == gstMessageAsyncDone {
+				return 77
+			}
+			return 0
+		},
+		gstMiniObjectUnref: func(message uintptr) {
+			unrefed = message
+		},
+	}
+
+	done, err := api.waitForSeekDone(1, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !done {
+		t.Fatal("ASYNC_DONE was not reported")
+	}
+	if unrefed != 77 {
+		t.Fatalf("unrefed message=%d, want 77", unrefed)
+	}
+	want := []int32{gstMessageError, gstMessageEOS, gstMessageAsyncDone}
+	if len(filters) != len(want) {
+		t.Fatalf("filters=%v, want %v", filters, want)
+	}
+	for i := range want {
+		if filters[i] != want[i] {
+			t.Fatalf("filters=%v, want %v", filters, want)
+		}
+	}
+}
+
+func TestWaitForSeekDoneTreatsMissingAsyncDoneAsSoftTimeout(t *testing.T) {
+	api := &gstAPI{
+		gstBusTimedPopFiltered: func(uintptr, uint64, int32) uintptr { return 0 },
+	}
+
+	done, err := api.waitForSeekDone(1, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done {
+		t.Fatal("ASYNC_DONE was reported on timeout")
+	}
+}

--- a/server/gstreamer/handlers.go
+++ b/server/gstreamer/handlers.go
@@ -413,16 +413,9 @@ func (s *Service) subtitle(c *gin.Context) {
 		c.Status(http.StatusBadRequest)
 		return
 	}
-	value, ready := task.SubtitleVTT(trackIndex, segmentIndex)
-	if !ready {
-		timer := time.NewTimer(time.Second)
-		defer timer.Stop()
-		select {
-		case <-c.Request.Context().Done():
-			return
-		case <-timer.C:
-		}
-		value, _ = task.SubtitleVTT(trackIndex, segmentIndex)
+	value, err := task.WaitSubtitleVTT(c.Request.Context(), trackIndex, segmentIndex, subtitleWaitTimeout)
+	if err != nil {
+		return
 	}
 	c.Data(http.StatusOK, "text/vtt; charset=utf-8", []byte(value))
 }

--- a/server/gstreamer/handlers_test.go
+++ b/server/gstreamer/handlers_test.go
@@ -1,0 +1,301 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type masterInitRunner struct {
+	task  *Task
+	calls int
+}
+
+func (r *masterInitRunner) EnsureInit(context.Context, int, int) error {
+	r.calls++
+	r.task.initMu.Lock()
+	r.task.initMP4 = []byte{1}
+	r.task.variant = &HLSVariantInfo{
+		Codecs: "hvc1.1.6.L153.B0,mp4a.40.2",
+		Width:  3840,
+		Height: 2160,
+	}
+	r.task.initMu.Unlock()
+	return nil
+}
+
+func (r *masterInitRunner) GetSegment(context.Context, int, int) (Segment, error) {
+	return Segment{}, nil
+}
+
+func (r *masterInitRunner) Seek(float64) bool { return true }
+func (r *masterInitRunner) Frozen()           {}
+func (r *masterInitRunner) Dispose()          {}
+func (r *masterInitRunner) IsFrozen() bool    { return false }
+
+func TestSetupRouteDoesNotConflict(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+
+	service := NewService(DefaultConfig())
+	defer service.Dispose()
+
+	service.SetupRoute(router)
+
+	routes := router.Routes()
+	registered := make(map[string]bool, len(routes))
+	for _, route := range routes {
+		registered[route.Method+" "+route.Path] = true
+	}
+
+	for _, path := range []string{
+		"/gst/remove",
+		"/gst/echo",
+		"/gst/:hash/heartbeat",
+		"/gst/:hash/probe",
+		"/gst/:hash/master.m3u8",
+		"/gst/:hash/init.mp4",
+		"/gst/:hash/seg/*segment",
+	} {
+		if !registered["GET "+path] {
+			t.Fatalf("route for %s was not registered", path)
+		}
+	}
+}
+
+func TestProbeRouteReturnsCachedProbe(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+
+	service := &Service{
+		conf:       Config{}.normalized(),
+		tasks:      make(map[string]*Task),
+		probeCache: make(map[string]probeCacheEntry),
+	}
+	service.setCachedProbe("hash", "1", ProbeInfo{
+		DurationNS: 60 * int64(time.Second),
+		Container:  "Matroska",
+		Tracks: []TrackInfo{
+			{Type: "video", CapsName: "video/x-h264", Width: 1920, Height: 1080},
+		},
+	})
+	service.SetupRoute(router)
+
+	request := httptest.NewRequest(http.MethodGet, "/gst/hash/probe?index=1", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("probe route status=%d body=%q", response.Code, response.Body.String())
+	}
+
+	var probe ProbeInfo
+	if err := json.Unmarshal(response.Body.Bytes(), &probe); err != nil {
+		t.Fatal(err)
+	}
+	if probe.Container != "Matroska" || !probe.IsH264() || probe.Video().Width != 1920 {
+		t.Fatalf("probe route returned unexpected probe: %+v", probe)
+	}
+}
+
+func TestHeartbeatReturnsTorrentDetailsResponse(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+
+	service := &Service{
+		conf: Config{}.normalized(),
+		tasks: map[string]*Task{
+			"hash": {
+				ID:         "hash",
+				lastActive: time.Now().UTC(),
+			},
+		},
+	}
+	service.SetupRoute(router)
+
+	request := httptest.NewRequest(http.MethodGet, "/gst/hash/heartbeat", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("heartbeat status=%d body=%q", response.Code, response.Body.String())
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["Hash"] != "hash" {
+		t.Fatalf("heartbeat returned unexpected body: %v", body)
+	}
+}
+
+func TestMasterEnsuresInitBeforeWritingCodecMetadata(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	router := gin.New()
+
+	conf := Config{}.normalized()
+	task := &Task{
+		ID:              "hash",
+		FileID:          "1",
+		Audio:           0,
+		Config:          conf,
+		LastSentSegment: -1,
+		lastActive:      time.Now().UTC(),
+		Probe: ProbeInfo{
+			DurationNS: int64(2 * time.Hour),
+			FileSize:   24 * 1024 * 1024 * 1024,
+			Tracks: []TrackInfo{
+				{Type: "video", CapsName: "video/x-h265", Width: 3840, Height: 2160},
+				{Type: "audio", Index: 0, CapsName: "audio/mpeg"},
+			},
+		},
+	}
+	runner := &masterInitRunner{task: task}
+	task.runner = runner
+	service := &Service{
+		conf:       conf,
+		tasks:      map[string]*Task{"hash": task},
+		probeCache: make(map[string]probeCacheEntry),
+	}
+	service.SetupRoute(router)
+
+	request := httptest.NewRequest(http.MethodGet, "/gst/hash/master.m3u8?index=1&audio=0", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("master status=%d body=%q", response.Code, response.Body.String())
+	}
+	if runner.calls != 1 {
+		t.Fatalf("EnsureInit calls=%d, want 1", runner.calls)
+	}
+	if !strings.Contains(response.Body.String(), `CODECS="hvc1.1.6.L153.B0,mp4a.40.2"`) {
+		t.Fatalf("master did not use codec metadata from init.mp4: %q", response.Body.String())
+	}
+}
+
+func TestHLSBandwidthDoesNotOverflowForLargeFile(t *testing.T) {
+	task := &Task{
+		Config: Config{}.normalized(),
+		Probe: ProbeInfo{
+			FileSize:   24 * 1024 * 1024 * 1024,
+			DurationNS: int64(2 * time.Hour),
+		},
+	}
+
+	bandwidth, average := task.hlsBandwidth()
+	const wantAverage int64 = 28_633_116
+	const wantBandwidth int64 = 42_949_674
+	if average != wantAverage || bandwidth != wantBandwidth {
+		t.Fatalf("hlsBandwidth() = (%d, %d), want (%d, %d)", bandwidth, average, wantBandwidth, wantAverage)
+	}
+}
+
+func TestParseSingleRange(t *testing.T) {
+	tests := []struct {
+		header string
+		total  int64
+		start  int64
+		end    int64
+		ok     bool
+	}{
+		{header: "bytes=0-9", total: 100, start: 0, end: 9, ok: true},
+		{header: "bytes=10-", total: 100, start: 10, end: 99, ok: true},
+		{header: "bytes=-5", total: 100, start: 95, end: 99, ok: true},
+		{header: "bytes=100-101", total: 100, ok: false},
+		{header: "items=0-1", total: 100, ok: false},
+		{header: "bytes=0-1,2-3", total: 100, ok: false},
+	}
+
+	for _, test := range tests {
+		start, end, ok := parseSingleRange(test.header, test.total)
+		if ok != test.ok || start != test.start || end != test.end {
+			t.Fatalf("parseSingleRange(%q, %d) = (%d, %d, %v), want (%d, %d, %v)",
+				test.header, test.total, start, end, ok, test.start, test.end, test.ok)
+		}
+	}
+}
+
+func TestWriteSegmentWritesPartialContentHeaders(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	response := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(response)
+	c.Request = httptest.NewRequest(http.MethodGet, "/segment", nil)
+	c.Request.Header.Set("Range", "bytes=2-5")
+
+	if err := writeSegment(c, Segment{Header: []byte("header"), Payloads: [][]byte{[]byte("payload")}}); err != nil {
+		t.Fatal(err)
+	}
+	if response.Code != http.StatusPartialContent {
+		t.Fatalf("status=%d, want %d", response.Code, http.StatusPartialContent)
+	}
+	if got, want := response.Header().Get("Content-Range"), "bytes 2-5/13"; got != want {
+		t.Fatalf("Content-Range=%q, want %q", got, want)
+	}
+	if got, want := response.Header().Get("Content-Length"), "4"; got != want {
+		t.Fatalf("Content-Length=%q, want %q", got, want)
+	}
+	if got, want := response.Body.String(), "ader"; got != want {
+		t.Fatalf("body=%q, want %q", got, want)
+	}
+}
+
+func TestHLSQuotedRemovesControlCharacters(t *testing.T) {
+	if got, want := hlsQuoted("line\r\n\"name\""), `line  \"name\"`; got != want {
+		t.Fatalf("hlsQuoted()=%q, want %q", got, want)
+	}
+}
+
+func TestStartSegmentIndex(t *testing.T) {
+	tests := []struct {
+		seconds        int
+		segmentSeconds int
+		count          int
+		want           int
+	}{
+		{seconds: 0, segmentSeconds: 6, count: 1000, want: 0},
+		{seconds: 600, segmentSeconds: 6, count: 1000, want: 100},
+		{seconds: 599, segmentSeconds: 6, count: 1000, want: 99},
+		{seconds: 9999, segmentSeconds: 6, count: 100, want: 100},
+		{seconds: 600, segmentSeconds: 0, count: 1000, want: 0},
+	}
+
+	for _, test := range tests {
+		got := startSegmentIndex(test.seconds, test.segmentSeconds, test.count)
+		if got != test.want {
+			t.Fatalf("startSegmentIndex(%d, %d, %d) = %d, want %d", test.seconds, test.segmentSeconds, test.count, got, test.want)
+		}
+	}
+}
+
+func TestParseSegmentIndexRejectsNegative(t *testing.T) {
+	if _, err := parseSegmentIndex("/-1.m4s"); err == nil {
+		t.Fatal("negative segment index was accepted")
+	}
+}
+
+func TestParseSegmentIndexAllowsNonNegative(t *testing.T) {
+	tests := map[string]int{
+		"/0.m4s": 0,
+		"42.m4s": 42,
+	}
+
+	for value, want := range tests {
+		got, err := parseSegmentIndex(value)
+		if err != nil {
+			t.Fatalf("parseSegmentIndex(%q) returned error: %v", value, err)
+		}
+		if got != want {
+			t.Fatalf("parseSegmentIndex(%q) = %d, want %d", value, got, want)
+		}
+	}
+}

--- a/server/gstreamer/mp4box.go
+++ b/server/gstreamer/mp4box.go
@@ -336,6 +336,14 @@ func (r *mp4BoxReader) SeekReset(seconds float64) {
 	r.resetBoxState()
 }
 
+func (r *mp4BoxReader) SetTimelineOffsetNS(offsetNS uint64) {
+	if offsetNS == math.MaxUint64 {
+		r.tfdtOffsetSeconds = 0
+		return
+	}
+	r.tfdtOffsetSeconds = float64(offsetNS) / 1_000_000_000
+}
+
 func (r *mp4BoxReader) SetTargetSegment(startNS uint64, endNS uint64, toleranceNS uint64) error {
 	if !r.cueMode {
 		return nil

--- a/server/gstreamer/mp4box_audio_split_test.go
+++ b/server/gstreamer/mp4box_audio_split_test.go
@@ -1,0 +1,255 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"bytes"
+	"testing"
+)
+
+func testAudioSplitExplicitRun(
+	t *testing.T,
+	sampleCount int,
+	duration uint32,
+	size uint32,
+) mp4Run {
+	t.Helper()
+
+	samples := make([]mp4Sample, sampleCount)
+	for i := range samples {
+		samples[i] = mp4Sample{
+			duration: duration,
+			size:     size,
+			flags:    0,
+		}
+	}
+
+	run, err := buildExplicitRun(
+		mp4Run{version: 0},
+		samples,
+	)
+	if err != nil {
+		t.Fatalf("buildExplicitRun: %v", err)
+	}
+	return run
+}
+
+func testAudioSplitFragment(
+	t *testing.T,
+	decodeTime uint64,
+	timescale uint32,
+	runs ...mp4Run,
+) mp4Fragment {
+	t.Helper()
+
+	var duration uint64
+	var payloadLength int
+	var payloadOffset int64
+
+	for i := range runs {
+		runs[i].payloadOffset = payloadOffset
+		payloadOffset += int64(runs[i].dataSize)
+		duration += runs[i].duration
+		payloadLength += int(runs[i].dataSize)
+	}
+
+	payload := make([]byte, payloadLength)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	return mp4Fragment{
+		trackID:        2,
+		timescale:      timescale,
+		decodeTime:     decodeTime,
+		duration:       duration,
+		startsWithSync: true,
+		tfhd:           buildCanonicalTfhd(2, 1),
+		runs:           runs,
+		payloadStart:   0,
+		payloadLen:     len(payload),
+	}
+}
+
+func TestSplitFragmentAtSamplePreservesTimelineAndPayload(t *testing.T) {
+	source := testAudioSplitFragment(
+		t,
+		10_000,
+		48_000,
+		testAudioSplitExplicitRun(t, 4, 1024, 10),
+		testAudioSplitExplicitRun(t, 3, 1024, 20),
+	)
+	sourcePayload := make([]byte, source.payloadLen)
+	for i := range sourcePayload {
+		sourcePayload[i] = byte(i)
+	}
+
+	left, right, err := splitFragmentAtSample(source, 5)
+	if err != nil {
+		t.Fatalf("splitFragmentAtSample: %v", err)
+	}
+
+	if got, want := left.duration, uint64(5*1024); got != want {
+		t.Fatalf("left duration = %d, want %d", got, want)
+	}
+	if got, want := right.duration, uint64(2*1024); got != want {
+		t.Fatalf("right duration = %d, want %d", got, want)
+	}
+	if got, want := right.decodeTime, source.decodeTime+left.duration; got != want {
+		t.Fatalf("right decode time = %d, want %d", got, want)
+	}
+	if got, want := left.payloadLen, 4*10+1*20; got != want {
+		t.Fatalf("left payload length = %d, want %d", got, want)
+	}
+	if got, want := right.payloadLen, 2*20; got != want {
+		t.Fatalf("right payload length = %d, want %d", got, want)
+	}
+
+	joined := append(
+		append([]byte(nil), sourcePayload[left.payloadStart:left.payloadStart+left.payloadLen]...),
+		sourcePayload[right.payloadStart:right.payloadStart+right.payloadLen]...,
+	)
+	if !bytes.Equal(joined, sourcePayload) {
+		t.Fatal("left+right payload does not reproduce source payload")
+	}
+
+	rightSamples, err := fragmentSampleCount(right)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leftSamples, err := fragmentSampleCount(left)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if leftSamples != 5 {
+		t.Fatalf("left samples = %d, want 5", leftSamples)
+	}
+	if rightSamples != 2 {
+		t.Fatalf("right samples = %d, want 2", rightSamples)
+	}
+}
+
+func TestSelectAudioCountSplitsAtFirstBoundaryNotBeforeVideoEnd(t *testing.T) {
+	reader := Mp4BoxReader(
+		func([]byte) {},
+		func(Segment) {},
+		6,
+		0,
+		false,
+	)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.audioTrack = trackInfo{id: 2, timescale: 48_000}
+
+	reader.audio = append(
+		reader.audio,
+		testAudioSplitFragment(
+			t,
+			0,
+			48_000,
+			testAudioSplitExplicitRun(t, 10, 1024, 10),
+		),
+	)
+
+	count, err := reader.selectAudioCount(100)
+	if err != nil {
+		t.Fatalf("selectAudioCount: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("audio count = %d, want 1", count)
+	}
+	if len(reader.audio) != 2 {
+		t.Fatalf("audio fragments = %d, want 2 after split", len(reader.audio))
+	}
+
+	left := reader.audio[0]
+	right := reader.audio[1]
+
+	if got, want := left.duration, uint64(5*1024); got != want {
+		t.Fatalf("left duration = %d, want %d", got, want)
+	}
+	if got, want := right.decodeTime, left.endTime(); got != want {
+		t.Fatalf("right decode time = %d, want %d", got, want)
+	}
+	if left.payloadLen+right.payloadLen != 100 {
+		t.Fatalf(
+			"payload partition = %d+%d, want 100",
+			left.payloadLen,
+			right.payloadLen,
+		)
+	}
+
+	if !scaledGreaterOrEqual(
+		left.endTime(),
+		reader.videoTrack.timescale,
+		100,
+		reader.audioTrack.timescale,
+	) {
+		t.Fatal("selected audio ends before video")
+	}
+
+	previousBoundary := left.endTime() - 1024
+	if scaledGreaterOrEqual(
+		previousBoundary,
+		reader.videoTrack.timescale,
+		100,
+		reader.audioTrack.timescale,
+	) {
+		t.Fatal("split was not made at the first audio boundary at/after video end")
+	}
+}
+
+func TestReclaimPayloadsKeepsSplitAudioTail(t *testing.T) {
+	reader := Mp4BoxReader(
+		func([]byte) {},
+		func(Segment) {},
+		6,
+		0,
+		false,
+	)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.audioTrack = trackInfo{id: 2, timescale: 48_000}
+
+	source := testAudioSplitFragment(
+		t,
+		0,
+		48_000,
+		testAudioSplitExplicitRun(t, 10, 1024, 10),
+	)
+	sourcePayload := make([]byte, source.payloadLen)
+	for i := range sourcePayload {
+		sourcePayload[i] = byte(i)
+	}
+	_, _ = reader.sourcePayload.Write(sourcePayload)
+	reader.audio = append(reader.audio, source)
+
+	count, err := reader.selectAudioCount(100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 || len(reader.audio) != 2 {
+		t.Fatalf("split result count=%d fragments=%d, want 1/2", count, len(reader.audio))
+	}
+
+	rightBefore := reader.audio[1]
+	rightPayload := append(
+		[]byte(nil),
+		reader.sourcePayload.Bytes()[rightBefore.payloadStart:rightBefore.payloadStart+rightBefore.payloadLen]...,
+	)
+
+	reader.audio = removeFragments(reader.audio, 1)
+	reader.ReclaimPayloads()
+
+	if len(reader.audio) != 1 {
+		t.Fatalf("audio fragments=%d, want 1", len(reader.audio))
+	}
+	rightAfter := reader.audio[0]
+	if rightAfter.payloadStart != 0 {
+		t.Fatalf("right payload start=%d, want 0", rightAfter.payloadStart)
+	}
+	if rightAfter.payloadLen != len(rightPayload) {
+		t.Fatalf("right payload len=%d, want %d", rightAfter.payloadLen, len(rightPayload))
+	}
+	if !bytes.Equal(reader.sourcePayload.Bytes()[:rightAfter.payloadLen], rightPayload) {
+		t.Fatal("right payload bytes changed after reclaim")
+	}
+}

--- a/server/gstreamer/mp4box_test.go
+++ b/server/gstreamer/mp4box_test.go
@@ -1,0 +1,708 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"math"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func testTfhd(trackID uint32) canonicalTfhd {
+	return buildCanonicalTfhd(trackID, 1)
+}
+
+func testTrun(duration uint32, size uint32, flags uint32) []byte {
+	const trunFlags = trunDataOffsetPresent |
+		trunSampleDurationPresent |
+		trunSampleSizePresent |
+		trunSampleFlagsPresent
+	const boxSize = 32
+
+	box := make([]byte, boxSize)
+	binary.BigEndian.PutUint32(box[0:4], boxSize)
+	binary.BigEndian.PutUint32(box[4:8], boxTrun)
+	binary.BigEndian.PutUint32(box[8:12], trunFlags)
+	binary.BigEndian.PutUint32(box[12:16], 1)
+	binary.BigEndian.PutUint32(box[16:20], 0)
+	binary.BigEndian.PutUint32(box[20:24], duration)
+	binary.BigEndian.PutUint32(box[24:28], size)
+	binary.BigEndian.PutUint32(box[28:32], flags)
+	return box
+}
+
+func testFragment(
+	trackID uint32,
+	timescale uint32,
+	decodeTime uint64,
+	duration uint32,
+	payloadSize uint32,
+	sync bool,
+	fill byte,
+) mp4Fragment {
+	flags := uint32(0)
+	if !sync {
+		flags = 0x00010000
+	}
+
+	run := mp4Run{
+		samples: []mp4Sample{
+			{
+				duration: duration,
+				size:     payloadSize,
+				flags:    flags,
+			},
+		},
+		duration:       uint64(duration),
+		dataSize:       uint64(payloadSize),
+		payloadOffset:  0,
+		startsWithSync: sync,
+	}
+
+	return mp4Fragment{
+		trackID:        trackID,
+		timescale:      timescale,
+		decodeTime:     decodeTime,
+		duration:       uint64(duration),
+		startsWithSync: sync,
+		tfhd:           testTfhd(trackID),
+		runs:           []mp4Run{run},
+		payloadLen:     int(payloadSize),
+	}
+}
+
+func appendTestFragmentPayload(reader *mp4BoxReader, fragment mp4Fragment, fill byte) mp4Fragment {
+	payload := bytes.Repeat([]byte{fill}, fragment.payloadLen)
+	fragment.payloadStart = reader.sourcePayload.Len()
+	_, _ = reader.sourcePayload.Write(payload)
+	return fragment
+}
+
+func newTestEOSRunner(segmentSeconds float64) (*gstRunner, *mp4BoxReader, *[]Segment) {
+	task := &Task{Config: Config{SegmentSeconds: int(segmentSeconds)}.normalized()}
+	runner := &gstRunner{task: task}
+	task.runner = runner
+	segments := make([]Segment, 0, 4)
+
+	reader := Mp4BoxReader(
+		func([]byte) {},
+		func(seg Segment) {
+			segments = append(segments, seg)
+			runner.readySegment.segment = seg
+			runner.readySegment.complete = true
+		},
+		segmentSeconds,
+		0,
+		false,
+	)
+
+	runner.reader = reader
+	return runner, reader, &segments
+}
+
+func resetTestReady(runner *gstRunner) {
+	runner.discardReadySegment()
+}
+
+func testU32(values ...uint32) []byte {
+	out := make([]byte, len(values)*4)
+	for i, value := range values {
+		binary.BigEndian.PutUint32(out[i*4:(i+1)*4], value)
+	}
+	return out
+}
+
+func testBox(boxType uint32, payload ...[]byte) []byte {
+	size := 8
+	for _, part := range payload {
+		size += len(part)
+	}
+
+	out := make([]byte, size)
+	binary.BigEndian.PutUint32(out[0:4], uint32(size))
+	binary.BigEndian.PutUint32(out[4:8], boxType)
+
+	position := 8
+	for _, part := range payload {
+		copy(out[position:], part)
+		position += len(part)
+	}
+	return out
+}
+
+func testFullBox(boxType uint32, versionFlags uint32, body []byte) []byte {
+	fullBody := make([]byte, 4+len(body))
+	binary.BigEndian.PutUint32(fullBody[0:4], versionFlags)
+	copy(fullBody[4:], body)
+	return testBox(boxType, fullBody)
+}
+
+func TestLinearGrowthBufferDoesNotDoubleCapacity(t *testing.T) {
+	const mib = 1024 * 1024
+	for _, test := range []struct {
+		required int
+		want     int
+	}{
+		{required: 40 * mib, want: 40 * mib},
+		{required: 40*mib + 1, want: 41 * mib},
+		{required: 41 * mib, want: 41 * mib},
+		{required: 41*mib + 1, want: 42 * mib},
+	} {
+		if got := roundedBufferCapacity(test.required); got != test.want {
+			t.Fatalf("rounded capacity for %d = %d, want %d", test.required, got, test.want)
+		}
+	}
+
+	var buffer linearGrowthBuffer
+	buffer.Grow(65 * 1024)
+	if got, want := buffer.Cap(), 128*1024; got != want {
+		t.Fatalf("initial capacity = %d, want %d", got, want)
+	}
+	buffer.Reset()
+	buffer.Grow(129 * 1024)
+	if got, want := buffer.Cap(), 192*1024; got != want {
+		t.Fatalf("grown capacity = %d, want %d", got, want)
+	}
+}
+
+func TestEquivalentTfhdTrunRepresentationsCanMerge(t *testing.T) {
+	videoTrack := trackInfo{
+		id:        1,
+		timescale: 1000,
+		trex: trexInfo{
+			descriptionIndex: 1,
+		},
+	}
+
+	tfhdA := testFullBox(
+		boxTfhd,
+		tfhdDefaultSampleDurationPresent|
+			tfhdDefaultSampleSizePresent|
+			tfhdDefaultSampleFlagsPresent,
+		testU32(
+			1,
+			40,
+			100,
+			0,
+		),
+	)
+	tfdtA := testFullBox(boxTfdt, 0, testU32(0))
+	trunA := testFullBox(
+		boxTrun,
+		trunDataOffsetPresent,
+		testU32(
+			2,
+			0,
+		),
+	)
+
+	tfhdB := testFullBox(
+		boxTfhd,
+		tfhdSampleDescriptionIndexPresent,
+		testU32(
+			1,
+			1,
+		),
+	)
+	tfdtB := testFullBox(boxTfdt, 0, testU32(80))
+	trunB := testFullBox(
+		boxTrun,
+		trunDataOffsetPresent|
+			trunSampleDurationPresent|
+			trunSampleSizePresent|
+			trunSampleFlagsPresent,
+		testU32(
+			2,
+			0,
+			40, 100, 0,
+			40, 100, 0,
+		),
+	)
+
+	var fragmentA mp4Fragment
+	err := parseTraf(
+		testBox(boxTraf, tfhdA, tfdtA, trunA),
+		8,
+		videoTrack,
+		trackInfo{},
+		0,
+		0,
+		&fragmentA,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var fragmentB mp4Fragment
+	err = parseTraf(
+		testBox(boxTraf, tfhdB, tfdtB, trunB),
+		8,
+		videoTrack,
+		trackInfo{},
+		0,
+		0,
+		&fragmentB,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fragmentA.tfhd != fragmentB.tfhd {
+		t.Fatal("canonical tfhd differs")
+	}
+	if fragmentA.runs[0].version != fragmentB.runs[0].version ||
+		fragmentA.runs[0].hasCompositionTimeOffsets != fragmentB.runs[0].hasCompositionTimeOffsets ||
+		!slices.Equal(fragmentA.runs[0].samples, fragmentB.runs[0].samples) {
+		t.Fatal("canonical trun differs")
+	}
+
+	if err := validateTrack([]mp4Fragment{fragmentA, fragmentB}, 2); err != nil {
+		t.Fatalf("semantically equivalent fragments do not merge: %v", err)
+	}
+}
+
+func TestWriteCanonicalTrunMatchesCanonicalLayout(t *testing.T) {
+	run := mp4Run{
+		version: 0,
+		samples: []mp4Sample{
+			{duration: 1000, size: 3, flags: 0x01020304},
+		},
+	}
+
+	var output bytes.Buffer
+	if err := writeCanonicalTrun(&output, &run, 1234); err != nil {
+		t.Fatal(err)
+	}
+
+	want := testTrun(1000, 3, 0x01020304)
+	binary.BigEndian.PutUint32(want[16:20], 1234)
+	if !bytes.Equal(output.Bytes(), want) {
+		t.Fatalf("canonical trun = %x, want %x", output.Bytes(), want)
+	}
+}
+
+func BenchmarkWriteCanonicalTrun(b *testing.B) {
+	samples := make([]mp4Sample, 300)
+	for i := range samples {
+		samples[i] = mp4Sample{duration: 1024, size: 512, flags: 0}
+	}
+	run := mp4Run{samples: samples}
+
+	var output bytes.Buffer
+	output.Grow(int(canonicalTrunSize(run)))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		output.Reset()
+		if err := writeCanonicalTrun(&output, &run, 1024); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkBuildSegmentSteadyState(b *testing.B) {
+	const sampleCount = 150
+	const sampleSize = 512
+
+	samples := make([]mp4Sample, sampleCount)
+	for i := range samples {
+		samples[i] = mp4Sample{duration: 1000, size: sampleSize, flags: 0}
+	}
+	payload := make([]byte, sampleCount*sampleSize)
+	fragment := mp4Fragment{
+		trackID:                1,
+		timescale:              1000,
+		decodeTime:             0,
+		duration:               sampleCount * 1000,
+		startsWithSync:         true,
+		sampleDescriptionIndex: 1,
+		tfhd:                   buildCanonicalTfhd(1, 1),
+		runs: []mp4Run{
+			{
+				samples:        samples,
+				duration:       sampleCount * 1000,
+				dataSize:       sampleCount * sampleSize,
+				startsWithSync: true,
+			},
+		},
+		payloadLen: len(payload),
+	}
+
+	reader := Mp4BoxReader(func([]byte) {}, func(Segment) {}, 6, 0, false)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.video = make([]mp4Fragment, 0, 1)
+	reader.sourcePayload.Grow(len(payload))
+
+	build := func() {
+		fragment.decodeTime = uint64(reader.sequence-1) * fragment.duration
+		fragment.payloadStart = reader.sourcePayload.Len()
+		_, _ = reader.sourcePayload.Write(payload)
+		reader.video = append(reader.video, fragment)
+		if err := reader.buildSegment(1, 0, false); err != nil {
+			b.Fatal(err)
+		}
+		reader.ReleaseSegment()
+	}
+
+	build()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		build()
+	}
+}
+
+func BenchmarkParseTraf(b *testing.B) {
+	const sampleCount = 300
+	const trunFlags = trunDataOffsetPresent |
+		trunSampleDurationPresent |
+		trunSampleSizePresent |
+		trunSampleFlagsPresent
+
+	body := make([]byte, 8+sampleCount*12)
+	binary.BigEndian.PutUint32(body[0:4], sampleCount)
+	position := 8
+	for range sampleCount {
+		binary.BigEndian.PutUint32(body[position:position+4], 1024)
+		binary.BigEndian.PutUint32(body[position+4:position+8], 512)
+		binary.BigEndian.PutUint32(body[position+8:position+12], 0)
+		position += 12
+	}
+
+	traf := testBox(
+		boxTraf,
+		testFullBox(boxTfhd, tfhdSampleDescriptionIndexPresent, testU32(1, 1)),
+		testFullBox(boxTfdt, 0, testU32(0)),
+		testFullBox(boxTrun, trunFlags, body),
+	)
+	videoTrack := trackInfo{id: 1, timescale: 48_000}
+	var fragment mp4Fragment
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := parseTraf(traf, 8, videoTrack, trackInfo{}, 0, 0, &fragment); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestBuildSegmentAllowsVideoOnly(t *testing.T) {
+	samples := []mp4Sample{
+		{
+			duration: 1000,
+			size:     3,
+			flags:    0,
+		},
+	}
+	var got Segment
+	reader := Mp4BoxReader(
+		func([]byte) {},
+		func(segment Segment) {
+			got = segment
+		},
+		1,
+		0,
+		false,
+	)
+
+	reader.videoTrack = trackInfo{
+		id:        1,
+		timescale: 1000,
+		trex: trexInfo{
+			descriptionIndex: 1,
+		},
+	}
+	reader.video = []mp4Fragment{
+		appendTestFragmentPayload(reader, mp4Fragment{
+			trackID:                1,
+			timescale:              1000,
+			decodeTime:             0,
+			duration:               1000,
+			startsWithSync:         true,
+			sampleDescriptionIndex: 1,
+			tfhd:                   buildCanonicalTfhd(1, 1),
+			runs: []mp4Run{
+				{
+					samples:        samples,
+					duration:       1000,
+					dataSize:       3,
+					startsWithSync: true,
+				},
+			},
+			payloadLen: 3,
+		}, 0x01),
+	}
+
+	if err := reader.buildSegment(1, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if got.Empty() {
+		t.Fatal("video-only segment is empty")
+	}
+	if len(got.Payloads) != 1 {
+		t.Fatalf("Payloads=%d, want 1", len(got.Payloads))
+	}
+}
+
+func TestReleaseSegmentClearsPayloadReferencesAndKeepsSliceCapacity(t *testing.T) {
+	reader := Mp4BoxReader(func([]byte) {}, func(Segment) {}, 6, 0, false)
+	_, _ = reader.sourcePayload.Write([]byte("payload"))
+	reader.segmentPayloads = append(reader.segmentPayloads, reader.sourcePayload.Bytes())
+	capacity := cap(reader.segmentPayloads)
+
+	reader.ReleaseSegment()
+
+	if len(reader.segmentPayloads) != 0 {
+		t.Fatalf("payload ranges length = %d, want 0", len(reader.segmentPayloads))
+	}
+	if cap(reader.segmentPayloads) != capacity {
+		t.Fatalf("payload ranges capacity = %d, want %d", cap(reader.segmentPayloads), capacity)
+	}
+	for i, payload := range reader.segmentPayloads[:capacity] {
+		if payload != nil {
+			t.Fatalf("payload range %d still retains storage", i)
+		}
+	}
+}
+
+func TestSegmentCarriesEndSecondsForResume(t *testing.T) {
+	var got Segment
+	reader := Mp4BoxReader(
+		func([]byte) {},
+		func(seg Segment) {
+			got = seg
+		},
+		6,
+		0,
+		false,
+	)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.video = []mp4Fragment{
+		appendTestFragmentPayload(reader, testFragment(1, 1000, 0, 1000, 10, true, 0x11), 0x11),
+		appendTestFragmentPayload(reader, testFragment(1, 1000, 1000, 1000, 11, true, 0x22), 0x22),
+	}
+
+	if err := reader.buildSegment(2, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	if got.StartSeconds != 0 {
+		t.Fatalf("start=%v, want 0", got.StartSeconds)
+	}
+	if got.EndSeconds != 2 {
+		t.Fatalf("end=%v, want 2", got.EndSeconds)
+	}
+}
+
+func TestDrainEndOfStreamOrdersRegularRemainderThenTruncation(t *testing.T) {
+	runner, reader, segments := newTestEOSRunner(2)
+
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.audioTrack = trackInfo{}
+
+	reader.video = append(
+		reader.video,
+		appendTestFragmentPayload(reader, testFragment(1, 1000, 0, 1000, 10, true, 0x11), 0x11),
+		appendTestFragmentPayload(reader, testFragment(1, 1000, 1000, 1000, 11, true, 0x22), 0x22),
+		appendTestFragmentPayload(reader, testFragment(1, 1000, 2000, 500, 12, true, 0x33), 0x33),
+	)
+
+	reader.pendingStorage = mp4Fragment{
+		trackID:    1,
+		timescale:  1000,
+		decodeTime: 2500,
+	}
+	reader.pending = &reader.pendingStorage
+	_, _ = reader.sourceMoof.Write(make([]byte, 16))
+	_, _ = reader.sourcePayload.Write([]byte{1, 2, 3})
+	reader.currentBoxType = boxMdat
+	reader.currentBoxRemaining = 7
+
+	regular, err := runner.drainEndOfStream(10)
+	if err != nil {
+		t.Fatalf("regular EOS drain failed: %v", err)
+	}
+	if regular.StartSeconds != 0 {
+		t.Fatalf("regular StartSeconds=%v, want 0", regular.StartSeconds)
+	}
+	if len(reader.video) != 1 {
+		t.Fatalf("video fragments after regular=%d, want 1", len(reader.video))
+	}
+
+	resetTestReady(runner)
+
+	remainder, err := runner.drainEndOfStream(11)
+	if err != nil {
+		t.Fatalf("EOS remainder failed: %v", err)
+	}
+	if remainder.StartSeconds != 2 {
+		t.Fatalf("remainder StartSeconds=%v, want 2", remainder.StartSeconds)
+	}
+	if len(reader.video) != 0 {
+		t.Fatalf("video fragments after remainder=%d, want 0", len(reader.video))
+	}
+
+	resetTestReady(runner)
+
+	_, err = runner.drainEndOfStream(12)
+	if !errors.Is(err, ErrTruncatedMP4Fragment) {
+		t.Fatalf("final error=%v, want ErrTruncatedMP4Fragment", err)
+	}
+
+	if len(*segments) != 2 {
+		t.Fatalf("emitted segments=%d, want 2", len(*segments))
+	}
+}
+
+func TestTryBuildEndOfStreamRemainderAllowsAudioOnly(t *testing.T) {
+	_, reader, segments := newTestEOSRunner(6)
+
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.audioTrack = trackInfo{id: 2, timescale: 48000}
+	reader.audio = append(
+		reader.audio,
+		appendTestFragmentPayload(reader, testFragment(2, 48000, 144000, 48000, 32, true, 0x44), 0x44),
+	)
+
+	completed, err := reader.TryBuildEndOfStreamRemainder()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !completed {
+		t.Fatal("audio-only remainder was not completed")
+	}
+	if len(reader.audio) != 0 {
+		t.Fatalf("remaining audio fragments=%d, want 0", len(reader.audio))
+	}
+	if len(*segments) != 1 {
+		t.Fatalf("emitted segments=%d, want 1", len(*segments))
+	}
+	if (*segments)[0].StartSeconds != 3 {
+		t.Fatalf("StartSeconds=%v, want 3", (*segments)[0].StartSeconds)
+	}
+}
+
+func TestTryBuildEndOfStreamRemainderDoesNotEmitNonSyncVideo(t *testing.T) {
+	_, reader, segments := newTestEOSRunner(6)
+
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.video = append(
+		reader.video,
+		appendTestFragmentPayload(reader, testFragment(1, 1000, 1000, 1000, 16, false, 0x55), 0x55),
+	)
+
+	completed, err := reader.TryBuildEndOfStreamRemainder()
+	if completed {
+		t.Fatal("non-sync video remainder must not be emitted")
+	}
+	if err != nil {
+		t.Fatalf("error=%v, want nil for a non-sync EOS tail", err)
+	}
+	if len(*segments) != 0 {
+		t.Fatalf("emitted segments=%d, want 0", len(*segments))
+	}
+	if len(reader.video) != 1 {
+		t.Fatalf("video fragments=%d, want retained 1", len(reader.video))
+	}
+}
+
+func TestNormalizeTrunRejectsExcessiveSampleCountBeforeAllocation(t *testing.T) {
+	box := make([]byte, 16)
+	binary.BigEndian.PutUint32(box[0:4], uint32(len(box)))
+	binary.BigEndian.PutUint32(box[4:8], boxTrun)
+	binary.BigEndian.PutUint32(box[12:16], maxTrunSamples+1)
+
+	_, err := normalizeTrun(box, 8, 1, 1, 0, false)
+	if err == nil || !strings.Contains(err.Error(), "sample_count exceeds safety limit") {
+		t.Fatalf("error=%v, want sample_count safety error", err)
+	}
+}
+
+func TestDrainEndOfStreamReturnsUndecodableRemainder(t *testing.T) {
+	runner, reader, _ := newTestEOSRunner(6)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.video = append(reader.video, appendTestFragmentPayload(reader, testFragment(1, 1000, 1000, 1000, 16, false, 0x55), 0x55))
+
+	_, err := runner.drainEndOfStream(100)
+	if !errors.Is(err, ErrUndecodableEOSRemainder) {
+		t.Fatalf("error=%v, want ErrUndecodableEOSRemainder", err)
+	}
+}
+
+func TestDrainEndOfStreamReturnsCleanExhaustion(t *testing.T) {
+	runner, reader, _ := newTestEOSRunner(6)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+
+	_, err := runner.drainEndOfStream(100)
+	if !errors.Is(err, ErrEndOfStreamExhausted) {
+		t.Fatalf("error=%v, want ErrEndOfStreamExhausted", err)
+	}
+}
+
+func TestFinishEndOfStreamFreezesOnReaderError(t *testing.T) {
+	runner, reader, _ := newTestEOSRunner(6)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+	reader.video = append(reader.video, appendTestFragmentPayload(reader, testFragment(1, 1000, 1000, 1000, 16, false, 0x55), 0x55))
+	runner.task.setInitMP4([]byte{1, 2, 3})
+
+	_, err := runner.finishEndOfStream(100)
+	if !errors.Is(err, ErrUndecodableEOSRemainder) {
+		t.Fatalf("error=%v, want ErrUndecodableEOSRemainder", err)
+	}
+	if !runner.IsFrozen() || runner.reader != nil {
+		t.Fatal("reader error did not freeze and release the runner")
+	}
+	if runner.task.hasInitMP4() {
+		t.Fatal("reader error retained init mp4")
+	}
+}
+
+func TestFinishEndOfStreamKeepsCleanExhaustion(t *testing.T) {
+	runner, reader, _ := newTestEOSRunner(6)
+	reader.videoTrack = trackInfo{id: 1, timescale: 1000}
+
+	_, err := runner.finishEndOfStream(100)
+	if !errors.Is(err, ErrEndOfStreamExhausted) {
+		t.Fatalf("error=%v, want ErrEndOfStreamExhausted", err)
+	}
+	if runner.IsFrozen() || runner.reader != reader {
+		t.Fatal("clean end of stream unexpectedly froze the runner")
+	}
+}
+
+func TestAddTfdtOffsetNoOffset(t *testing.T) {
+	got, err := addTfdtOffset(100, 1000, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 100 {
+		t.Fatalf("got %d, want 100", got)
+	}
+}
+
+func TestAddTfdtOffsetValid(t *testing.T) {
+	got, err := addTfdtOffset(100, 1000, 1.5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1600 {
+		t.Fatalf("got %d, want 1600", got)
+	}
+}
+
+func TestAddTfdtOffsetInvalidSeconds(t *testing.T) {
+	if _, err := addTfdtOffset(100, 1000, math.Inf(1)); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAddTfdtOffsetOverflow(t *testing.T) {
+	if _, err := addTfdtOffset(math.MaxUint64-10, 1000, 1); err == nil {
+		t.Fatal("expected overflow error")
+	}
+}

--- a/server/gstreamer/pipeline_gst.go
+++ b/server/gstreamer/pipeline_gst.go
@@ -96,14 +96,16 @@ func (r *gstRunner) ensureTransientState() {
 		r.subtitleSinks = make(map[int]uintptr)
 	}
 	if r.subtitleStores == nil {
-		r.subtitleStores = make(map[int]*subtitleStore)
+		stores := make(map[int]*subtitleStore)
 		if r.task.Config.Subtitles {
 			for _, track := range r.task.Probe.Tracks {
 				if supportedSubtitleTrack(track) {
-					r.subtitleStores[track.Index] = newSubtitleStore()
+					stores[track.Index] = newSubtitleStore()
 				}
 			}
 		}
+		r.subtitleStores = stores
+		r.task.setSubtitleStores(stores)
 	}
 	if r.reader != nil {
 		return
@@ -128,6 +130,7 @@ func (r *gstRunner) ensureTransientState() {
 
 func (r *gstRunner) releaseTransientState() {
 	r.reader = nil
+	r.task.setSubtitleStores(nil)
 	r.subtitleStores = nil
 	r.subtitleSinks = nil
 	_ = r.takeBusError()
@@ -707,6 +710,7 @@ func videoIsTranscoded(conf Config, probe ProbeInfo) bool {
 func (r *gstRunner) Seek(seconds float64) bool {
 	r.ensureTransientState()
 	r.discardReadySegment()
+	r.resetSubtitleProgress(seconds)
 	wasFrozen := r.IsFrozen()
 	reuse := r.pipeline != 0
 	accurate := r.task.Cue != nil
@@ -726,6 +730,7 @@ func (r *gstRunner) Seek(seconds float64) bool {
 		return false
 	}
 	r.reader.SeekReset(actualSeconds)
+	r.resetSubtitleProgress(actualSeconds)
 
 	r.frozen.Store(false)
 	r.setPosition(actualSeconds)
@@ -1226,6 +1231,11 @@ func (r *gstRunner) completeReadySegment(index int) Segment {
 	} else {
 		r.readySegment.index = 0
 	}
+	_, videoReadTo := r.task.subtitleRange(index)
+	if r.readySegment.segment.EndNS > videoReadTo {
+		videoReadTo = r.readySegment.segment.EndNS
+	}
+	r.advanceSubtitleProgress(videoReadTo)
 	return r.readySegment.segment
 }
 
@@ -1397,6 +1407,7 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 	r.bus = bus
 	r.sink = sink
 	r.subtitleSinks = subtitleSinks
+	r.resetSubtitleProgress(actualStartSeconds)
 	r.startBusWatch()
 	gstTaskDebugf(r.task, "pipeline started requested=%.3fs actual=%.3fs audio=%d", seconds, actualStartSeconds, r.audioIndex)
 	return actualStartSeconds, nil

--- a/server/gstreamer/pipeline_gst.go
+++ b/server/gstreamer/pipeline_gst.go
@@ -28,8 +28,9 @@ var (
 const (
 	defaultAACChannels   = 2
 	defaultAACSampleRate = 48000
-	pipelineReadTimeout  = 20 * time.Second
+	pipelineReadTimeout  = 45 * time.Second
 	pipelineStateTimeout = 5 * time.Second
+	pipelineEOSBackoff   = 120 * time.Second
 	gstPollInterval      = 100 * time.Millisecond
 )
 
@@ -756,8 +757,12 @@ func (r *gstRunner) reusePipeline(seconds float64, accurate bool, waitTimeout ti
 	if videoTimestamper != 0 {
 		defer gstRuntime.objectUnref(videoTimestamper)
 	}
-	videoEncoder := gstRuntime.binGetByName(r.pipeline, "video_encoder")
-	if videoEncoder != 0 {
+	var videoEncoder uintptr
+	if videoIsTranscoded(r.task.Config, r.task.Probe) {
+		videoEncoder = gstRuntime.binGetByName(r.pipeline, "video_encoder")
+		if videoEncoder == 0 {
+			return 0, errors.New("video encoder is not available for seek reset")
+		}
 		defer gstRuntime.objectUnref(videoEncoder)
 	}
 
@@ -1004,7 +1009,13 @@ func (r *gstRunner) pullOutputSample() (bool, error) {
 		if err := r.pollPipelineError(); err != nil {
 			return false, err
 		}
-		return gstRuntime.appSinkIsEOS(r.sink), nil
+		if !gstRuntime.appSinkIsEOS(r.sink) {
+			return false, nil
+		}
+		if err := r.earlyEndOfStreamError(); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 	defer gstRuntime.sampleUnref(sample)
 	r.applyPendingVideoStart()
@@ -1074,7 +1085,40 @@ func (r *gstRunner) watchBus(bus uintptr, generation uint64, cancel <-chan struc
 			go r.freezeBusGeneration(generation)
 			return
 		}
+		if gstRuntime.popBusMessage(bus, 0, gstMessageEOS) {
+			if err := r.earlyEndOfStreamError(); err != nil {
+				gstTaskErrorf(r.task, "pipeline bus failed at %.3fs: %v", r.position(), err)
+				r.storeBusError(err)
+				go r.freezeBusGeneration(generation)
+			}
+			return
+		}
 	}
+}
+
+func (r *gstRunner) earlyEndOfStreamError() error {
+	if r.task == nil || r.task.Probe.DurationNS <= 0 {
+		return nil
+	}
+
+	durationSeconds := float64(r.task.Probe.DurationNS) / float64(time.Second)
+	thresholdSeconds := durationSeconds - pipelineEOSBackoff.Seconds()
+	if thresholdSeconds < 0 {
+		thresholdSeconds = 0
+	}
+
+	positionSeconds := r.position()
+	if !math.IsNaN(positionSeconds) && !math.IsInf(positionSeconds, 0) && positionSeconds >= thresholdSeconds {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: position=%.3fs threshold=%.3fs duration=%.3fs",
+		ErrEarlyEndOfStream,
+		positionSeconds,
+		thresholdSeconds,
+		durationSeconds,
+	)
 }
 
 func (r *gstRunner) freezeBusGeneration(generation uint64) {

--- a/server/gstreamer/pipeline_gst.go
+++ b/server/gstreamer/pipeline_gst.go
@@ -53,11 +53,13 @@ type gstRunner struct {
 
 	reader *mp4BoxReader
 
-	pipeline       uintptr
-	bus            uintptr
-	sink           uintptr
-	subtitleSinks  map[int]uintptr
-	subtitleStores map[int]*subtitleStore
+	pipeline        uintptr
+	bus             uintptr
+	sink            uintptr
+	subtitleSinks   map[int]uintptr
+	subtitleStores  map[int]*subtitleStore
+	videoStartProbe *gstPadProbeRegistration
+	videoClipProbe  *gstPadProbeRegistration
 
 	watchMu     sync.Mutex
 	watchCancel chan struct{}
@@ -712,7 +714,7 @@ func (r *gstRunner) Seek(seconds float64) bool {
 	var actualSeconds float64
 	var err error
 	if reuse {
-		actualSeconds, err = r.reusePipeline(seconds, accurate)
+		actualSeconds, err = r.reusePipeline(seconds, accurate, pipelineStateTimeout)
 	} else {
 		r.reader.SeekReset(seconds)
 		actualSeconds, err = r.startPipeline(seconds)
@@ -735,7 +737,7 @@ func (r *gstRunner) Seek(seconds float64) bool {
 	return true
 }
 
-func (r *gstRunner) reusePipeline(seconds float64, accurate bool) (float64, error) {
+func (r *gstRunner) reusePipeline(seconds float64, accurate bool, waitTimeout time.Duration) (float64, error) {
 	if r.pipeline == 0 || r.bus == 0 || r.sink == 0 {
 		return 0, errors.New("pipeline cannot be reused")
 	}
@@ -779,8 +781,23 @@ func (r *gstRunner) reusePipeline(seconds float64, accurate bool) (float64, erro
 		flags |= gstSeekFlagAccurate
 	}
 	seekNS := int64(math.Round(seconds * 1_000_000_000))
+	if seekNS < 0 {
+		return 0, errors.New("gstreamer seek position is negative")
+	}
+	r.installVideoSeekProbes(r.pipeline, uint64(seekNS), accurate)
+	if err := gstRuntime.popBusError(r.bus, 0); err != nil {
+		return 0, err
+	}
+	gstRuntime.drainBusMessages(r.bus, gstMessageAsyncDone|gstMessageEOS)
 	if err := sendVideoSeekEvent(r.pipeline, flags, seekNS); err != nil {
 		return 0, fmt.Errorf("gstreamer seek failed while reusing pipeline: %w", err)
+	}
+	asyncDone, err := gstRuntime.waitForSeekDone(r.bus, waitTimeout)
+	if err != nil {
+		return 0, fmt.Errorf("gstreamer seek did not finish while reusing pipeline: %w", err)
+	}
+	if !asyncDone {
+		gstTaskDebugf(r.task, "seek ASYNC_DONE not observed at %.3fs; validating pipeline state", seconds)
 	}
 
 	waitResult := gstRuntime.elementGetState(r.pipeline, pipelineStateTimeout)
@@ -791,10 +808,7 @@ func (r *gstRunner) reusePipeline(seconds float64, accurate bool) (float64, erro
 		return 0, fmt.Errorf("gstreamer seek state=%d while reusing pipeline", waitResult)
 	}
 
-	actualSeconds := seconds
-	if positionNS, ok := gstRuntime.elementQueryPosition(r.pipeline); ok && positionNS >= 0 {
-		actualSeconds = float64(positionNS) / 1_000_000_000
-	}
+	actualSeconds := r.querySeekPosition(r.pipeline, seconds)
 	if err := r.setPipelineState(r.pipeline, r.bus, gstStatePlaying); err != nil {
 		return 0, fmt.Errorf("resume pipeline after seek: %w", err)
 	}
@@ -819,6 +833,15 @@ func sendVideoSeekEvent(pipeline uintptr, flags int32, positionNS int64) error {
 		return errors.New("video seek event returned false")
 	}
 	return nil
+}
+
+func (r *gstRunner) querySeekPosition(pipeline uintptr, requestedSeconds float64) float64 {
+	if positionNS, ok := gstRuntime.elementQueryPosition(pipeline); ok {
+		return float64(positionNS) / 1_000_000_000
+	}
+
+	gstTaskDebugf(r.task, "position query unavailable or invalid after seek; using requested=%.3fs", requestedSeconds)
+	return requestedSeconds
 }
 
 func (r *gstRunner) EnsureInit(ctx context.Context, audio int, startIndex int) error {
@@ -984,6 +1007,7 @@ func (r *gstRunner) pullOutputSample() (bool, error) {
 		return gstRuntime.appSinkIsEOS(r.sink), nil
 	}
 	defer gstRuntime.sampleUnref(sample)
+	r.applyPendingVideoStart()
 
 	if err := gstRuntime.withSampleBytes(sample, func(data []byte) error {
 		if len(data) == 0 {
@@ -1251,6 +1275,7 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 	actualStartSeconds := seconds
 
 	cleanup := func() {
+		r.removeVideoSeekProbes()
 		gstRuntime.elementSetState(pipeline, gstStateNull)
 		gstRuntime.objectUnref(sink)
 		gstRuntime.objectUnref(pipeline)
@@ -1270,9 +1295,28 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 		if r.task.Cue != nil {
 			flags |= gstSeekFlagAccurate
 		}
-		if err := sendVideoSeekEvent(pipeline, flags, int64(math.Round(seconds*1_000_000_000))); err != nil {
+		if err := gstRuntime.popBusError(bus, 0); err != nil {
+			cleanup()
+			return 0, err
+		}
+		gstRuntime.drainBusMessages(bus, gstMessageAsyncDone|gstMessageEOS)
+		seekNS := int64(math.Round(seconds * 1_000_000_000))
+		if seekNS < 0 {
+			cleanup()
+			return 0, errors.New("gstreamer seek position is negative")
+		}
+		r.installVideoSeekProbes(pipeline, uint64(seekNS), r.task.Cue != nil)
+		if err := sendVideoSeekEvent(pipeline, flags, seekNS); err != nil {
 			cleanup()
 			return 0, fmt.Errorf("gstreamer seek failed: %w", err)
+		}
+		asyncDone, err := gstRuntime.waitForSeekDone(bus, pipelineStateTimeout)
+		if err != nil {
+			cleanup()
+			return 0, fmt.Errorf("gstreamer seek did not finish: %w", err)
+		}
+		if !asyncDone {
+			gstTaskDebugf(r.task, "initial seek ASYNC_DONE not observed at %.3fs; validating pipeline state", seconds)
 		}
 
 		waitResult := gstRuntime.elementGetState(pipeline, pipelineStateTimeout)
@@ -1297,11 +1341,7 @@ func (r *gstRunner) startPipeline(seconds float64) (float64, error) {
 			return 0, fmt.Errorf("unexpected GstStateChangeReturn=%d after seek", waitResult)
 		}
 
-		if positionNS, ok := gstRuntime.elementQueryPosition(pipeline); ok {
-			actualStartSeconds = float64(positionNS) / 1_000_000_000.0
-		} else {
-			gstTaskDebugf(r.task, "position query unavailable after seek; using requested=%.3fs", seconds)
-		}
+		actualStartSeconds = r.querySeekPosition(pipeline, seconds)
 	}
 
 	if err := r.setPipelineState(pipeline, bus, gstStatePlaying); err != nil {
@@ -1351,6 +1391,7 @@ func (r *gstRunner) setPipelineState(pipeline uintptr, bus uintptr, state int32)
 
 func (r *gstRunner) stopPipeline() {
 	r.stopBusWatch()
+	r.removeVideoSeekProbes()
 	if r.pipeline != 0 {
 		_ = gstRuntime.elementSetState(r.pipeline, gstStateNull)
 	}

--- a/server/gstreamer/pipeline_gst_test.go
+++ b/server/gstreamer/pipeline_gst_test.go
@@ -1,0 +1,1385 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"context"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func TestCreatePipelineArgsUsesSingleBufferAppSink(t *testing.T) {
+	runner := &gstRunner{
+		task: &Task{
+			SourceURL: "http://127.0.0.1/video",
+			Config:    Config{}.normalized(),
+			Probe: ProbeInfo{
+				Container: "Matroska",
+				Tracks: []TrackInfo{
+					{
+						Type:     "video",
+						Index:    0,
+						CapsName: "video/x-h264",
+					},
+				},
+			},
+		},
+		audioIndex: -1,
+	}
+
+	args := runner.createPipelineArgs()
+	want := "appsink name=out emit-signals=false sync=false max-buffers=1"
+	if !strings.Contains(args, want) {
+		t.Fatalf("createPipelineArgs() appsink =\n%s\nwant %q", args, want)
+	}
+	if strings.Contains(args, "queue2") || strings.Contains(args, "temp-template=") {
+		t.Fatalf("createPipelineArgs() must rely on TorrServer cache, got:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsUsesMultiqueueWithoutBranchQueueLimits(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	args := newVersionedVideoPipelineRunner(1.28).createPipelineArgs()
+
+	for _, want := range []string{
+		"multiqueue name=mq use-buffering=false max-size-buffers=5",
+		"d.video_0 ! mq.sink_0",
+		"mq.src_0 ! h264parse",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("createPipelineArgs() =\n%s\nwant %q", args, want)
+		}
+	}
+	if strings.Contains(args, "d.video_0 ! queue ") || strings.Contains(args, " leaky=0 !") {
+		t.Fatalf("createPipelineArgs() must not use per-branch queue limits:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsCopiesAACAudio(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.audioIndex = 1
+	runner.task.Probe.Tracks = append(runner.task.Probe.Tracks,
+		TrackInfo{Type: "audio", Index: 0, Codec: "AC-3", CapsName: "audio/x-ac3"},
+		TrackInfo{Type: "audio", Index: 1, Codec: "MPEG-4 AAC", CapsName: "audio/mpeg"},
+	)
+
+	args := runner.createPipelineArgs()
+	want := "d.audio_1 ! mq.sink_1 mq.src_1 ! aacparse ! audio/mpeg,mpegversion=4,stream-format=raw ! mux.audio_0"
+	if !strings.Contains(args, want) {
+		t.Fatalf("createPipelineArgs() =\n%s\nwant %q", args, want)
+	}
+	for _, forbidden := range []string{"decodebin ! audioconvert", "avenc_aac bitrate="} {
+		if strings.Contains(args, forbidden) {
+			t.Fatalf("AAC copy pipeline must not contain %q:\n%s", forbidden, args)
+		}
+	}
+}
+
+func TestCreatePipelineArgsEncodesNonAACAudio(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.audioIndex = 0
+	runner.task.Probe.Tracks = append(runner.task.Probe.Tracks,
+		TrackInfo{Type: "audio", Index: 0, Codec: "AC-3", CapsName: "audio/x-ac3"},
+	)
+
+	args := runner.createPipelineArgs()
+	for _, want := range []string{
+		"d.audio_0 ! mq.sink_1 mq.src_1 ! decodebin ! audioconvert",
+		"avenc_aac bitrate=",
+		"aacparse ! audio/mpeg,mpegversion=4,stream-format=raw,rate=48000,channels=2 ! mux.audio_0",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("createPipelineArgs() =\n%s\nwant %q", args, want)
+		}
+	}
+}
+
+func TestCreatePipelineArgsUsesProbeAudioCapsWhenConfigAuto(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.audioIndex = 0
+	runner.task.Probe.Tracks = append(runner.task.Probe.Tracks,
+		TrackInfo{
+			Type:     "audio",
+			Index:    0,
+			Codec:    "AC-3",
+			CapsName: "audio/x-ac3",
+			Channels: 6,
+			Rate:     44100,
+		},
+	)
+
+	args := runner.createPipelineArgs()
+	for _, want := range []string{
+		"audio/x-raw,format=F32LE,layout=interleaved,rate=44100,channels=6,channel-mask=(bitmask)0x000000000000003f",
+		"aacparse ! audio/mpeg,mpegversion=4,stream-format=raw,rate=44100,channels=6 ! mux.audio_0",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("createPipelineArgs() =\n%s\nwant %q", args, want)
+		}
+	}
+}
+
+func TestCreatePipelineArgsConfigOverridesProbeAudioCaps(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.audioIndex = 0
+	runner.task.Config.AACChannels = 1
+	runner.task.Config.AACSamplerate = 32000
+	runner.task.Probe.Tracks = append(runner.task.Probe.Tracks,
+		TrackInfo{
+			Type:     "audio",
+			Index:    0,
+			Codec:    "AC-3",
+			CapsName: "audio/x-ac3",
+			Channels: 6,
+			Rate:     44100,
+		},
+	)
+
+	args := runner.createPipelineArgs()
+	for _, want := range []string{
+		"audio/x-raw,format=F32LE,layout=interleaved,rate=32000,channels=1",
+		"aacparse ! audio/mpeg,mpegversion=4,stream-format=raw,rate=32000,channels=1 ! mux.audio_0",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("createPipelineArgs() =\n%s\nwant %q", args, want)
+		}
+	}
+}
+
+func TestCreatePipelineArgsMultiqueueUsesFixedLimits(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.task.Config.SegmentSeconds = 7
+
+	args := runner.createPipelineArgs()
+	want := "multiqueue name=mq use-buffering=false max-size-buffers=5 max-size-bytes=0 max-size-time=0"
+	if !strings.Contains(args, want) {
+		t.Fatalf("createPipelineArgs() =\n%s\nwant %q", args, want)
+	}
+	mqEnd := strings.Index(args, " d.video_0 ! mq.sink_0")
+	if mqEnd < 0 {
+		t.Fatalf("createPipelineArgs() missing video branch:\n%s", args)
+	}
+	mqStart := strings.Index(args, "multiqueue name=mq")
+	if mqStart < 0 {
+		t.Fatalf("createPipelineArgs() missing multiqueue:\n%s", args)
+	}
+	mqArgs := args[mqStart:mqEnd]
+	if !strings.Contains(mqArgs, "max-size-bytes=0") || !strings.Contains(mqArgs, "max-size-time=0") {
+		t.Fatalf("multiqueue must explicitly disable byte/time limits:\n%s", mqArgs)
+	}
+}
+
+func TestCreatePipelineArgsGStreamer122OmitsNewerProperties(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	args := newVersionedVideoPipelineRunner(1.22).createPipelineArgs()
+
+	if strings.Contains(args, " retry-backoff-factor=") || strings.Contains(args, " retry-backoff-max=") {
+		t.Fatalf("GStreamer 1.22 pipeline must not contain 1.26 souphttpsrc retry-backoff properties:\n%s", args)
+	}
+	if !strings.Contains(args, " max-buffers=1") {
+		t.Fatalf("GStreamer 1.22 pipeline must use one appsink buffer:\n%s", args)
+	}
+	if strings.Contains(args, " leaky-type=") {
+		t.Fatalf("GStreamer 1.22 pipeline must not contain 1.28 appsink leaky-type property:\n%s", args)
+	}
+	if !strings.Contains(args, " drop=false") {
+		t.Fatalf("GStreamer 1.22 pipeline must use appsink drop=false fallback:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsGStreamer124UsesSingleAppSinkBuffer(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	args := newVersionedVideoPipelineRunner(1.24).createPipelineArgs()
+
+	if strings.Contains(args, " retry-backoff-factor=") || strings.Contains(args, " retry-backoff-max=") {
+		t.Fatalf("GStreamer 1.24 pipeline must not contain 1.26 retry-backoff properties:\n%s", args)
+	}
+	if !strings.Contains(args, "max-buffers=1") || strings.Contains(args, "max-bytes=") {
+		t.Fatalf("GStreamer 1.24 pipeline must use one appsink buffer without byte limit:\n%s", args)
+	}
+	if !strings.Contains(args, " drop=false") {
+		t.Fatalf("GStreamer 1.24 pipeline must use drop=false fallback before 1.28:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsAppSinkOmitsByteLimit(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	runner := newVersionedVideoPipelineRunner(1.28)
+	args := runner.createPipelineArgs()
+
+	if !strings.Contains(args, " max-buffers=1") {
+		t.Fatalf("pipeline must use max-buffers=1:\n%s", args)
+	}
+	if strings.Contains(args, " max-bytes=") || strings.Contains(args, " max-time=") {
+		t.Fatalf("appsink must not use byte/time limits:\n%s", args)
+	}
+	if !strings.Contains(args, " leaky-type=none") {
+		t.Fatalf("GStreamer 1.28+ pipeline must use appsink leaky-type:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsGStreamer126UsesSoupRetryBackoff(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	args := newVersionedVideoPipelineRunner(1.26).createPipelineArgs()
+
+	if !strings.Contains(args, " retry-backoff-factor=0.5 retry-backoff-max=10") {
+		t.Fatalf("GStreamer 1.26+ pipeline must contain souphttpsrc retry-backoff properties:\n%s", args)
+	}
+	if !strings.Contains(args, "max-buffers=1") || strings.Contains(args, "max-bytes=") {
+		t.Fatalf("GStreamer 1.26 pipeline must use one appsink buffer without byte limit:\n%s", args)
+	}
+	if !strings.Contains(args, " drop=false") {
+		t.Fatalf("GStreamer 1.26 pipeline must use drop=false fallback before 1.28:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsGStreamer128UsesAppSinkLeakyType(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+
+	args := newVersionedVideoPipelineRunner(1.28).createPipelineArgs()
+
+	if !strings.Contains(args, "max-buffers=1") || strings.Contains(args, "max-bytes=") {
+		t.Fatalf("GStreamer 1.28 pipeline must use one appsink buffer without byte limit:\n%s", args)
+	}
+	if !strings.Contains(args, " leaky-type=none") {
+		t.Fatalf("GStreamer 1.28+ pipeline must use appsink leaky-type:\n%s", args)
+	}
+	if strings.Contains(args, " drop=false") {
+		t.Fatalf("GStreamer 1.28+ pipeline must not use deprecated appsink drop property:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsUsesRuntimeVersionWhenAvailable(t *testing.T) {
+	previous := gstRuntime
+	gstRuntime = &gstAPI{version: gstVersionInfo{major: 1, minor: 22}}
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	args := newVersionedVideoPipelineRunner(1.28).createPipelineArgs()
+
+	if strings.Contains(args, " max-bytes=") || strings.Contains(args, " max-time=") || strings.Contains(args, " leaky-type=none") {
+		t.Fatalf("runtime GStreamer 1.22 version must override config feature gates:\n%s", args)
+	}
+	if !strings.Contains(args, " max-buffers=1") {
+		t.Fatalf("runtime GStreamer 1.22 pipeline must use one appsink buffer:\n%s", args)
+	}
+	if !strings.Contains(args, " drop=false") {
+		t.Fatalf("runtime GStreamer 1.22 pipeline must use drop=false fallback:\n%s", args)
+	}
+}
+
+func clearGStreamerRuntimeVersion(t *testing.T) {
+	t.Helper()
+
+	previous := gstRuntime
+	gstRuntime = nil
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+}
+
+func newVersionedVideoPipelineRunner(gstVersion float64) *gstRunner {
+	return &gstRunner{
+		task: &Task{
+			SourceURL: "http://127.0.0.1/video",
+			Config: Config{
+				GSTVersion: gstVersion,
+			}.normalized(),
+			Probe: ProbeInfo{
+				Container: "Matroska",
+				Tracks: []TrackInfo{
+					{
+						Type:     "video",
+						Index:    0,
+						CapsName: "video/x-h264",
+					},
+				},
+			},
+		},
+		audioIndex: -1,
+	}
+}
+
+func TestAACEncoderDefaultsToLibAV(t *testing.T) {
+	runner := &gstRunner{}
+
+	if got := runner.aacEncoder(); got != "avenc_aac" {
+		t.Fatalf("aacEncoder() = %q, want avenc_aac", got)
+	}
+}
+
+func TestGSTRuntimeRootsPreferUserPath(t *testing.T) {
+	userRoot := makeFakeGSTRoot(t)
+
+	roots := gstRuntimeRoots(Config{GSTPath: userRoot})
+	if len(roots) == 0 {
+		t.Fatalf("gstRuntimeRoots() returned no roots, want user path %q", userRoot)
+	}
+	if !sameTestPath(roots[0], userRoot) {
+		t.Fatalf("gstRuntimeRoots()[0] = %q, want user path %q; roots=%v", roots[0], userRoot, roots)
+	}
+
+	probeRoots := gstDiscovererRoots(Config{GSTPath: userRoot})
+	if len(probeRoots) == 0 {
+		t.Fatalf("gstDiscovererRoots() returned no roots, want user path %q", userRoot)
+	}
+	if !sameTestPath(probeRoots[0], userRoot) {
+		t.Fatalf("gstDiscovererRoots()[0] = %q, want user path %q; roots=%v", probeRoots[0], userRoot, probeRoots)
+	}
+}
+
+func TestGSTRuntimeRootsSkipInvalidUserPath(t *testing.T) {
+	invalidRoot := t.TempDir()
+
+	for _, root := range gstRuntimeRoots(Config{GSTPath: invalidRoot}) {
+		if sameTestPath(root, invalidRoot) {
+			t.Fatalf("gstRuntimeRoots() included invalid user path %q: %v", invalidRoot, root)
+		}
+	}
+	for _, root := range gstDiscovererRoots(Config{GSTPath: invalidRoot}) {
+		if sameTestPath(root, invalidRoot) {
+			t.Fatalf("gstDiscovererRoots() included invalid user path %q: %v", invalidRoot, root)
+		}
+	}
+}
+
+func makeFakeGSTRoot(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	var baseLib string
+	switch runtime.GOOS {
+	case "windows":
+		baseLib = filepath.Join(root, "bin", "libgstreamer-1.0-0.dll")
+	case "darwin":
+		baseLib = filepath.Join(root, "lib", "libgstreamer-1.0.0.dylib")
+	default:
+		baseLib = filepath.Join(root, "lib", "libgstreamer-1.0.so.0")
+	}
+	if err := os.MkdirAll(filepath.Dir(baseLib), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(baseLib, []byte("fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func sameTestPath(a, b string) bool {
+	return strings.EqualFold(filepath.Clean(a), filepath.Clean(b))
+}
+
+func TestVideoOnlyPipelineHasNoAudioBranch(t *testing.T) {
+	runner := &gstRunner{
+		task: &Task{
+			SourceURL: "http://127.0.0.1/video",
+			Config:    Config{}.normalized(),
+			Probe: ProbeInfo{
+				Container: "Matroska",
+				Tracks: []TrackInfo{
+					{
+						Type:     "video",
+						Index:    0,
+						CapsName: "video/x-h264",
+					},
+				},
+			},
+		},
+		audioIndex: -1,
+	}
+
+	args := runner.createPipelineArgs()
+
+	if strings.Contains(args, "d.audio_") {
+		t.Fatalf("video-only pipeline contains audio branch:\n%s", args)
+	}
+	if !strings.Contains(args, "mux.video_0") {
+		t.Fatalf("video branch is absent:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsTranscodesVP8(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.task.Probe.Tracks[0].CapsName = "video/x-vp8"
+	runner.task.Config.TranscodeVP8 = true
+
+	args := runner.createPipelineArgs()
+	if !strings.Contains(args, "mq.src_0 ! decodebin ! videoconvert ! video/x-raw,format=I420 ! x264enc") {
+		t.Fatalf("VP8 transcode branch is absent:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsTranscodesAVI(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.task.Probe.Container = "AVI"
+	runner.task.Probe.ContainerCapsName = "video/x-msvideo"
+	runner.task.Config.TranscodeAVI = true
+
+	args := runner.createPipelineArgs()
+	for _, want := range []string{"avidemux name=d", "mq.src_0 ! decodebin", "x264enc name=video_encoder"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("AVI transcode pipeline is missing %q:\n%s", want, args)
+		}
+	}
+}
+
+func TestCreatePipelineArgsToneMapsHDR(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.task.Probe.Tracks[0].CapsName = "video/x-h265"
+	runner.task.Probe.Tracks[0].VideoTransfer = "pq"
+	runner.task.Config.HDRToSDR = true
+	runner.task.Config.UseGPU = false
+
+	args := runner.createPipelineArgs()
+	if !strings.Contains(args, "decodebin ! hdrtonemap transfer=pq use-opencl=false ! video/x-raw,format=I420 ! x264enc") {
+		t.Fatalf("HDR tone mapping branch is absent:\n%s", args)
+	}
+}
+
+func TestCreatePipelineArgsUsesX264Ultrafast(t *testing.T) {
+	clearGStreamerRuntimeVersion(t)
+	runner := newVersionedVideoPipelineRunner(1.28)
+	runner.task.Config.TranscodeH264 = true
+	runner.task.Config.X264Ultrafast = true
+
+	args := runner.createPipelineArgs()
+	if !strings.Contains(args, "x264enc name=video_encoder tune=zerolatency speed-preset=ultrafast") {
+		t.Fatalf("x264 ultrafast preset is absent:\n%s", args)
+	}
+}
+
+func TestSetPipelineStateRejectsAsyncTimeout(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	gstRuntime = &gstAPI{
+		gstElementSetState: func(uintptr, int32) int32 {
+			return gstStateChangeAsync
+		},
+		gstElementGetState: func(uintptr, unsafe.Pointer, unsafe.Pointer, uint64) int32 {
+			return gstStateChangeAsync
+		},
+		gstBusTimedPopFiltered: func(uintptr, uint64, int32) uintptr {
+			return 0
+		},
+	}
+
+	err := (&gstRunner{}).setPipelineState(1, 2, gstStatePlaying)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStartPipelineUsesActualQueriedSeekPosition(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	var seekPad uintptr
+	var seekPosition int64
+	seekPending := false
+	gstRuntime = &gstAPI{
+		gstParseLaunch: func(string, unsafe.Pointer) uintptr { return 1 },
+		gstBinGetByName: func(_ uintptr, name string) uintptr {
+			if name == "mq" {
+				return 4
+			}
+			return 2
+		},
+		gstPipelineGetBus: func(uintptr) uintptr { return 3 },
+		gstElementSetState: func(uintptr, int32) int32 {
+			return gstStateChangeSuccess
+		},
+		gstElementGetState: func(uintptr, unsafe.Pointer, unsafe.Pointer, uint64) int32 {
+			return gstStateChangeSuccess
+		},
+		gstElementGetStaticPad: func(element uintptr, name string) uintptr {
+			if element != 4 || name != "src_0" {
+				t.Fatalf("unexpected seek target: element=%d pad=%q", element, name)
+			}
+			return 5
+		},
+		gstEventNewSeek: func(rate float64, format int32, flags int32, startType int32, start int64, stopType int32, stop int64) uintptr {
+			if rate != 1 || format != gstFormatTime || startType != gstSeekTypeSet || stopType != gstSeekTypeNone || stop != -1 {
+				t.Fatalf("unexpected seek event: rate=%v format=%d flags=%d startType=%d start=%d stopType=%d stop=%d", rate, format, flags, startType, start, stopType, stop)
+			}
+			seekPosition = start
+			return 6
+		},
+		gstPadSendEvent: func(pad uintptr, event uintptr) int32 {
+			seekPad = pad
+			if event != 6 {
+				t.Fatalf("event=%d, want 6", event)
+			}
+			seekPending = true
+			return 1
+		},
+		gstElementQueryPosition: func(_ uintptr, _ int32, cur unsafe.Pointer) int32 {
+			*(*int64)(cur) = int64(16 * time.Second)
+			return 1
+		},
+		gstBusTimedPopFiltered: func(_ uintptr, _ uint64, filter int32) uintptr {
+			if filter == gstMessageAsyncDone && seekPending {
+				seekPending = false
+				return 7
+			}
+			return 0
+		},
+		gstObjectUnref:     func(uintptr) {},
+		gstMiniObjectUnref: func(uintptr) {},
+	}
+
+	runner := &gstRunner{
+		task: &Task{
+			Config: Config{}.normalized(),
+		},
+	}
+	actual, err := runner.startPipeline(12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runner.stopPipeline()
+
+	if actual != 16 {
+		t.Fatalf("actual=%v, want 16", actual)
+	}
+	if seekPad != 5 {
+		t.Fatalf("seek pad=%d, want mq.src_0", seekPad)
+	}
+	if seekPosition != int64(12*time.Second) {
+		t.Fatalf("seek position=%d, want %d", seekPosition, int64(12*time.Second))
+	}
+	runner.stopPipeline()
+
+	gstRuntime.gstElementQueryPosition = func(uintptr, int32, unsafe.Pointer) int32 {
+		return 0
+	}
+	fallbackRunner := &gstRunner{
+		task: &Task{Config: Config{}.normalized()},
+	}
+	actual, err = fallbackRunner.startPipeline(12)
+	if err != nil {
+		t.Fatalf("startPipeline failed when position query was unavailable: %v", err)
+	}
+	defer fallbackRunner.stopPipeline()
+	if actual != 12 {
+		t.Fatalf("fallback actual=%v, want requested position 12", actual)
+	}
+}
+
+func TestReusePipelineUsesQueriedPositionOrRequestedFallback(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	tests := []struct {
+		name          string
+		queryResult   int32
+		queryPosition int64
+		want          float64
+	}{
+		{name: "queried position", queryResult: 1, queryPosition: int64(16 * time.Second), want: 16},
+		{name: "unavailable position", queryResult: 0, queryPosition: int64(16 * time.Second), want: 12},
+		{name: "negative position", queryResult: 1, queryPosition: -1, want: 12},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, _ := newReusePipelineTestRunner(t, tt.queryResult, tt.queryPosition, 1, true)
+			defer func() {
+				runner.stopPipeline()
+				runner.releaseTransientState()
+			}()
+
+			actual, err := runner.reusePipeline(12, false, pipelineStateTimeout)
+			if err != nil {
+				t.Fatalf("reusePipeline failed: %v", err)
+			}
+			if actual != tt.want {
+				t.Fatalf("actual=%v, want %v", actual, tt.want)
+			}
+		})
+	}
+}
+
+func TestReusePipelineContinuesWhenAsyncDoneIsNotObserved(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	runner, _ := newReusePipelineTestRunner(t, 1, int64(16*time.Second), 1, false)
+	defer func() {
+		runner.stopPipeline()
+		runner.releaseTransientState()
+	}()
+
+	actual, err := runner.reusePipeline(12, false, time.Millisecond)
+	if err != nil {
+		t.Fatalf("reusePipeline failed without ASYNC_DONE: %v", err)
+	}
+	if actual != 16 {
+		t.Fatalf("actual=%v, want queried position 16", actual)
+	}
+}
+
+func TestReusePipelineRequiresVideoEncoderWhenTranscoding(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	runner, _ := newReusePipelineTestRunner(t, 1, int64(16*time.Second), 1, true)
+	runner.task.Config.TranscodeH264 = true
+	runner.task.Probe.Tracks = []TrackInfo{{Type: "video", CapsName: "video/x-h264"}}
+	defer func() {
+		runner.stopPipeline()
+		runner.releaseTransientState()
+	}()
+
+	_, err := runner.reusePipeline(12, false, pipelineStateTimeout)
+	if err == nil || !strings.Contains(err.Error(), "video encoder is not available") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReusePipelineFailureFreezesAndReleasesPipeline(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	runner, unrefs := newReusePipelineTestRunner(t, 1, int64(16*time.Second), 0, false)
+	registration := &gstPadProbeRegistration{
+		api:   gstRuntime,
+		pad:   9,
+		token: 10,
+		state: struct{}{},
+	}
+	registration.id.Store(11)
+	videoProbeStates.Store(registration.token, registration.state)
+	t.Cleanup(func() { videoProbeStates.Delete(registration.token) })
+	runner.videoStartProbe = registration
+
+	if runner.Seek(12) {
+		t.Fatal("Seek succeeded after the native seek event failed")
+	}
+	if !runner.IsFrozen() {
+		t.Fatal("runner was not frozen after reusePipeline failure")
+	}
+	if runner.pipeline != 0 || runner.bus != 0 || runner.sink != 0 {
+		t.Fatalf("native pipeline was retained: pipeline=%d bus=%d sink=%d", runner.pipeline, runner.bus, runner.sink)
+	}
+	if runner.reader != nil {
+		t.Fatal("MP4 reader was retained after reusePipeline failure")
+	}
+	if runner.videoStartProbe != nil || runner.videoClipProbe != nil {
+		t.Fatal("video probes were retained after reusePipeline failure")
+	}
+	if _, ok := videoProbeStates.Load(registration.token); ok {
+		t.Fatal("video probe state remains registered after reusePipeline failure")
+	}
+	for _, handle := range []uintptr{1, 2, 3, 9} {
+		if unrefs[handle] != 1 {
+			t.Fatalf("native handle %d unref count=%d, want 1", handle, unrefs[handle])
+		}
+	}
+}
+
+func newReusePipelineTestRunner(t *testing.T, queryResult int32, queryPosition int64, sendSeekResult int32, emitAsyncDone bool) (*gstRunner, map[uintptr]int) {
+	t.Helper()
+
+	seekPending := false
+	unrefs := make(map[uintptr]int)
+	api := &gstAPI{}
+	api.gstBinGetByName = func(_ uintptr, name string) uintptr {
+		switch name {
+		case "mux":
+			return 4
+		case "mq":
+			return 5
+		default:
+			return 0
+		}
+	}
+	api.gstElementSetState = func(_ uintptr, state int32) int32 {
+		if state == gstStatePlaying {
+			// reusePipeline has already consumed the seek message. Disabling the
+			// fake bus prevents its watcher from spinning after this point.
+			api.gstBusTimedPopFiltered = nil
+		}
+		return gstStateChangeSuccess
+	}
+	api.gstElementGetState = func(uintptr, unsafe.Pointer, unsafe.Pointer, uint64) int32 {
+		return gstStateChangeSuccess
+	}
+	api.gstElementGetStaticPad = func(element uintptr, name string) uintptr {
+		if element != 5 || name != "src_0" {
+			t.Fatalf("unexpected seek target: element=%d pad=%q", element, name)
+		}
+		return 6
+	}
+	api.gstEventNewSeek = func(float64, int32, int32, int32, int64, int32, int64) uintptr {
+		return 7
+	}
+	api.gstPadSendEvent = func(pad uintptr, event uintptr) int32 {
+		if pad != 6 || event != 7 {
+			t.Fatalf("unexpected seek event: pad=%d event=%d", pad, event)
+		}
+		seekPending = sendSeekResult != 0
+		return sendSeekResult
+	}
+	api.gstElementQueryPosition = func(_ uintptr, format int32, position unsafe.Pointer) int32 {
+		if format != gstFormatTime {
+			t.Fatalf("query format=%d, want time", format)
+		}
+		*(*int64)(position) = queryPosition
+		return queryResult
+	}
+	api.gstBusTimedPopFiltered = func(_ uintptr, _ uint64, filter int32) uintptr {
+		if filter == gstMessageAsyncDone && seekPending && emitAsyncDone {
+			seekPending = false
+			return 8
+		}
+		return 0
+	}
+	api.gstPadRemoveProbe = func(uintptr, uintptr) {}
+	api.gstObjectUnref = func(handle uintptr) {
+		unrefs[handle]++
+	}
+	api.gstMiniObjectUnref = func(uintptr) {}
+	gstRuntime = api
+
+	task := &Task{Config: Config{}.normalized()}
+	runner := &gstRunner{
+		task:     task,
+		pipeline: 1,
+		bus:      2,
+		sink:     3,
+	}
+	task.runner = runner
+	runner.ensureTransientState()
+	return runner, unrefs
+}
+
+func TestRunnerPositionUsesSegmentEnd(t *testing.T) {
+	runner := &gstRunner{}
+	runner.positionSeekSeconds = 10
+
+	runner.acceptSegment(Segment{
+		StartSeconds: 2,
+		EndSeconds:   8,
+	})
+
+	if got := runner.position(); got != 8 {
+		t.Fatalf("position=%v, want 8", got)
+	}
+}
+
+func TestEarlyEndOfStreamValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		durationNS int64
+		position   float64
+		wantEarly  bool
+	}{
+		{name: "unknown duration", position: 0},
+		{name: "short media", durationNS: int64(60 * time.Second), position: 0},
+		{name: "before threshold", durationNS: int64(10 * time.Minute), position: 479.999, wantEarly: true},
+		{name: "at threshold", durationNS: int64(10 * time.Minute), position: 480},
+		{name: "after threshold", durationNS: int64(10 * time.Minute), position: 599},
+		{name: "invalid position", durationNS: int64(10 * time.Minute), position: math.NaN(), wantEarly: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &gstRunner{task: &Task{Probe: ProbeInfo{DurationNS: tt.durationNS}}}
+			runner.setPosition(tt.position)
+
+			err := runner.earlyEndOfStreamError()
+			if got := errors.Is(err, ErrEarlyEndOfStream); got != tt.wantEarly {
+				t.Fatalf("error=%v, early=%t, want %t", err, got, tt.wantEarly)
+			}
+		})
+	}
+}
+
+func TestPipelineReadTimeout(t *testing.T) {
+	if pipelineReadTimeout != 45*time.Second {
+		t.Fatalf("pipelineReadTimeout=%s, want 45s", pipelineReadTimeout)
+	}
+}
+
+func TestGetSegmentReturnsRuntimeBusError(t *testing.T) {
+	previous := gstRuntime
+	t.Cleanup(func() {
+		gstRuntime = previous
+	})
+
+	messageText := append([]byte("decoder failed at runtime"), 0)
+	gerror := make([]byte, 16)
+	*(*uintptr)(unsafe.Pointer(&gerror[8])) = uintptr(unsafe.Pointer(&messageText[0]))
+
+	messageReturned := false
+	gstRuntime = &gstAPI{
+		gstBusTimedPopFiltered: func(uintptr, uint64, int32) uintptr {
+			if messageReturned {
+				return 0
+			}
+			messageReturned = true
+			return 77
+		},
+		gstMessageParseError: func(_ uintptr, errOut unsafe.Pointer, debugOut unsafe.Pointer) {
+			*(*uintptr)(errOut) = uintptr(unsafe.Pointer(&gerror[0]))
+			*(*uintptr)(debugOut) = 0
+		},
+		gstMiniObjectUnref: func(uintptr) {},
+		gErrorFree:         func(uintptr) {},
+		gFree:              func(uintptr) {},
+		gstElementSetState: func(uintptr, int32) int32 {
+			return gstStateChangeSuccess
+		},
+		gstObjectUnref: func(uintptr) {},
+	}
+
+	runner := &gstRunner{
+		task: &Task{
+			Config: Config{}.normalized(),
+		},
+		statePlaying: true,
+		pipeline:     1,
+		bus:          2,
+		sink:         3,
+		reader: Mp4BoxReader(
+			func([]byte) {},
+			func(Segment) {},
+			6,
+			0,
+			false,
+		),
+	}
+
+	_, err := runner.GetSegment(context.Background(), 0, 0)
+	if err == nil || !strings.Contains(err.Error(), "decoder failed at runtime") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	runtime.KeepAlive(messageText)
+	runtime.KeepAlive(gerror)
+}
+
+type fakePipelineRunner struct {
+	frozen     atomic.Bool
+	ensureInit func(context.Context, int, int) error
+	getSegment func(context.Context, int, int) (Segment, error)
+	seek       func(float64) bool
+}
+
+func (f *fakePipelineRunner) EnsureInit(ctx context.Context, audio int, startIndex int) error {
+	if f.ensureInit != nil {
+		return f.ensureInit(ctx, audio, startIndex)
+	}
+	return nil
+}
+func (f *fakePipelineRunner) GetSegment(ctx context.Context, index int, audio int) (Segment, error) {
+	if f.getSegment != nil {
+		return f.getSegment(ctx, index, audio)
+	}
+	return Segment{}, nil
+}
+func (f *fakePipelineRunner) Seek(seconds float64) bool {
+	if f.seek != nil {
+		return f.seek(seconds)
+	}
+	return true
+}
+func (f *fakePipelineRunner) Frozen() {
+	f.frozen.Store(true)
+}
+func (f *fakePipelineRunner) Dispose() {}
+func (f *fakePipelineRunner) IsFrozen() bool {
+	return f.frozen.Load()
+}
+
+func TestSegmentCatchupCutoffSeconds(t *testing.T) {
+	if maxSegmentCatchupSeconds != 60 {
+		t.Fatalf("maxSegmentCatchupSeconds = %d, want 60", maxSegmentCatchupSeconds)
+	}
+}
+
+func TestTaskWithFirstDistantSegmentSeeks(t *testing.T) {
+	var seekSeconds []float64
+	var pulled []int
+	task := &Task{
+		LastSentSegment: -1,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+	}
+	task.runner = &fakePipelineRunner{
+		seek: func(seconds float64) bool {
+			seekSeconds = append(seekSeconds, seconds)
+			return true
+		},
+		getSegment: func(_ context.Context, index int, _ int) (Segment, error) {
+			pulled = append(pulled, index)
+			return Segment{Header: []byte{1}}, nil
+		},
+	}
+
+	if err := task.WithSegment(context.Background(), 100, 0, func(Segment) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(seekSeconds) != 1 || seekSeconds[0] != 600 {
+		t.Fatalf("seekSeconds=%v, want [600]", seekSeconds)
+	}
+	if len(pulled) != 1 || pulled[0] != 100 {
+		t.Fatalf("pulled=%v, want [100]", pulled)
+	}
+}
+
+func TestFrozenTaskSeeksToRequestedSegment(t *testing.T) {
+	var seekSeconds []float64
+	var pulled []int
+	runner := &fakePipelineRunner{
+		seek: func(seconds float64) bool {
+			seekSeconds = append(seekSeconds, seconds)
+			return true
+		},
+		getSegment: func(_ context.Context, index int, _ int) (Segment, error) {
+			pulled = append(pulled, index)
+			return Segment{Header: []byte{1}}, nil
+		},
+	}
+	runner.frozen.Store(true)
+	task := &Task{
+		LastSentSegment: 41,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+		runner:          runner,
+	}
+
+	if err := task.WithSegment(context.Background(), 42, 0, func(Segment) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(seekSeconds) != 1 || seekSeconds[0] != 252 {
+		t.Fatalf("seekSeconds=%v, want [252]", seekSeconds)
+	}
+	if len(pulled) != 1 || pulled[0] != 42 {
+		t.Fatalf("pulled=%v, want [42]", pulled)
+	}
+}
+
+func TestTaskRejectsSegmentIndexThatOverflowsSeekTime(t *testing.T) {
+	called := false
+	task := &Task{
+		LastSentSegment: 0,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+		runner: &fakePipelineRunner{
+			seek: func(float64) bool {
+				called = true
+				return true
+			},
+			getSegment: func(context.Context, int, int) (Segment, error) {
+				called = true
+				return Segment{}, nil
+			},
+		},
+	}
+
+	index := int(^uint(0) >> 1)
+	err := task.WithSegment(context.Background(), index, 0, func(Segment) error { return nil })
+	if !errors.Is(err, ErrInvalidIdentifier) {
+		t.Fatalf("error=%v, want ErrInvalidIdentifier", err)
+	}
+	if called {
+		t.Fatal("pipeline was called for an overflowing segment index")
+	}
+}
+
+func TestTaskRejectsSegmentPastKnownDuration(t *testing.T) {
+	task := &Task{
+		LastSentSegment: 0,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+		Probe:           ProbeInfo{DurationNS: int64(60 * time.Second)},
+		runner:          &fakePipelineRunner{},
+	}
+
+	err := task.WithSegment(context.Background(), 10, 0, func(Segment) error { return nil })
+	if !errors.Is(err, ErrEndOfStreamExhausted) {
+		t.Fatalf("error=%v, want ErrEndOfStreamExhausted", err)
+	}
+}
+
+func TestTaskWithSegmentCatchesUpWithinCutoff(t *testing.T) {
+	var pulled []int
+	task := &Task{
+		LastSentSegment: 0,
+		Config: Config{
+			SegmentSeconds: 6,
+		}.normalized(),
+	}
+	task.runner = &fakePipelineRunner{
+		getSegment: func(_ context.Context, index int, _ int) (Segment, error) {
+			pulled = append(pulled, index)
+			return Segment{Header: []byte{1}}, nil
+		},
+		seek: func(float64) bool {
+			t.Fatal("Seek must not be called within catchup cutoff")
+			return false
+		},
+	}
+
+	if err := task.WithSegment(context.Background(), 10, 0, func(Segment) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(pulled) != 10 || pulled[0] != 1 || pulled[len(pulled)-1] != 10 {
+		t.Fatalf("pulled=%v, want segments 1..10", pulled)
+	}
+	if task.LastSentSegment != 10 {
+		t.Fatalf("LastSentSegment=%d, want 10", task.LastSentSegment)
+	}
+}
+
+func TestTaskWithSegmentSeeksPastCatchupCutoff(t *testing.T) {
+	var pulled []int
+	var seekSeconds []float64
+	task := &Task{
+		LastSentSegment: 0,
+		Config: Config{
+			SegmentSeconds: 6,
+		}.normalized(),
+	}
+	task.runner = &fakePipelineRunner{
+		getSegment: func(_ context.Context, index int, _ int) (Segment, error) {
+			pulled = append(pulled, index)
+			return Segment{Header: []byte{1}}, nil
+		},
+		seek: func(seconds float64) bool {
+			seekSeconds = append(seekSeconds, seconds)
+			return true
+		},
+	}
+
+	if err := task.WithSegment(context.Background(), 11, 0, func(Segment) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if len(seekSeconds) != 1 || seekSeconds[0] != 66 {
+		t.Fatalf("seekSeconds=%v, want [66]", seekSeconds)
+	}
+	if len(pulled) != 1 || pulled[0] != 11 {
+		t.Fatalf("pulled=%v, want only segment 11 after seek", pulled)
+	}
+}
+
+func TestTaskIsFrozenConcurrentDispose(t *testing.T) {
+	task := &Task{
+		runner: &fakePipelineRunner{},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = task.IsFrozen()
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		task.Dispose()
+	}()
+
+	wg.Wait()
+}
+
+func TestTaskFrozenClearsInitMP4(t *testing.T) {
+	runner := &fakePipelineRunner{}
+	task := &Task{
+		Config: Config{SegmentSeconds: 6}.normalized(),
+		runner: runner,
+	}
+	task.setInitMP4([]byte{1, 2, 3})
+
+	task.Frozen()
+
+	if !runner.IsFrozen() {
+		t.Fatal("runner was not frozen")
+	}
+	if task.hasInitMP4() {
+		t.Fatal("init mp4 was retained after freeze")
+	}
+}
+
+func TestTaskFreezeIfInactiveRechecksLastActive(t *testing.T) {
+	runner := &fakePipelineRunner{}
+	now := time.Now().UTC()
+	task := &Task{
+		Config:     Config{SegmentSeconds: 6}.normalized(),
+		lastActive: now,
+		runner:     runner,
+	}
+
+	if task.FreezeIfInactive(now.Add(-time.Minute)) {
+		t.Fatal("active task was frozen")
+	}
+	if runner.IsFrozen() {
+		t.Fatal("runner was frozen despite fresh activity")
+	}
+
+	task.activeMu.Lock()
+	task.lastActive = now.Add(-2 * time.Minute)
+	task.activeMu.Unlock()
+	if !task.FreezeIfInactive(now.Add(-time.Minute)) {
+		t.Fatal("inactive task was not frozen")
+	}
+}
+
+func TestGstRunnerFreezeReleasesTransientState(t *testing.T) {
+	task := &Task{
+		Config: Config{
+			SegmentSeconds: 6,
+			Subtitles:      true,
+		}.normalized(),
+		Probe: ProbeInfo{Tracks: []TrackInfo{
+			{Index: 2, Type: "subtitle", Codec: "subrip"},
+		}},
+	}
+	runner := &gstRunner{task: task}
+	task.runner = runner
+	runner.ensureTransientState()
+
+	oldReader := runner.reader
+	oldStore := runner.subtitleStores[2]
+	if oldReader == nil || oldStore == nil {
+		t.Fatal("transient state was not initialized")
+	}
+	task.setInitMP4([]byte{1, 2, 3})
+	oldReader.sourcePayload.Write(make([]byte, 1024))
+	oldStore.appendVTT("00:00:01.000 --> 00:00:02.000\ntext\n\n", 0, 0)
+
+	runner.freezeAtPosition(12)
+
+	if runner.reader != nil || runner.subtitleStores != nil || runner.subtitleSinks != nil {
+		t.Fatal("transient state was retained after freeze")
+	}
+	if task.hasInitMP4() {
+		t.Fatal("init mp4 was retained after runner freeze")
+	}
+	if !runner.IsFrozen() || runner.position() != 12 || runner.statePlaying {
+		t.Fatalf("unexpected frozen state: frozen=%v position=%v playing=%v", runner.IsFrozen(), runner.position(), runner.statePlaying)
+	}
+
+	runner.ensureTransientState()
+	if runner.reader == nil || runner.reader == oldReader {
+		t.Fatal("mp4 reader was not recreated")
+	}
+	if store := runner.subtitleStores[2]; store == nil || store == oldStore {
+		t.Fatal("subtitle store was not recreated")
+	}
+}
+
+func TestDetachTaskDoesNotRemoveReplacement(t *testing.T) {
+	oldTask := &Task{}
+	newTask := &Task{}
+
+	service := &Service{
+		tasks: map[string]*Task{
+			"id": newTask,
+		},
+	}
+
+	if _, ok := service.detachTask("id", oldTask); ok {
+		t.Fatal("old snapshot removed replacement task")
+	}
+
+	service.mu.RLock()
+	current := service.tasks["id"]
+	service.mu.RUnlock()
+
+	if current != newTask {
+		t.Fatal("replacement task was removed")
+	}
+}
+
+func TestProbeCacheReturnsFreshCopy(t *testing.T) {
+	service := &Service{probeCache: make(map[string]probeCacheEntry)}
+	probe := ProbeInfo{
+		Container: "Matroska",
+		Tracks: []TrackInfo{
+			{Type: "video", CapsName: "video/x-h264"},
+		},
+	}
+
+	service.setCachedProbe("hash", "1", probe)
+
+	cached, ok := service.getCachedProbe("hash", "1")
+	if !ok {
+		t.Fatal("cached probe was not returned")
+	}
+	cached.Tracks[0].CapsName = "video/x-h265"
+
+	cachedAgain, ok := service.getCachedProbe("hash", "1")
+	if !ok {
+		t.Fatal("cached probe disappeared")
+	}
+	if cachedAgain.Tracks[0].CapsName != "video/x-h264" {
+		t.Fatalf("cached probe was mutated through returned slice: %+v", cachedAgain.Tracks[0])
+	}
+}
+
+func TestProbeCacheExpires(t *testing.T) {
+	service := &Service{
+		probeCache: map[string]probeCacheEntry{
+			probeCacheKey("hash", "1"): {
+				probe:     ProbeInfo{Container: "Matroska"},
+				expiresAt: time.Now().UTC().Add(-time.Second),
+			},
+		},
+	}
+
+	if _, ok := service.getCachedProbe("hash", "1"); ok {
+		t.Fatal("expired cached probe was returned")
+	}
+	if len(service.probeCache) != 0 {
+		t.Fatal("expired cached probe was not removed")
+	}
+}
+
+func TestTaskEnsureInitDoesNotRequireSegment(t *testing.T) {
+	task := &Task{
+		LastSentSegment: -1,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+	}
+
+	task.runner = &fakePipelineRunner{
+		ensureInit: func(_ context.Context, _ int, startIndex int) error {
+			if startIndex != 100 {
+				t.Fatalf("startIndex=%d, want 100", startIndex)
+			}
+			task.setInitMP4([]byte{1, 2, 3})
+			return nil
+		},
+		getSegment: func(context.Context, int, int) (Segment, error) {
+			t.Fatal("GetSegment was called for init")
+			return Segment{}, nil
+		},
+	}
+
+	if err := task.EnsureInit(context.Background(), 0, 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := task.WithInitMP4(func(init []byte) error {
+		if len(init) != 3 {
+			t.Fatal("init mp4 was not stored")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if task.LastSentSegment != 99 {
+		t.Fatalf("LastSentSegment=%d, want 99", task.LastSentSegment)
+	}
+}
+
+func TestTaskWithSegmentReturnsConsumerErrorUnderLock(t *testing.T) {
+	sentinel := errors.New("consumer failed")
+	task := &Task{
+		LastSentSegment: -1,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+		runner: &fakePipelineRunner{
+			getSegment: func(context.Context, int, int) (Segment, error) {
+				return Segment{Header: []byte("segment")}, nil
+			},
+		},
+	}
+
+	lockAttempted := make(chan struct{})
+	lockAcquired := make(chan struct{})
+	err := task.WithSegment(context.Background(), 0, 0, func(seg Segment) error {
+		if seg.Empty() {
+			t.Fatal("segment is empty")
+		}
+
+		go func() {
+			close(lockAttempted)
+			task.mu.Lock()
+			task.mu.Unlock()
+			close(lockAcquired)
+		}()
+
+		<-lockAttempted
+		select {
+		case <-lockAcquired:
+			t.Fatal("Task.mu was released before segment consumer returned")
+		case <-time.After(20 * time.Millisecond):
+		}
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("error=%v, want sentinel", err)
+	}
+
+	select {
+	case <-lockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("Task.mu was not released after segment consumer returned")
+	}
+}
+
+func TestTaskWithSegmentSkipsConsumerAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	task := &Task{
+		LastSentSegment: -1,
+		Config:          Config{SegmentSeconds: 6}.normalized(),
+		runner: &fakePipelineRunner{
+			getSegment: func(context.Context, int, int) (Segment, error) {
+				cancel()
+				return Segment{Header: []byte("segment")}, nil
+			},
+		},
+	}
+
+	consumerCalled := false
+	err := task.WithSegment(ctx, 0, 0, func(Segment) error {
+		consumerCalled = true
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error=%v, want context.Canceled", err)
+	}
+	if consumerCalled {
+		t.Fatal("segment consumer was called after request cancellation")
+	}
+}

--- a/server/gstreamer/probe_test.go
+++ b/server/gstreamer/probe_test.go
@@ -1,0 +1,171 @@
+//go:build gst
+
+package gstreamer
+
+import "testing"
+
+func TestProbeFromDiscoverer(t *testing.T) {
+	text := `
+Properties:
+  Duration: 1:34:09.920000000
+  Seekable: yes
+  container: Matroska
+    video #1: H.264 (High Profile)
+      Width: 1920
+      Height: 800
+      Frame rate: 24000/1001
+      language code: und
+    audio #2: AC-3 (ATSC A/52)
+      Sample rate: 48000
+      Channels: 6
+      language code: ru
+      title: DUB
+    audio #3: E-AC-3 (ATSC A/52B)
+      Sample rate: 48000
+      Channels: 6
+      language code: en
+      title: Original
+`
+
+	probe := probeFromDiscoverer(text)
+	if probe.DurationNS != 5_649_920_000_000 {
+		t.Fatalf("DurationNS = %d", probe.DurationNS)
+	}
+	if probe.Container != "Matroska" {
+		t.Fatalf("Container = %q, want Matroska", probe.Container)
+	}
+	if len(probe.Tracks) != 3 {
+		t.Fatalf("Tracks len = %d", len(probe.Tracks))
+	}
+
+	video := probe.Tracks[0]
+	if video.Type != "video" || video.Index != 0 || video.PadName != "video_0" || video.CapsName != "video/x-h264" {
+		t.Fatalf("video track = %+v", video)
+	}
+	if video.Width != 1920 || video.Height != 800 || video.FrameRateNum != 24000 || video.FrameRateDen != 1001 {
+		t.Fatalf("video details = %+v", video)
+	}
+
+	audio0 := probe.Tracks[1]
+	if audio0.Type != "audio" || audio0.Index != 0 || audio0.PadName != "audio_0" || audio0.CapsName != "audio/x-ac3" {
+		t.Fatalf("audio0 track = %+v", audio0)
+	}
+	if audio0.Rate != 48000 || audio0.Channels != 6 || audio0.Language != "ru" || audio0.Title != "DUB" {
+		t.Fatalf("audio0 details = %+v", audio0)
+	}
+
+	audio1 := probe.Tracks[2]
+	if audio1.Type != "audio" || audio1.Index != 1 || audio1.PadName != "audio_1" || audio1.CapsName != "audio/x-eac3" {
+		t.Fatalf("audio1 track = %+v", audio1)
+	}
+	if audio1.Rate != 48000 || audio1.Channels != 6 || audio1.Language != "en" || audio1.Title != "Original" {
+		t.Fatalf("audio1 details = %+v", audio1)
+	}
+}
+
+func TestProbeParsesMatroskaContainer(t *testing.T) {
+	probe := probeFromDiscoverer(`
+Properties:
+  Duration: 0:01:00.000000000
+  container #0: Matroska
+    video #1: H.264 (High Profile)
+    audio #2: AAC
+`)
+
+	if probe.Container != "Matroska" {
+		t.Fatalf("Container=%q", probe.Container)
+	}
+	if !probe.IsMatroskaContainer() {
+		t.Fatal("Matroska container was not accepted")
+	}
+	if !probe.HasAudio() {
+		t.Fatal("audio track was not detected")
+	}
+}
+
+func TestProbeParsesAACAudioCodec(t *testing.T) {
+	probe := probeFromDiscoverer(`
+Properties:
+  Duration: 0:01:00.000000000
+  container #0: Matroska
+    video #1: H.264
+    audio #2: MPEG-4 AAC
+`)
+
+	audio := probe.AudioTrack(0)
+	if audio == nil {
+		t.Fatal("audio track was not detected")
+	}
+	if audio.Codec != "MPEG-4 AAC" || audio.CapsName != "audio/mpeg" {
+		t.Fatalf("audio track = %+v", *audio)
+	}
+	if !audio.IsAACAudio() {
+		t.Fatal("AAC audio track was not detected")
+	}
+}
+
+func TestAACAudioDetectionAcceptsMPEG4Caps(t *testing.T) {
+	track := TrackInfo{
+		Type:  "audio",
+		Codec: "audio/mpeg, mpegversion=(int)4, stream-format=(string)raw",
+	}
+
+	if !track.IsAACAudio() {
+		t.Fatal("MPEG-4 audio caps were not detected as AAC")
+	}
+}
+
+func TestProbeParsesVideoOnlyWebM(t *testing.T) {
+	probe := probeFromDiscoverer(`
+Properties:
+  Duration: 0:00:10.000000000
+  container #0: WebM
+    video #1: VP9
+`)
+
+	if !probe.IsMatroskaContainer() {
+		t.Fatal("WebM container was not accepted")
+	}
+	if probe.HasAudio() {
+		t.Fatal("video-only source unexpectedly has audio")
+	}
+}
+
+func TestValidateProbeRejectsNonMatroska(t *testing.T) {
+	err := validateProbe(ProbeInfo{
+		Container: "Quicktime",
+		Tracks: []TrackInfo{
+			{Type: "video", CapsName: "video/x-h264"},
+		},
+	}, Config{})
+	if err == nil {
+		t.Fatal("non-Matroska source was accepted")
+	}
+}
+
+func TestValidateProbeAcceptsAVIOnlyWithTranscode(t *testing.T) {
+	probe := ProbeInfo{
+		Container:         "AVI",
+		ContainerCapsName: "video/x-msvideo",
+		Tracks:            []TrackInfo{{Type: "video", CapsName: "video/x-h264"}},
+	}
+	if err := validateProbe(probe, Config{}); err == nil {
+		t.Fatal("AVI was accepted without TranscodeAVI")
+	}
+	if err := validateProbe(probe, Config{TranscodeAVI: true}); err != nil {
+		t.Fatalf("AVI with TranscodeAVI was rejected: %v", err)
+	}
+}
+
+func TestValidateProbeAcceptsVP8OnlyWithTranscode(t *testing.T) {
+	probe := ProbeInfo{
+		Container: "WebM",
+		Tracks:    []TrackInfo{{Type: "video", CapsName: "video/x-vp8"}},
+	}
+	if err := validateProbe(probe, Config{}); err == nil {
+		t.Fatal("VP8 was accepted without TranscodeVP8")
+	}
+	if err := validateProbe(probe, Config{TranscodeVP8: true}); err != nil {
+		t.Fatalf("VP8 with TranscodeVP8 was rejected: %v", err)
+	}
+}

--- a/server/gstreamer/segment_test.go
+++ b/server/gstreamer/segment_test.go
@@ -1,0 +1,87 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestSegmentWriteToWritesHeaderAndPayloads(t *testing.T) {
+	seg := Segment{
+		Header:   []byte("head"),
+		Payloads: [][]byte{[]byte("video"), []byte("audio")},
+	}
+
+	var out bytes.Buffer
+	written, err := seg.WriteTo(&out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if written != int64(seg.Len()) {
+		t.Fatalf("WriteTo() wrote %d bytes, want %d", written, seg.Len())
+	}
+
+	if got, want := out.String(), "headvideoaudio"; got != want {
+		t.Fatalf("WriteTo() = %q, want %q", got, want)
+	}
+	if got, want := seg.Len(), len("headvideoaudio"); got != want {
+		t.Fatalf("Len() = %d, want %d", got, want)
+	}
+}
+
+func TestSegmentWriteRangeCrossesParts(t *testing.T) {
+	seg := Segment{
+		Header:   []byte("head"),
+		Payloads: [][]byte{[]byte("video"), []byte("audio")},
+	}
+
+	var out bytes.Buffer
+	if err := seg.WriteRange(&out, 2, 8); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := out.String(), "advideoa"; got != want {
+		t.Fatalf("WriteRange() = %q, want %q", got, want)
+	}
+}
+
+func TestSegmentWriteRangeDoesNotAllocateParts(t *testing.T) {
+	seg := Segment{
+		Header:   []byte("head"),
+		Payloads: [][]byte{[]byte("video"), []byte("audio")},
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		if err := seg.WriteRange(io.Discard, 2, 8); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("WriteRange allocations = %v, want 0", allocs)
+	}
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	return len(data) - 1, nil
+}
+
+func TestSegmentWriteToRejectsShortWrite(t *testing.T) {
+	seg := Segment{Header: []byte("header")}
+	if _, err := seg.WriteTo(shortWriter{}); err != io.ErrShortWrite {
+		t.Fatalf("WriteTo error=%v, want io.ErrShortWrite", err)
+	}
+}
+
+func TestSegmentWriteRangeRejectsShortWrite(t *testing.T) {
+	seg := Segment{Header: []byte("header")}
+	if err := seg.WriteRange(shortWriter{}, 1, 3); err != io.ErrShortWrite {
+		t.Fatalf("WriteRange error=%v, want io.ErrShortWrite", err)
+	}
+}

--- a/server/gstreamer/service.go
+++ b/server/gstreamer/service.go
@@ -30,6 +30,7 @@ var (
 	ErrTaskNotFound            = errors.New("gstreamer task not found")
 	ErrServiceClosed           = errors.New("gstreamer service is closed")
 	ErrInvalidIdentifier       = errors.New("invalid gstreamer task id")
+	ErrEarlyEndOfStream        = errors.New("gstreamer reached EOS before the expected end")
 	ErrEndOfStreamExhausted    = errors.New("gstreamer end of stream is exhausted")
 	ErrTruncatedMP4Fragment    = errors.New("truncated mp4 fragment at end of stream")
 	ErrUndecodableEOSRemainder = errors.New("undecodable mp4 eos remainder")

--- a/server/gstreamer/service_test.go
+++ b/server/gstreamer/service_test.go
@@ -1,0 +1,195 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type trackingRunner struct {
+	disposed atomic.Bool
+	frozen   atomic.Bool
+}
+
+func (r *trackingRunner) EnsureInit(context.Context, int, int) error {
+	return nil
+}
+
+func (r *trackingRunner) GetSegment(context.Context, int, int) (Segment, error) {
+	return Segment{}, nil
+}
+
+func (r *trackingRunner) Seek(float64) bool {
+	return true
+}
+
+func (r *trackingRunner) Frozen() {
+	r.frozen.Store(true)
+}
+
+func (r *trackingRunner) Dispose() {
+	r.disposed.Store(true)
+}
+
+func (r *trackingRunner) IsFrozen() bool {
+	return r.frozen.Load()
+}
+
+func newTrackedTask(id string, lastActive time.Time) (*Task, *trackingRunner) {
+	runner := &trackingRunner{}
+	return &Task{
+		ID:              id,
+		FileID:          "1",
+		LastSentSegment: -1,
+		lastActive:      lastActive,
+		runner:          runner,
+	}, runner
+}
+
+func TestTaskLimitOneEvictsExistingTaskForProtectedNewTask(t *testing.T) {
+	now := time.Now().UTC()
+	oldTask, oldRunner := newTrackedTask("old", now.Add(-time.Minute))
+	newTask, newRunner := newTrackedTask("new", now)
+
+	service := &Service{
+		conf: Config{MaxTasks: 1}.normalized(),
+		tasks: map[string]*Task{
+			oldTask.ID: oldTask,
+			newTask.ID: newTask,
+		},
+	}
+
+	service.mu.Lock()
+	evicted := service.evictTasksForLimitLocked(newTask.ID)
+	service.mu.Unlock()
+	disposeTasks(evicted)
+
+	if _, ok := service.tasks[oldTask.ID]; ok {
+		t.Fatal("old task was not evicted")
+	}
+	if service.tasks[newTask.ID] != newTask {
+		t.Fatal("protected new task was evicted")
+	}
+	if !oldTask.IsDisposed() || !oldRunner.disposed.Load() {
+		t.Fatal("old task was not disposed")
+	}
+	if newTask.IsDisposed() || newRunner.disposed.Load() {
+		t.Fatal("protected new task was disposed")
+	}
+}
+
+func TestTaskLimitEvictsOldestTask(t *testing.T) {
+	now := time.Now().UTC()
+	oldTask, oldRunner := newTrackedTask("old", now.Add(-3*time.Minute))
+	midTask, midRunner := newTrackedTask("mid", now.Add(-time.Minute))
+	newTask, newRunner := newTrackedTask("new", now)
+
+	service := &Service{
+		conf: Config{MaxTasks: 2}.normalized(),
+		tasks: map[string]*Task{
+			oldTask.ID: oldTask,
+			midTask.ID: midTask,
+			newTask.ID: newTask,
+		},
+	}
+
+	service.mu.Lock()
+	evicted := service.evictTasksForLimitLocked(newTask.ID)
+	service.mu.Unlock()
+	disposeTasks(evicted)
+
+	if _, ok := service.tasks[oldTask.ID]; ok {
+		t.Fatal("oldest task was not evicted")
+	}
+	if service.tasks[midTask.ID] != midTask {
+		t.Fatal("newer task was evicted instead of the oldest one")
+	}
+	if service.tasks[newTask.ID] != newTask {
+		t.Fatal("protected new task was evicted")
+	}
+	if !oldTask.IsDisposed() || !oldRunner.disposed.Load() {
+		t.Fatal("oldest task was not disposed")
+	}
+	if midTask.IsDisposed() || midRunner.disposed.Load() {
+		t.Fatal("newer task was disposed")
+	}
+	if newTask.IsDisposed() || newRunner.disposed.Load() {
+		t.Fatal("protected new task was disposed")
+	}
+}
+
+func TestRemoveInactiveTaskRechecksLastActive(t *testing.T) {
+	now := time.Now().UTC()
+	task, runner := newTrackedTask("task", now)
+	service := &Service{
+		tasks: map[string]*Task{task.ID: task},
+	}
+
+	if service.tryRemoveExpectedInactive(task.ID, task, now.Add(-time.Minute)) {
+		t.Fatal("active task was removed")
+	}
+	if service.tasks[task.ID] != task || task.IsDisposed() || runner.disposed.Load() {
+		t.Fatal("active task changed during cleanup recheck")
+	}
+
+	task.activeMu.Lock()
+	task.lastActive = now.Add(-2 * time.Minute)
+	task.activeMu.Unlock()
+	if !service.tryRemoveExpectedInactive(task.ID, task, now.Add(-time.Minute)) {
+		t.Fatal("inactive task was not removed")
+	}
+	if !task.IsDisposed() || !runner.disposed.Load() {
+		t.Fatal("removed task was not disposed")
+	}
+}
+
+func TestServiceDisposeRejectsFurtherWork(t *testing.T) {
+	task, runner := newTrackedTask("task", time.Now().UTC())
+	service := &Service{
+		tasks:       map[string]*Task{task.ID: task},
+		probeCache:  make(map[string]probeCacheEntry),
+		stopCleanup: make(chan struct{}),
+	}
+
+	service.Dispose()
+	service.Dispose()
+
+	if !service.disposed.Load() {
+		t.Fatal("service was not marked disposed")
+	}
+	if !task.IsDisposed() || !runner.disposed.Load() {
+		t.Fatal("service task was not disposed")
+	}
+	if got := service.Get(task.ID); got != nil {
+		t.Fatal("disposed service returned a task")
+	}
+	if _, err := service.GetOrAdd("hash", "1", 0); !errors.Is(err, ErrServiceClosed) {
+		t.Fatalf("GetOrAdd error=%v, want ErrServiceClosed", err)
+	}
+	if _, err := service.Probe("hash", "1"); !errors.Is(err, ErrServiceClosed) {
+		t.Fatalf("Probe error=%v, want ErrServiceClosed", err)
+	}
+}
+
+func TestCachedProbeIsRevalidatedAfterConfigChange(t *testing.T) {
+	service := &Service{
+		conf:       Config{TranscodeAVI: true}.normalized(),
+		tasks:      make(map[string]*Task),
+		probeCache: make(map[string]probeCacheEntry),
+	}
+	service.setCachedProbe("hash", "1", ProbeInfo{
+		Container: "AVI",
+		Tracks: []TrackInfo{
+			{Type: "video", CapsName: "video/x-h264"},
+		},
+	})
+
+	service.updateConfig(Config{})
+	if _, err := service.Probe("hash", "1"); !errors.Is(err, ErrUnsupportedContainer) {
+		t.Fatalf("Probe error=%v, want ErrUnsupportedContainer", err)
+	}
+}

--- a/server/gstreamer/subtitles.go
+++ b/server/gstreamer/subtitles.go
@@ -3,14 +3,20 @@
 package gstreamer
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
-const maxPendingVTTChars = 64 * 1024
+const (
+	maxPendingVTTChars  = 64 * 1024
+	subtitleWaitTimeout = 5 * time.Second
+)
 
 var vttCuePattern = regexp.MustCompile(`(?ms)(?:^|\n)(?:[^\n]*\n)?(\d{2,}:\d{2}:\d{2}[.,]\d{3})[ \t]+-->[ \t]+(\d{2,}:\d{2}:\d{2}[.,]\d{3})[^\n]*\n(.*?)(?:\n[ \t]*\n)`)
 
@@ -27,18 +33,109 @@ type subtitleCueKey struct {
 }
 
 type subtitleStore struct {
-	mu       sync.RWMutex
-	pending  string
-	parsedTo uint64
-	cues     []subtitleCue
-	seen     map[subtitleCueKey]struct{}
+	mu          sync.RWMutex
+	pending     string
+	videoReadTo uint64
+	cues        []subtitleCue
+	seen        map[subtitleCueKey]struct{}
+	updated     chan struct{}
 }
 
 func newSubtitleStore() *subtitleStore {
 	return &subtitleStore{
-		cues: make([]subtitleCue, 0, 256),
-		seen: make(map[subtitleCueKey]struct{}),
+		cues:    make([]subtitleCue, 0, 256),
+		seen:    make(map[subtitleCueKey]struct{}),
+		updated: make(chan struct{}),
 	}
+}
+
+func (t *Task) setSubtitleStores(stores map[int]*subtitleStore) {
+	if t == nil {
+		return
+	}
+
+	t.subtitleMu.Lock()
+	previous := t.subtitleStores
+	t.subtitleStores = stores
+	t.subtitleMu.Unlock()
+
+	for _, store := range previous {
+		store.notify()
+	}
+}
+
+func (t *Task) subtitleStore(index int) *subtitleStore {
+	if t == nil {
+		return nil
+	}
+	t.subtitleMu.RLock()
+	store := t.subtitleStores[index]
+	t.subtitleMu.RUnlock()
+	return store
+}
+
+func (s *subtitleStore) notify() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.notifyLocked()
+	s.mu.Unlock()
+}
+
+func (s *subtitleStore) notifyLocked() {
+	if s.updated != nil {
+		close(s.updated)
+	}
+	s.updated = make(chan struct{})
+}
+
+func (s *subtitleStore) setVideoReadTo(value uint64) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.videoReadTo != value {
+		s.videoReadTo = value
+		s.notifyLocked()
+	}
+	s.mu.Unlock()
+}
+
+func (s *subtitleStore) advanceVideoReadTo(value uint64) {
+	if s == nil || value == 0 {
+		return
+	}
+	s.mu.Lock()
+	if value > s.videoReadTo {
+		s.videoReadTo = value
+		s.notifyLocked()
+	}
+	s.mu.Unlock()
+}
+
+func (r *gstRunner) resetSubtitleProgress(seconds float64) {
+	value := subtitleProgressNS(seconds)
+	for _, store := range r.subtitleStores {
+		store.setVideoReadTo(value)
+	}
+}
+
+func (r *gstRunner) advanceSubtitleProgress(value uint64) {
+	for _, store := range r.subtitleStores {
+		store.advanceVideoReadTo(value)
+	}
+}
+
+func subtitleProgressNS(seconds float64) uint64 {
+	if seconds <= 0 || math.IsNaN(seconds) {
+		return 0
+	}
+	maximum := ^uint64(0)
+	if math.IsInf(seconds, 1) || seconds >= float64(maximum)/1_000_000_000 {
+		return maximum
+	}
+	return uint64(math.Round(seconds * 1_000_000_000))
 }
 
 func supportedSubtitleTrack(track TrackInfo) bool {
@@ -120,9 +217,6 @@ func (s *subtitleStore) appendVTT(chunk string, seekSeconds float64, maxBackDiff
 			startNS = saturatingAdd(startNS, seekNS)
 			endNS = saturatingAdd(endNS, seekNS)
 		}
-		if endNS > s.parsedTo {
-			s.parsedTo = endNS
-		}
 		key := subtitleCueKey{startNS: startNS, endNS: endNS, text: text}
 		if _, exists := s.seen[key]; !exists {
 			s.seen[key] = struct{}{}
@@ -141,43 +235,84 @@ func (s *subtitleStore) appendVTT(chunk string, seekSeconds float64, maxBackDiff
 		}
 		s.pending = s.pending[cut:]
 	}
+	s.notifyLocked()
 }
 
 func (t *Task) SubtitleVTT(trackIndex int, segmentIndex int) (string, bool) {
+	value, ready, _ := t.subtitleVTTSnapshot(trackIndex, segmentIndex)
+	return value, ready
+}
+
+func (t *Task) WaitSubtitleVTT(ctx context.Context, trackIndex int, segmentIndex int, timeout time.Duration) (string, error) {
 	if t == nil {
-		return "", false
+		return "", ErrTaskNotFound
+	}
+	if timeout <= 0 {
+		value, _, _ := t.subtitleVTTSnapshot(trackIndex, segmentIndex)
+		return value, nil
 	}
 
-	t.mu.Lock()
-	if t.disposed.Load() || t.runner == nil {
-		t.mu.Unlock()
-		return "", false
-	}
-	runner, ok := t.runner.(*gstRunner)
-	if !ok {
-		t.mu.Unlock()
-		return "", false
-	}
-	store := runner.subtitleStores[trackIndex]
-	t.mu.Unlock()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for {
+		value, ready, updated := t.subtitleVTTSnapshot(trackIndex, segmentIndex)
+		if ready {
+			return value, nil
+		}
 
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-timer.C:
+			value, _, _ = t.subtitleVTTSnapshot(trackIndex, segmentIndex)
+			return value, nil
+		case <-updated:
+		}
+	}
+}
+
+func (t *Task) subtitleVTTSnapshot(trackIndex int, segmentIndex int) (string, bool, <-chan struct{}) {
+	if t == nil {
+		return "", false, nil
+	}
+	fromNS, toNS := t.subtitleRange(segmentIndex)
+	if t.disposed.Load() {
+		return emptyVTT(fromNS), true, nil
+	}
+
+	store := t.subtitleStore(trackIndex)
 	if store == nil {
-		return emptyVTT(t.segmentStartNS(segmentIndex)), true
+		return emptyVTT(fromNS), true, nil
 	}
-	fromNS := t.segmentStartNS(segmentIndex)
-	toNS := fromNS + uint64(max(t.Config.SegmentSeconds, 1))*1_000_000_000
+	return store.renderVTT(fromNS, toNS)
+}
+
+func (t *Task) subtitleRange(segmentIndex int) (uint64, uint64) {
 	if cue, ok := t.Cue.Segment(segmentIndex); ok {
-		fromNS, toNS = cue.StartNS, cue.EndNS
+		return cue.StartNS, cue.EndNS
 	}
 
-	store.mu.RLock()
-	defer store.mu.RUnlock()
-	if store.parsedTo > 0 && store.parsedTo < toNS {
-		return "", false
+	fromNS := t.segmentStartNS(segmentIndex)
+	durationNS := uint64(max(t.Config.SegmentSeconds, 1)) * 1_000_000_000
+	toNS := saturatingAdd(fromNS, durationNS)
+	if t.Probe.DurationNS > 0 {
+		mediaEndNS := uint64(t.Probe.DurationNS)
+		if fromNS >= mediaEndNS {
+			toNS = fromNS
+		} else if toNS > mediaEndNS {
+			toNS = mediaEndNS
+		}
 	}
+	return fromNS, toNS
+}
+
+func (s *subtitleStore) renderVTT(fromNS uint64, toNS uint64) (string, bool, <-chan struct{}) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	var result strings.Builder
 	writeVTTHeader(&result, fromNS)
-	for _, cue := range store.cues {
+	for _, cue := range s.cues {
 		if cue.EndNS <= fromNS || cue.StartNS >= toNS {
 			continue
 		}
@@ -199,7 +334,8 @@ func (t *Task) SubtitleVTT(trackIndex int, segmentIndex int) (string, bool) {
 		result.WriteString(cue.Text)
 		result.WriteString("\n\n")
 	}
-	return result.String(), true
+	ready := toNS <= fromNS || s.videoReadTo >= toNS
+	return result.String(), ready, s.updated
 }
 
 func emptyVTT(startNS uint64) string {

--- a/server/gstreamer/subtitles_test.go
+++ b/server/gstreamer/subtitles_test.go
@@ -1,0 +1,104 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubtitleVTTWaitsForVideoRange(t *testing.T) {
+	task, store := subtitleTestTask()
+	store.appendVTT("00:00:01.000 --> 00:00:02.000\nhello\n\n", 0, 0)
+
+	value, ready := task.SubtitleVTT(2, 0)
+	if ready {
+		t.Fatal("subtitle range was ready before the video reader passed it")
+	}
+	if !strings.Contains(value, "hello") {
+		t.Fatalf("partial VTT does not contain parsed cue: %q", value)
+	}
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		store.advanceVideoReadTo(6_000_000_000)
+	}()
+
+	value, err := task.WaitSubtitleVTT(context.Background(), 2, 0, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(value, "hello") {
+		t.Fatalf("ready VTT does not contain parsed cue: %q", value)
+	}
+}
+
+func TestSubtitleVTTEmptyReadRangeIsReady(t *testing.T) {
+	task, store := subtitleTestTask()
+	store.advanceVideoReadTo(6_000_000_000)
+
+	value, ready := task.SubtitleVTT(2, 0)
+	if !ready {
+		t.Fatal("empty subtitle range remained pending after video passed it")
+	}
+	if strings.Contains(value, "-->") {
+		t.Fatalf("empty VTT unexpectedly contains a cue: %q", value)
+	}
+}
+
+func TestCompletedVideoSegmentMakesSubtitleRangeReady(t *testing.T) {
+	task, store := subtitleTestTask()
+	runner := &gstRunner{
+		task:           task,
+		subtitleStores: map[int]*subtitleStore{2: store},
+	}
+	runner.readySegment.segment = Segment{EndNS: 5_900_000_000}
+	runner.readySegment.complete = true
+
+	runner.completeReadySegment(0)
+
+	_, ready := task.SubtitleVTT(2, 0)
+	if !ready {
+		t.Fatal("completed video segment did not advance the subtitle range watermark")
+	}
+}
+
+func TestWaitSubtitleVTTReturnsPartialDataAtTimeout(t *testing.T) {
+	task, store := subtitleTestTask()
+	store.appendVTT("00:00:01.000 --> 00:00:02.000\npartial\n\n", 0, 0)
+
+	value, err := task.WaitSubtitleVTT(context.Background(), 2, 0, 20*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(value, "partial") {
+		t.Fatalf("timeout discarded partial subtitle data: %q", value)
+	}
+}
+
+func TestWaitSubtitleVTTReturnsEmptyVTTAtTimeout(t *testing.T) {
+	task, _ := subtitleTestTask()
+
+	value, err := task.WaitSubtitleVTT(context.Background(), 2, 0, 20*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(value, "WEBVTT\n") || strings.Contains(value, "-->") {
+		t.Fatalf("timeout did not return an empty VTT document: %q", value)
+	}
+}
+
+func subtitleTestTask() (*Task, *subtitleStore) {
+	task := &Task{
+		Config: Config{
+			SegmentSeconds: 6,
+			Subtitles:      true,
+		}.normalized(),
+		Probe: ProbeInfo{DurationNS: int64(time.Minute)},
+	}
+	store := newSubtitleStore()
+	task.setSubtitleStores(map[int]*subtitleStore{2: store})
+	return task, store
+}

--- a/server/gstreamer/task.go
+++ b/server/gstreamer/task.go
@@ -42,6 +42,9 @@ type Task struct {
 	mu     sync.Mutex
 	runner pipelineRunner
 
+	subtitleMu     sync.RWMutex
+	subtitleStores map[int]*subtitleStore
+
 	disposed atomic.Bool
 }
 

--- a/server/gstreamer/temp_test.go
+++ b/server/gstreamer/temp_test.go
@@ -1,0 +1,17 @@
+//go:build gst
+
+package gstreamer
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigDoesNotExposeGStreamerTempFiles(t *testing.T) {
+	typ := reflect.TypeOf(Config{})
+	for _, field := range []string{"TempFS", "TempFSRing", "AppSinkBuffers"} {
+		if _, ok := typ.FieldByName(field); ok {
+			t.Fatalf("Config still exposes removed field %s", field)
+		}
+	}
+}

--- a/server/gstreamer/video_probe_gst.go
+++ b/server/gstreamer/video_probe_gst.go
@@ -1,0 +1,432 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+const (
+	gstClockTimeNone = ^uint64(0)
+
+	gstPadProbeTypeBuffer          uint32 = 1 << 4
+	gstPadProbeTypeEventDownstream uint32 = 1 << 6
+
+	gstPadProbeDrop   uintptr = 0
+	gstPadProbeOK     uintptr = 1
+	gstPadProbeRemove uintptr = 2
+
+	gstEventFlushStart uint32 = 2563
+	gstEventSegment    uint32 = 17934
+)
+
+// These public GStreamer structures are ABI-stable. TorrServer only builds the
+// native bridge for 64-bit targets, so their pointer-sized fields are 8 bytes.
+type gstMiniObjectABI struct {
+	typeID          uintptr
+	refCount        int32
+	lockState       int32
+	flags           uint32
+	_               uint32
+	copyFunction    uintptr
+	disposeFunction uintptr
+	freeFunction    uintptr
+	privateUint     uint32
+	_               uint32
+	privatePointer  uintptr
+}
+
+type gstBufferABI struct {
+	miniObject gstMiniObjectABI
+	pool       uintptr
+	pts        uint64
+	dts        uint64
+}
+
+type gstEventABI struct {
+	miniObject gstMiniObjectABI
+	eventType  uint32
+}
+
+type gstSegmentABI struct {
+	flags       uint32
+	_           uint32
+	rate        float64
+	appliedRate float64
+	format      int32
+	_           uint32
+	base        uint64
+	offset      uint64
+	start       uint64
+	stop        uint64
+	time        uint64
+	position    uint64
+	duration    uint64
+}
+
+type gstPadProbeInfoABI struct {
+	probeType uint32
+}
+
+type gstPadProbeInfoWindowsABI struct {
+	probeType uint32
+	id        uint32
+	data      uintptr
+}
+
+type gstPadProbeInfoUnixABI struct {
+	probeType uint32
+	_         uint32
+	id        uint64
+	data      uintptr
+}
+
+type gstPadProbeRegistration struct {
+	api   *gstAPI
+	pad   uintptr
+	token uintptr
+	id    atomic.Uint64
+	state any
+}
+
+type videoStartProbeState struct {
+	registration  *gstPadProbeRegistration
+	requestedNS   uint64
+	maxBackDiffNS uint64
+	actualNS      atomic.Uint64
+}
+
+type videoSegmentClipProbeState struct {
+	registration   *gstPadProbeRegistration
+	requestedStart uint64
+	segmentStart   atomic.Uint64
+}
+
+var (
+	videoProbeStates    sync.Map
+	videoProbeNextToken atomic.Uint64
+
+	videoStartProbeCallback = purego.NewCallback(videoStartPadProbe)
+	videoClipProbeCallback  = purego.NewCallback(videoSegmentClipPadProbe)
+)
+
+func (r *gstRunner) installVideoSeekProbes(pipeline uintptr, requestedNS uint64, accurate bool) {
+	r.removeVideoSeekProbes()
+	if gstRuntime == nil || pipeline == 0 || gstRuntime.gstPadAddProbe == nil || gstRuntime.gstPadRemoveProbe == nil {
+		return
+	}
+
+	r.installVideoStartProbe(pipeline, requestedNS)
+	clipStart := uint64(gstClockTimeNone)
+	if accurate {
+		clipStart = requestedNS
+	}
+	r.installVideoSegmentClipProbe(pipeline, clipStart)
+}
+
+func (r *gstRunner) installVideoStartProbe(pipeline uintptr, requestedNS uint64) {
+	pad := gstPipelineElementPad(gstRuntime, pipeline, "mq", "src_0")
+	if pad == 0 {
+		return
+	}
+
+	maxBackDiffNS := uint64(max(r.task.Config.SegmentSeconds, 1)) * 1_000_000_000
+	if r.task.Cue != nil {
+		maxBackDiffNS = r.task.Cue.MaxDurationNS
+	}
+	state := &videoStartProbeState{
+		requestedNS:   requestedNS,
+		maxBackDiffNS: maxBackDiffNS,
+	}
+	state.actualNS.Store(gstClockTimeNone)
+	r.videoStartProbe = addVideoPadProbe(
+		gstRuntime,
+		pad,
+		gstPadProbeTypeEventDownstream|gstPadProbeTypeBuffer,
+		videoStartProbeCallback,
+		state,
+	)
+	if r.videoStartProbe != nil {
+		state.registration = r.videoStartProbe
+	}
+}
+
+func (r *gstRunner) installVideoSegmentClipProbe(pipeline uintptr, requestedStart uint64) {
+	passthrough := !videoIsTranscoded(r.task.Config, r.task.Probe)
+	if !passthrough || (!r.task.Probe.IsH264() && !r.task.Probe.IsH265()) {
+		return
+	}
+
+	pad := gstPipelineElementPad(gstRuntime, pipeline, "video_timestamper", "src")
+	if pad == 0 {
+		return
+	}
+
+	state := &videoSegmentClipProbeState{requestedStart: requestedStart}
+	state.segmentStart.Store(requestedStart)
+	r.videoClipProbe = addVideoPadProbe(
+		gstRuntime,
+		pad,
+		gstPadProbeTypeEventDownstream|gstPadProbeTypeBuffer,
+		videoClipProbeCallback,
+		state,
+	)
+	if r.videoClipProbe != nil {
+		state.registration = r.videoClipProbe
+	}
+}
+
+func gstPipelineElementPad(api *gstAPI, pipeline uintptr, elementName string, padName string) uintptr {
+	if api == nil || api.gstBinGetByName == nil || api.gstElementGetStaticPad == nil || api.gstObjectUnref == nil {
+		return 0
+	}
+	element := api.binGetByName(pipeline, elementName)
+	if element == 0 {
+		return 0
+	}
+	defer api.objectUnref(element)
+	return api.elementGetStaticPad(element, padName)
+}
+
+func addVideoPadProbe(api *gstAPI, pad uintptr, mask uint32, callback uintptr, state any) *gstPadProbeRegistration {
+	if api == nil || pad == 0 || callback == 0 || api.gstPadAddProbe == nil {
+		if api != nil && pad != 0 && api.gstObjectUnref != nil {
+			api.objectUnref(pad)
+		}
+		return nil
+	}
+
+	token := uintptr(videoProbeNextToken.Add(1))
+	if token == 0 {
+		token = uintptr(videoProbeNextToken.Add(1))
+	}
+	registration := &gstPadProbeRegistration{
+		api:   api,
+		pad:   pad,
+		token: token,
+		state: state,
+	}
+	videoProbeStates.Store(token, state)
+	id := api.gstPadAddProbe(pad, mask, callback, token, 0)
+	if id == 0 {
+		videoProbeStates.Delete(token)
+		if api.gstObjectUnref != nil {
+			api.objectUnref(pad)
+		}
+		return nil
+	}
+	registration.id.Store(uint64(id))
+	return registration
+}
+
+func (r *gstRunner) removeVideoSeekProbes() {
+	removeVideoPadProbe(&r.videoStartProbe)
+	removeVideoPadProbe(&r.videoClipProbe)
+}
+
+func removeVideoPadProbe(target **gstPadProbeRegistration) {
+	registration := *target
+	*target = nil
+	if registration == nil {
+		return
+	}
+
+	id := registration.id.Swap(0)
+	if id != 0 && registration.api != nil && registration.api.gstPadRemoveProbe != nil {
+		registration.api.gstPadRemoveProbe(registration.pad, uintptr(id))
+	}
+	videoProbeStates.Delete(registration.token)
+	if registration.api != nil && registration.api.gstObjectUnref != nil {
+		registration.api.objectUnref(registration.pad)
+	}
+}
+
+func (r *gstRunner) applyPendingVideoStart() {
+	registration := r.videoStartProbe
+	if registration == nil {
+		return
+	}
+	state, ok := registration.state.(*videoStartProbeState)
+	if !ok {
+		return
+	}
+	clockTime := state.actualNS.Swap(gstClockTimeNone)
+	if clockTime == gstClockTimeNone {
+		return
+	}
+
+	seconds := float64(clockTime) / 1_000_000_000
+	if r.reader != nil {
+		r.reader.SetTimelineOffsetNS(clockTime)
+	}
+	r.positionSeekSeconds = seconds
+	r.setPosition(seconds)
+	gstTaskDebugf(r.task, "video seek start requested=%.3fs actual=%.3fs", float64(state.requestedNS)/1_000_000_000, seconds)
+}
+
+func videoStartPadProbe(_ purego.CDecl, _ uintptr, info uintptr, userData uintptr) (result uintptr) {
+	result = gstPadProbeOK
+	defer func() {
+		if recover() != nil {
+			result = gstPadProbeOK
+		}
+	}()
+
+	value, ok := videoProbeStates.Load(userData)
+	if !ok {
+		return gstPadProbeRemove
+	}
+	state, ok := value.(*videoStartProbeState)
+	if !ok || state.registration == nil {
+		return gstPadProbeRemove
+	}
+
+	probeType := gstProbeInfoType(info)
+	if probeType&gstPadProbeTypeEventDownstream != 0 {
+		event := gstProbeInfoData(info)
+		if clockTime, ok := gstSegmentClockTime(state.registration.api, event); ok && state.accepts(clockTime) {
+			state.actualNS.Store(clockTime)
+		}
+		return gstPadProbeOK
+	}
+	if probeType&gstPadProbeTypeBuffer == 0 {
+		return gstPadProbeOK
+	}
+
+	buffer := gstProbeInfoData(info)
+	clockTime, ok := gstBufferClockTime(buffer)
+	if !ok || !state.accepts(clockTime) {
+		return gstPadProbeOK
+	}
+	state.actualNS.Store(clockTime)
+	state.registration.id.Store(0)
+	return gstPadProbeRemove
+}
+
+func (state *videoStartProbeState) accepts(clockTime uint64) bool {
+	return state.requestedNS <= state.maxBackDiffNS || clockTime >= state.requestedNS-state.maxBackDiffNS
+}
+
+func videoSegmentClipPadProbe(_ purego.CDecl, _ uintptr, info uintptr, userData uintptr) (result uintptr) {
+	result = gstPadProbeOK
+	defer func() {
+		if recover() != nil {
+			result = gstPadProbeOK
+		}
+	}()
+
+	value, ok := videoProbeStates.Load(userData)
+	if !ok {
+		return gstPadProbeRemove
+	}
+	state, ok := value.(*videoSegmentClipProbeState)
+	if !ok || state.registration == nil {
+		return gstPadProbeRemove
+	}
+
+	probeType := gstProbeInfoType(info)
+	if probeType&gstPadProbeTypeEventDownstream != 0 {
+		event := gstProbeInfoData(info)
+		switch gstEventType(event) {
+		case gstEventFlushStart:
+			state.segmentStart.Store(state.requestedStart)
+		case gstEventSegment:
+			if start, _, ok := gstTimeSegment(state.registration.api, event); ok {
+				if state.requestedStart != gstClockTimeNone && start < state.requestedStart {
+					start = state.requestedStart
+				}
+				state.segmentStart.Store(start)
+			}
+		}
+		return gstPadProbeOK
+	}
+	if probeType&gstPadProbeTypeBuffer == 0 {
+		return gstPadProbeOK
+	}
+
+	buffer := gstProbeInfoData(info)
+	pts, ok := gstBufferPTS(buffer)
+	start := state.segmentStart.Load()
+	if ok && start != gstClockTimeNone && pts < start {
+		return gstPadProbeDrop
+	}
+	return gstPadProbeOK
+}
+
+func gstProbeInfoType(info uintptr) uint32 {
+	if info == 0 {
+		return 0
+	}
+	return (*gstPadProbeInfoABI)(unsafe.Pointer(info)).probeType
+}
+
+func gstProbeInfoData(info uintptr) uintptr {
+	if info == 0 {
+		return 0
+	}
+	if runtime.GOOS == "windows" {
+		return (*gstPadProbeInfoWindowsABI)(unsafe.Pointer(info)).data
+	}
+	return (*gstPadProbeInfoUnixABI)(unsafe.Pointer(info)).data
+}
+
+func gstEventType(event uintptr) uint32 {
+	if event == 0 {
+		return 0
+	}
+	return (*gstEventABI)(unsafe.Pointer(event)).eventType
+}
+
+func gstBufferPTS(buffer uintptr) (uint64, bool) {
+	if buffer == 0 {
+		return 0, false
+	}
+	pts := (*gstBufferABI)(unsafe.Pointer(buffer)).pts
+	return pts, pts != gstClockTimeNone
+}
+
+func gstBufferClockTime(buffer uintptr) (uint64, bool) {
+	if buffer == 0 {
+		return 0, false
+	}
+	native := (*gstBufferABI)(unsafe.Pointer(buffer))
+	if native.pts != gstClockTimeNone {
+		return native.pts, true
+	}
+	if native.dts != gstClockTimeNone {
+		return native.dts, true
+	}
+	return 0, false
+}
+
+func gstSegmentClockTime(api *gstAPI, event uintptr) (uint64, bool) {
+	start, segmentTime, ok := gstTimeSegment(api, event)
+	if !ok {
+		return 0, false
+	}
+	if segmentTime != gstClockTimeNone {
+		return segmentTime, true
+	}
+	return start, start != gstClockTimeNone
+}
+
+func gstTimeSegment(api *gstAPI, event uintptr) (start uint64, segmentTime uint64, ok bool) {
+	if api == nil || event == 0 || gstEventType(event) != gstEventSegment || api.gstEventParseSegment == nil {
+		return gstClockTimeNone, gstClockTimeNone, false
+	}
+	var segmentPointer uintptr
+	api.gstEventParseSegment(event, unsafe.Pointer(&segmentPointer))
+	if segmentPointer == 0 {
+		return gstClockTimeNone, gstClockTimeNone, false
+	}
+	segment := (*gstSegmentABI)(unsafe.Pointer(segmentPointer))
+	if segment.format != gstFormatTime {
+		return gstClockTimeNone, gstClockTimeNone, false
+	}
+	return segment.start, segment.time, true
+}

--- a/server/gstreamer/video_probe_gst_test.go
+++ b/server/gstreamer/video_probe_gst_test.go
@@ -1,0 +1,231 @@
+//go:build gst && ((windows && (amd64 || arm64)) || (linux && (amd64 || arm64)) || (darwin && (amd64 || arm64)))
+
+package gstreamer
+
+import (
+	"runtime"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+func TestVideoProbePublicABILayout(t *testing.T) {
+	if unsafe.Sizeof(uintptr(0)) != 8 {
+		t.Fatal("GStreamer bridge requires a 64-bit target")
+	}
+	if got := unsafe.Sizeof(gstMiniObjectABI{}); got != 64 {
+		t.Fatalf("GstMiniObject size=%d, want 64", got)
+	}
+	if got := unsafe.Offsetof(gstBufferABI{}.pts); got != 72 {
+		t.Fatalf("GstBuffer.pts offset=%d, want 72", got)
+	}
+	if got := unsafe.Offsetof(gstBufferABI{}.dts); got != 80 {
+		t.Fatalf("GstBuffer.dts offset=%d, want 80", got)
+	}
+	if got := unsafe.Offsetof(gstEventABI{}.eventType); got != 64 {
+		t.Fatalf("GstEvent.type offset=%d, want 64", got)
+	}
+	if got := unsafe.Offsetof(gstSegmentABI{}.format); got != 24 {
+		t.Fatalf("GstSegment.format offset=%d, want 24", got)
+	}
+	if got := unsafe.Offsetof(gstSegmentABI{}.start); got != 48 {
+		t.Fatalf("GstSegment.start offset=%d, want 48", got)
+	}
+	if got := unsafe.Offsetof(gstSegmentABI{}.time); got != 64 {
+		t.Fatalf("GstSegment.time offset=%d, want 64", got)
+	}
+	if got := unsafe.Offsetof(gstPadProbeInfoWindowsABI{}.data); got != 8 {
+		t.Fatalf("Windows GstPadProbeInfo.data offset=%d, want 8", got)
+	}
+	if got := unsafe.Offsetof(gstPadProbeInfoUnixABI{}.data); got != 16 {
+		t.Fatalf("Unix GstPadProbeInfo.data offset=%d, want 16", got)
+	}
+}
+
+func TestVideoStartProbeUsesFirstAcceptableBufferTimestamp(t *testing.T) {
+	buffer := &gstBufferABI{pts: uint64(95_000_000_000), dts: gstClockTimeNone}
+	info, keepInfo := testPadProbeInfo(gstPadProbeTypeBuffer, uintptr(unsafe.Pointer(buffer)))
+	state := &videoStartProbeState{
+		requestedNS:   100_000_000_000,
+		maxBackDiffNS: 6_000_000_000,
+	}
+	state.actualNS.Store(gstClockTimeNone)
+	registration := &gstPadProbeRegistration{api: &gstAPI{}}
+	registration.id.Store(17)
+	registration.state = state
+	state.registration = registration
+	token := uintptr(videoProbeNextToken.Add(1))
+	videoProbeStates.Store(token, state)
+	t.Cleanup(func() { videoProbeStates.Delete(token) })
+
+	result := videoStartPadProbe(purego.CDecl{}, 0, info, token)
+	if result != gstPadProbeRemove {
+		t.Fatalf("probe result=%d, want REMOVE", result)
+	}
+	if got := state.actualNS.Load(); got != buffer.pts {
+		t.Fatalf("actual timestamp=%d, want %d", got, buffer.pts)
+	}
+	if got := registration.id.Load(); got != 0 {
+		t.Fatalf("probe id=%d after REMOVE, want 0", got)
+	}
+
+	runtime.KeepAlive(buffer)
+	runtime.KeepAlive(keepInfo)
+}
+
+func TestVideoStartProbeRejectsTimestampTooFarBehind(t *testing.T) {
+	state := &videoStartProbeState{
+		requestedNS:   100_000_000_000,
+		maxBackDiffNS: 6_000_000_000,
+	}
+	if state.accepts(93_999_999_999) {
+		t.Fatal("timestamp before the allowed seek window was accepted")
+	}
+	if !state.accepts(94_000_000_000) {
+		t.Fatal("timestamp at the allowed seek window was rejected")
+	}
+}
+
+func TestVideoSegmentClipProbeDropsPreSeekBuffer(t *testing.T) {
+	buffer := &gstBufferABI{pts: uint64(91_000_000_000), dts: gstClockTimeNone}
+	info, keepInfo := testPadProbeInfo(gstPadProbeTypeBuffer, uintptr(unsafe.Pointer(buffer)))
+	state := &videoSegmentClipProbeState{requestedStart: 92_000_000_000}
+	state.segmentStart.Store(92_000_000_000)
+	registration := &gstPadProbeRegistration{api: &gstAPI{}, state: state}
+	state.registration = registration
+	token := uintptr(videoProbeNextToken.Add(1))
+	videoProbeStates.Store(token, state)
+	t.Cleanup(func() { videoProbeStates.Delete(token) })
+
+	if result := videoSegmentClipPadProbe(purego.CDecl{}, 0, info, token); result != gstPadProbeDrop {
+		t.Fatalf("probe result=%d, want DROP", result)
+	}
+	buffer.pts = 92_000_000_000
+	if result := videoSegmentClipPadProbe(purego.CDecl{}, 0, info, token); result != gstPadProbeOK {
+		t.Fatalf("probe result=%d at seek boundary, want OK", result)
+	}
+
+	runtime.KeepAlive(buffer)
+	runtime.KeepAlive(keepInfo)
+}
+
+func TestVideoSegmentClipProbeUsesDownstreamTimeSegment(t *testing.T) {
+	segment := &gstSegmentABI{
+		format: gstFormatTime,
+		start:  92_759_000_000,
+		time:   92_759_000_000,
+	}
+	event := &gstEventABI{eventType: gstEventSegment}
+	info, keepInfo := testPadProbeInfo(gstPadProbeTypeEventDownstream, uintptr(unsafe.Pointer(event)))
+	api := &gstAPI{
+		gstEventParseSegment: func(_ uintptr, output unsafe.Pointer) {
+			*(*uintptr)(output) = uintptr(unsafe.Pointer(segment))
+		},
+	}
+	state := &videoSegmentClipProbeState{requestedStart: gstClockTimeNone}
+	state.segmentStart.Store(gstClockTimeNone)
+	registration := &gstPadProbeRegistration{api: api, state: state}
+	state.registration = registration
+	token := uintptr(videoProbeNextToken.Add(1))
+	videoProbeStates.Store(token, state)
+	t.Cleanup(func() { videoProbeStates.Delete(token) })
+
+	if result := videoSegmentClipPadProbe(purego.CDecl{}, 0, info, token); result != gstPadProbeOK {
+		t.Fatalf("probe result=%d, want OK", result)
+	}
+	if got := state.segmentStart.Load(); got != segment.start {
+		t.Fatalf("segment start=%d, want %d", got, segment.start)
+	}
+
+	runtime.KeepAlive(segment)
+	runtime.KeepAlive(event)
+	runtime.KeepAlive(keepInfo)
+}
+
+func TestRemoveVideoPadProbeReleasesNativeRegistration(t *testing.T) {
+	var removedPad, removedID, unrefed uintptr
+	api := &gstAPI{
+		gstPadRemoveProbe: func(pad uintptr, id uintptr) {
+			removedPad = pad
+			removedID = id
+		},
+		gstObjectUnref: func(object uintptr) {
+			unrefed = object
+		},
+	}
+	registration := &gstPadProbeRegistration{api: api, pad: 11, token: 12}
+	registration.id.Store(13)
+	videoProbeStates.Store(registration.token, struct{}{})
+	target := registration
+
+	removeVideoPadProbe(&target)
+	if target != nil {
+		t.Fatal("registration was not cleared")
+	}
+	if removedPad != 11 || removedID != 13 || unrefed != 11 {
+		t.Fatalf("removed pad/id/unref=%d/%d/%d, want 11/13/11", removedPad, removedID, unrefed)
+	}
+	if _, ok := videoProbeStates.Load(registration.token); ok {
+		t.Fatal("probe state remains registered")
+	}
+}
+
+func TestVideoStartProbeNativeCallback(t *testing.T) {
+	conf := DefaultConfig()
+	setupGStreamer(conf)
+	api, err := loadGST(conf)
+	if err != nil {
+		t.Skipf("gstreamer runtime is not available: %v", err)
+	}
+	if err := api.init(); err != nil {
+		t.Fatalf("gst init failed: %v", err)
+	}
+
+	pipeline, err := api.parseLaunch("fakesrc num-buffers=1 do-timestamp=true ! identity name=probe ! fakesink")
+	if err != nil {
+		t.Fatalf("parse launch failed: %v", err)
+	}
+	defer api.objectUnref(pipeline)
+
+	pad := gstPipelineElementPad(api, pipeline, "probe", "src")
+	if pad == 0 {
+		t.Fatal("test probe pad is not available")
+	}
+	state := &videoStartProbeState{maxBackDiffNS: uint64(time.Second)}
+	state.actualNS.Store(gstClockTimeNone)
+	registration := addVideoPadProbe(api, pad, gstPadProbeTypeBuffer, videoStartProbeCallback, state)
+	if registration == nil {
+		t.Fatal("failed to install native video probe")
+	}
+	state.registration = registration
+	defer removeVideoPadProbe(&registration)
+
+	bus := api.pipelineGetBus(pipeline)
+	if bus == 0 {
+		t.Fatal("test pipeline bus is not available")
+	}
+	defer api.objectUnref(bus)
+	defer api.elementSetState(pipeline, gstStateNull)
+	if result := api.elementSetState(pipeline, gstStatePlaying); result == gstStateChangeFailure {
+		t.Fatal("failed to start test pipeline")
+	}
+	message := api.gstBusTimedPopFiltered(bus, uint64(5*time.Second), gstMessageEOS|gstMessageError)
+	if message == 0 {
+		t.Fatal("test pipeline did not finish")
+	}
+	api.miniObjectUnref(message)
+	if got := state.actualNS.Load(); got == gstClockTimeNone {
+		t.Fatal("native callback did not observe a buffer timestamp")
+	}
+}
+
+func testPadProbeInfo(probeType uint32, data uintptr) (uintptr, any) {
+	if runtime.GOOS == "windows" {
+		info := &gstPadProbeInfoWindowsABI{probeType: probeType, data: data}
+		return uintptr(unsafe.Pointer(info)), info
+	}
+	info := &gstPadProbeInfoUnixABI{probeType: probeType, data: data}
+	return uintptr(unsafe.Pointer(info)), info
+}


### PR DESCRIPTION
## Исправления GStreamer seek

- Исправлен seek:
  - удаляются старые `ASYNC_DONE`/`EOS`;
  - после `FLUSH`-seek ожидается новый `ASYNC_DONE`;
  - контролируются `ERROR`, `EOS` и таймаут;
  - логика применяется при переиспользовании и пересоздании pipeline.

- Отсутствие `ASYNC_DONE` больше не считается самостоятельной ошибкой:
  - после таймаута проверяется фактическое состояние pipeline;
  - работа продолжается при `SUCCESS` или `NO_PREROLL`;
  - реальные bus/state ошибки по-прежнему приводят к заморозке задачи.

## Позиция после seek

- Добавлен video start probe:
  - получает фактическую позицию из `SEGMENT` event или первого подходящего video buffer;
  - отбрасывает устаревшие timestamps старого seek;
  - синхронизирует позицию задачи и timeline `Mp4BoxReader`.

- Добавлен segment clip probe для H.264/H.265 passthrough:
  - удаляет video buffers с PTS раньше границы нового сегмента;
  - предотвращает попадание кадров старой позиции в первый fMP4-сегмент.

- Усилена обработка `gst_element_query_position`:
  - недоступная или отрицательная позиция не ломает seek;
  - используется запрошенная позиция как fallback;
  - одинаковая логика применяется при старте и переиспользовании pipeline;
  - добавлен debug-лог для fallback.

## Освобождение ресурсов

- Pad probes корректно удаляются:
  - перед повторным seek;
  - при остановке и заморозке pipeline;
  - на ошибочных путях запуска;
  - вместе с registry state и native pad reference.

- При настоящей ошибке seek:
  - pipeline переводится в `NULL`;
  - освобождаются `appsink`, bus и pipeline;
  - удаляются probes и незавершённый сегмент;
  - освобождается `Mp4BoxReader`;
  - задача переводится в frozen-состояние для пересоздания pipeline при следующем запросе.

- Bus watcher защищён поколением, поэтому сообщение от старого pipeline не может заморозить новый.

## Тесты

- Добавлены тесты:
  - успешного получения фактической позиции;
  - fallback при недоступной позиции;
  - fallback при отрицательной позиции;
  - продолжения работы без `ASYNC_DONE`, если pipeline исправен;
  - заморозки и освобождения ресурсов после ошибки seek;
  - обработки video start и segment clip probes;
  - удаления native pad probe и registry state;
  - ABI-структур GStreamer на Windows/Linux.
