### PR TITLE
fix: trim whitespace/CR when reading trackers.txt

### DIFF
--- a/server/torr/utils/torrent.go
+++ b/server/torr/utils/torrent.go
@@ -52,6 +52,7 @@ func GetTrackerFromFile() []string {
 		list := strings.Split(string(buf), "\n")
 		var ret []string
 		for _, l := range list {
+			l = strings.TrimSpace(l)
 			if strings.HasPrefix(l, "udp") || strings.HasPrefix(l, "http") {
 				ret = append(ret, l)
 			}


### PR DESCRIPTION
Trim each line in GetTrackerFromFile before the http/udp prefix check so leading spaces and trailing CR (from CRLF-saved files) no longer drop valid trackers or leave a stray \r inside the announce URL.