### PR TITLE
fix: eliminate data races on shared maps and flags

### DIFF
--- a/server/settings/dbreadcache.go
+++ b/server/settings/dbreadcache.go
@@ -79,9 +79,11 @@ func (v *DBReadCache) Set(xPath, name string, value []byte) {
 	}
 	v.dataCacheMutex.Unlock()
 
+	v.listCacheMutex.Lock()
 	if v.listCache != nil {
 		delete(v.listCache, xPath)
 	}
+	v.listCacheMutex.Unlock()
 
 	v.db.Set(xPath, name, value)
 }
@@ -135,9 +137,11 @@ func (v *DBReadCache) Rem(xPath, name string) {
 	}
 	v.dataCacheMutex.Unlock()
 
+	v.listCacheMutex.Lock()
 	if v.listCache != nil {
 		delete(v.listCache, xPath)
 	}
+	v.listCacheMutex.Unlock()
 
 	v.db.Rem(xPath, name)
 }

--- a/server/settings/dbreadcache_race_test.go
+++ b/server/settings/dbreadcache_race_test.go
@@ -1,0 +1,44 @@
+package settings
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type stubDB struct{}
+
+func (s *stubDB) CloseDB()                             {}
+func (s *stubDB) Get(xPath, name string) []byte        { return []byte("v") }
+func (s *stubDB) Set(xPath, name string, value []byte) {}
+func (s *stubDB) List(xPath string) []string           { return []string{"a", "b"} }
+func (s *stubDB) Rem(xPath, name string)               {}
+func (s *stubDB) Clear(xPath string)                   {}
+
+func TestDBReadCacheConcurrentSetList(t *testing.T) {
+	cdb := NewDBReadCache(&stubDB{})
+
+	var wg sync.WaitGroup
+	const iters = 2000
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			cdb.Set("viewed", fmt.Sprintf("n%d", i), []byte("x"))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			cdb.Rem("viewed", fmt.Sprintf("n%d", i))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			cdb.List("viewed")
+		}
+	}()
+	wg.Wait()
+}

--- a/server/torr/apihelper.go
+++ b/server/torr/apihelper.go
@@ -271,7 +271,7 @@ func SetDefSettings() {
 }
 
 func dropAllTorrent() {
-	for _, torr := range bts.torrents {
+	for _, torr := range bts.ListTorrents() {
 		torr.drop()
 		<-torr.closed
 	}

--- a/server/torr/btserver.go
+++ b/server/torr/btserver.go
@@ -29,7 +29,7 @@ type BTServer struct {
 
 	torrents map[metainfo.Hash]*Torrent
 
-	mu sync.Mutex
+	mu sync.RWMutex
 }
 
 var privateIPBlocks []*net.IPNet
@@ -258,20 +258,23 @@ func (bt *BTServer) configureProxy() error {
 }
 
 func (bt *BTServer) GetTorrent(hash torrent.InfoHash) *Torrent {
-	if torr, ok := bt.torrents[hash]; ok {
-		return torr
-	}
-	return nil
+	bt.mu.RLock()
+	torr := bt.torrents[hash]
+	bt.mu.RUnlock()
+	return torr
 }
 
 func (bt *BTServer) ListTorrents() map[metainfo.Hash]*Torrent {
 	list := make(map[metainfo.Hash]*Torrent)
+	bt.mu.RLock()
 	maps.Copy(list, bt.torrents)
+	bt.mu.RUnlock()
 	return list
 }
 
 func (bt *BTServer) RemoveTorrent(hash torrent.InfoHash) bool {
-	if torr, ok := bt.torrents[hash]; ok {
+	// Torrent.Close takes bt.mu, so the lock must be released before calling it
+	if torr := bt.GetTorrent(hash); torr != nil {
 		return torr.Close()
 	}
 	return false

--- a/server/torr/btserver_race_test.go
+++ b/server/torr/btserver_race_test.go
@@ -1,0 +1,44 @@
+package torr
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/anacrolix/torrent/metainfo"
+)
+
+// Mimics the real writers (NewTorrent insert, Torrent.Close delete), which
+// hold bt.mu, racing against the public read methods used by HTTP handlers.
+func TestBTServerTorrentsConcurrentAccess(t *testing.T) {
+	bt := NewBTS()
+
+	var wg sync.WaitGroup
+	const iters = 5000
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			var h metainfo.Hash
+			h[0] = byte(i)
+			h[1] = byte(i >> 8)
+			bt.mu.Lock()
+			bt.torrents[h] = &Torrent{}
+			bt.mu.Unlock()
+			bt.mu.Lock()
+			delete(bt.torrents, h)
+			bt.mu.Unlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		var h metainfo.Hash
+		for i := 0; i < iters; i++ {
+			h[0] = byte(i)
+			h[1] = byte(i >> 8)
+			bt.GetTorrent(h)
+			bt.ListTorrents()
+		}
+	}()
+	wg.Wait()
+}

--- a/server/torr/storage/torrstor/cache.go
+++ b/server/torr/storage/torrstor/cache.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/anacrolix/torrent"
@@ -29,13 +30,17 @@ type Cache struct {
 	pieceLength int64
 	pieceCount  int
 
-	pieces map[int]*Piece
+	// pieces content is immutable after Init; muPieces guards the map
+	// reference itself (nilled in Close), so holders of a snapshot may
+	// safely iterate it without the lock
+	pieces   map[int]*Piece
+	muPieces sync.RWMutex
 
 	readers   map[*Reader]struct{}
-	muReaders sync.Mutex
+	muReaders sync.RWMutex
 
-	isRemove bool
-	isClosed bool
+	isRemove atomic.Bool
+	isClosed atomic.Bool
 	muRemove sync.Mutex
 	torrent  *torrent.Torrent
 }
@@ -79,8 +84,24 @@ func (c *Cache) SetTorrent(torr *torrent.Torrent) {
 	c.torrent = torr
 }
 
+func (c *Cache) getPieces() map[int]*Piece {
+	c.muPieces.RLock()
+	defer c.muPieces.RUnlock()
+	return c.pieces
+}
+
+func (c *Cache) readersSnapshot() []*Reader {
+	c.muReaders.RLock()
+	defer c.muReaders.RUnlock()
+	list := make([]*Reader, 0, len(c.readers))
+	for r := range c.readers {
+		list = append(list, r)
+	}
+	return list
+}
+
 func (c *Cache) Piece(m metainfo.Piece) storage.PieceImpl {
-	if val, ok := c.pieces[m.Index()]; ok {
+	if val, ok := c.getPieces()[m.Index()]; ok {
 		return val
 	}
 	return &PieceFake{}
@@ -92,14 +113,14 @@ func (c *Cache) Close() error {
 	} else {
 		log.TLogln("Close cache for:", c.hash)
 	}
-	c.isClosed = true
+	c.isClosed.Store(true)
 
-	delete(c.storage.caches, c.hash)
+	c.storage.removeCache(c.hash)
 
 	if settings.BTsets.RemoveCacheOnDrop {
 		name := filepath.Join(settings.BTsets.TorrentsSavePath, c.hash.HexString())
 		if name != "" && name != "/" {
-			for _, v := range c.pieces {
+			for _, v := range c.getPieces() {
 				if v.dPiece != nil {
 					os.Remove(v.dPiece.name)
 				}
@@ -110,15 +131,18 @@ func (c *Cache) Close() error {
 
 	c.muReaders.Lock()
 	c.readers = nil
-	c.pieces = nil
 	c.muReaders.Unlock()
+
+	c.muPieces.Lock()
+	c.pieces = nil
+	c.muPieces.Unlock()
 
 	utils.FreeOSMemGC()
 	return nil
 }
 
 func (c *Cache) removePiece(piece *Piece) {
-	if !c.isClosed {
+	if !c.isClosed.Load() {
 		piece.Release()
 	}
 }
@@ -127,12 +151,8 @@ func (c *Cache) AdjustRA(readahead int64) {
 	if settings.BTsets.CacheSize == 0 {
 		c.capacity = readahead * 3
 	}
-	if c.Readers() > 0 {
-		c.muReaders.Lock()
-		for r := range c.readers {
-			r.SetReadahead(readahead)
-		}
-		c.muReaders.Unlock()
+	for _, r := range c.readersSnapshot() {
+		r.SetReadahead(readahead)
 	}
 }
 
@@ -142,35 +162,29 @@ func (c *Cache) GetState() *state.CacheState {
 	piecesState := make(map[int]state.ItemState, 0)
 	var fill int64 = 0
 
-	if len(c.pieces) > 0 {
-		for _, p := range c.pieces {
-			if p.Size > 0 {
-				fill += p.Size
-				piecesState[p.Id] = state.ItemState{
-					Id:        p.Id,
-					Size:      p.Size,
-					Length:    c.pieceLength,
-					Completed: p.Complete,
-					Priority:  int(c.torrent.PieceState(p.Id).Priority),
-				}
+	for _, p := range c.getPieces() {
+		if p.Size > 0 {
+			fill += p.Size
+			piecesState[p.Id] = state.ItemState{
+				Id:        p.Id,
+				Size:      p.Size,
+				Length:    c.pieceLength,
+				Completed: p.Complete,
+				Priority:  int(c.torrent.PieceState(p.Id).Priority),
 			}
 		}
 	}
 
 	readersState := make([]*state.ReaderState, 0)
 
-	if c.Readers() > 0 {
-		c.muReaders.Lock()
-		for r := range c.readers {
-			rng := r.getPiecesRange()
-			pc := r.getReaderPiece()
-			readersState = append(readersState, &state.ReaderState{
-				Start:  rng.Start,
-				End:    rng.End,
-				Reader: pc,
-			})
-		}
-		c.muReaders.Unlock()
+	for _, r := range c.readersSnapshot() {
+		rng := r.getPiecesRange()
+		pc := r.getReaderPiece()
+		readersState = append(readersState, &state.ReaderState{
+			Start:  rng.Start,
+			End:    rng.End,
+			Reader: pc,
+		})
 	}
 
 	c.filled = fill
@@ -185,7 +199,7 @@ func (c *Cache) GetState() *state.CacheState {
 }
 
 func (c *Cache) cleanPieces() {
-	if c.isRemove || c.isClosed {
+	if c.isRemove.Load() || c.isClosed.Load() {
 		return
 	}
 	
@@ -195,8 +209,8 @@ func (c *Cache) cleanPieces() {
 	}
 	defer c.muRemove.Unlock()
 	
-	c.isRemove = true
-	defer func() { c.isRemove = false }()
+	c.isRemove.Store(true)
+	defer func() { c.isRemove.Store(false) }()
 
 	remPieces := c.getRemPieces()
 	if c.filled > c.capacity {
@@ -213,13 +227,7 @@ func (c *Cache) cleanPieces() {
 }
 
 func (c *Cache) getRemPieces() []*Piece {
-	// Copy readers without a long lock
-	c.muReaders.Lock()
-	readers := make([]*Reader, 0, len(c.readers))
-	for r := range c.readers {
-		readers = append(readers, r)
-	}
-	c.muReaders.Unlock()
+	readers := c.readersSnapshot()
 
 	// Collect read ranges from active readers
 	ranges := make([]Range, 0)
@@ -235,7 +243,7 @@ func (c *Cache) getRemPieces() []*Piece {
 	fill := int64(0)
 
 	// Determine which chunks can be deleted
-	for id, p := range c.pieces {
+	for id, p := range c.getPieces() {
 		if p.Size > 0 {
 			fill += p.Size
 		}
@@ -266,8 +274,12 @@ func (c *Cache) getRemPieces() []*Piece {
 }
 
 func (c *Cache) setLoadPriority(ranges []Range) {
-	c.muReaders.Lock()
-	for r := range c.readers {
+	readers := c.readersSnapshot()
+	pieces := c.getPieces()
+	if len(readers) == 0 || pieces == nil {
+		return
+	}
+	for _, r := range readers {
 		if !r.isUse {
 			continue
 		}
@@ -277,10 +289,10 @@ func (c *Cache) setLoadPriority(ranges []Range) {
 		readerPos := r.getReaderPiece()
 		readerRAHPos := r.getReaderRAHPiece()
 		end := r.getPiecesRange().End
-		count := settings.BTsets.ConnectionsLimit / len(c.readers) // max concurrent loading blocks
+		count := settings.BTsets.ConnectionsLimit / len(readers) // max concurrent loading blocks
 		limit := 0
 		for i := readerPos; i < end && limit < count; i++ {
-			if !c.pieces[i].Complete {
+			if !pieces[i].Complete {
 				if i == readerPos {
 					c.torrent.Piece(i).SetPriority(torrent.PiecePriorityNow)
 				} else if i == readerPos+1 {
@@ -296,7 +308,6 @@ func (c *Cache) setLoadPriority(ranges []Range) {
 			}
 		}
 	}
-	c.muReaders.Unlock()
 }
 
 func (c *Cache) isIdInFileBE(ranges []Range, id int) bool {
@@ -332,8 +343,8 @@ func (c *Cache) GetUseReaders() int {
 	if c == nil {
 		return 0
 	}
-	c.muReaders.Lock()
-	defer c.muReaders.Unlock()
+	c.muReaders.RLock()
+	defer c.muReaders.RUnlock()
 	readers := 0
 	for reader := range c.readers {
 		if reader.isUse {
@@ -347,19 +358,17 @@ func (c *Cache) Readers() int {
 	if c == nil {
 		return 0
 	}
-	c.muReaders.Lock()
-	defer c.muReaders.Unlock()
-	if c.readers == nil {
-		return 0
-	}
+	c.muReaders.RLock()
+	defer c.muReaders.RUnlock()
 	return len(c.readers)
 }
 
 func (c *Cache) CloseReader(r *Reader) {
 	r.cache.muReaders.Lock()
-	r.Close()
 	delete(r.cache.readers, r)
 	r.cache.muReaders.Unlock()
+	// Reader.Close touches anacrolix internals, keep it outside muReaders
+	r.Close()
 	go c.clearPriority()
 }
 
@@ -369,17 +378,15 @@ func (c *Cache) clearPriority() {
     }
 	time.Sleep(time.Second)
 	ranges := make([]Range, 0)
-	c.muReaders.Lock()
-	for r := range c.readers {
+	for _, r := range c.readersSnapshot() {
 		r.checkReader()
 		if r.isUse {
 			ranges = append(ranges, r.getPiecesRange())
 		}
 	}
-	c.muReaders.Unlock()
 	ranges = mergeRange(ranges)
 
-	for id := range c.pieces {
+	for id := range c.getPieces() {
 		if len(ranges) > 0 {
 			if !inRanges(ranges, id) {
 				if c.torrent.PieceState(id).Priority != torrent.PiecePriorityNone {

--- a/server/torr/storage/torrstor/cache.go
+++ b/server/torr/storage/torrstor/cache.go
@@ -148,6 +148,9 @@ func (c *Cache) removePiece(piece *Piece) {
 }
 
 func (c *Cache) AdjustRA(readahead int64) {
+	if c == nil {
+		return
+	}
 	if settings.BTsets.CacheSize == 0 {
 		c.capacity = readahead * 3
 	}
@@ -202,13 +205,13 @@ func (c *Cache) cleanPieces() {
 	if c.isRemove.Load() || c.isClosed.Load() {
 		return
 	}
-	
+
 	// Protection against concurrent deletion
 	if !c.muRemove.TryLock() {
 		return // Cleanup is already in progress in another goroutine
 	}
 	defer c.muRemove.Unlock()
-	
+
 	c.isRemove.Store(true)
 	defer func() { c.isRemove.Store(false) }()
 
@@ -373,9 +376,9 @@ func (c *Cache) CloseReader(r *Reader) {
 }
 
 func (c *Cache) clearPriority() {
-	if c.torrent == nil { 
-        return 
-    }
+	if c.torrent == nil {
+		return
+	}
 	time.Sleep(time.Second)
 	ranges := make([]Range, 0)
 	for _, r := range c.readersSnapshot() {

--- a/server/torr/storage/torrstor/race_test.go
+++ b/server/torr/storage/torrstor/race_test.go
@@ -1,0 +1,93 @@
+package torrstor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/anacrolix/torrent/metainfo"
+
+	"server/settings"
+)
+
+func testInfo() *metainfo.Info {
+	return &metainfo.Info{
+		Name:        "test",
+		PieceLength: 1 << 10,
+		Length:      1 << 20,
+		Pieces:      make([]byte, (1<<10)*20),
+	}
+}
+
+func initTestSettings(t *testing.T) {
+	if settings.BTsets == nil {
+		settings.BTsets = &settings.BTSets{}
+		t.Cleanup(func() { settings.BTsets = nil })
+	}
+}
+
+// Storage.caches: anacrolix-driven Cache.Close (delete) racing
+// OpenTorrent/GetCache from other goroutines.
+func TestStorageCachesConcurrentOpenClose(t *testing.T) {
+	initTestSettings(t)
+	stor := NewStorage(1 << 20)
+
+	var wg sync.WaitGroup
+	const iters = 500
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			var h metainfo.Hash
+			h[0] = byte(i)
+			stor.OpenTorrent(testInfo(), h)
+			cache := stor.GetCache(h)
+			if cache != nil {
+				// anacrolix calls TorrentImpl.Close from its own goroutine
+				cache.Close()
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			var h metainfo.Hash
+			h[0] = byte(i)
+			stor.GetCache(h)
+			var h2 metainfo.Hash
+			h2[0] = byte(i)
+			h2[1] = 1
+			stor.OpenTorrent(testInfo(), h2)
+			stor.CloseHash(h2)
+		}
+	}()
+	wg.Wait()
+}
+
+// Cache.pieces: GetState/cleanPieces iterating while Close nils the map.
+func TestCachePiecesConcurrentStateClose(t *testing.T) {
+	initTestSettings(t)
+
+	var wg sync.WaitGroup
+	const iters = 300
+
+	for i := 0; i < iters; i++ {
+		stor := NewStorage(1 << 20)
+		var h metainfo.Hash
+		h[0] = byte(i)
+		stor.OpenTorrent(testInfo(), h)
+		cache := stor.GetCache(h)
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cache.GetState()
+			cache.cleanPieces()
+		}()
+		go func() {
+			defer wg.Done()
+			cache.Close()
+		}()
+		wg.Wait()
+	}
+}

--- a/server/torr/storage/torrstor/reader.go
+++ b/server/torr/storage/torrstor/reader.go
@@ -161,7 +161,7 @@ func (r *Reader) getOffsetRange() (int64, int64) {
 }
 
 func (r *Reader) checkReader() {
-	if time.Now().Unix() > r.lastAccess+60 && len(r.cache.readers) > 1 {
+	if time.Now().Unix() > r.lastAccess+60 && r.cache.Readers() > 1 {
 		r.readerOff()
 	} else {
 		r.readerOn()
@@ -193,13 +193,5 @@ func (r *Reader) readerOff() {
 }
 
 func (r *Reader) getUseReaders() int {
-	readers := 0
-	if r.cache != nil {
-		for reader := range r.cache.readers {
-			if reader.isUse {
-				readers++
-			}
-		}
-	}
-	return readers
+	return r.cache.GetUseReaders()
 }

--- a/server/torr/storage/torrstor/storage.go
+++ b/server/torr/storage/torrstor/storage.go
@@ -45,24 +45,37 @@ func (s *Storage) OpenTorrent(info *metainfo.Info, infoHash metainfo.Hash) (ts.T
 }
 
 func (s *Storage) CloseHash(hash metainfo.Hash) {
-	if s.caches == nil {
-		return
-	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	if ch, ok := s.caches[hash]; ok {
-		ch.Close()
+	ch, ok := s.caches[hash]
+	if ok {
 		delete(s.caches, hash)
+	}
+	s.mu.Unlock()
+	// Cache.Close must be called without s.mu held: it calls removeCache
+	// and blocks on disk/anacrolix operations
+	if ok {
+		ch.Close()
 	}
 }
 
 func (s *Storage) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	caches := make([]*Cache, 0, len(s.caches))
 	for _, ch := range s.caches {
+		caches = append(caches, ch)
+	}
+	s.caches = make(map[metainfo.Hash]*Cache)
+	s.mu.Unlock()
+	for _, ch := range caches {
 		ch.Close()
 	}
 	return nil
+}
+
+func (s *Storage) removeCache(hash metainfo.Hash) {
+	s.mu.Lock()
+	delete(s.caches, hash)
+	s.mu.Unlock()
 }
 
 func (s *Storage) GetCache(hash metainfo.Hash) *Cache {


### PR DESCRIPTION
Fixes crash `fatal error: concurrent map read and map write`.

-  `BTServer.torrents`: readers accessed the map without the mutex writers hold — now guarded by RWMutex.
- `DBReadCache.listCache`: unlocked `delete` in `Set`/`Rem` — now under `listCacheMutex`.
- `torrstor`: `pieces`/`readers`/`caches` maps and `isClosed`/`isRemove` flags synchronized (snapshots + atomics), no anacrolix calls under our locks.

Each fix is covered by a new `-race` test that reproduced the crash before the fix.