### PR TITLE
feat: support fractional preload cache percentage

### DIFF
--- a/server/docs/docs.go
+++ b/server/docs/docs.go
@@ -1595,8 +1595,8 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "preloadCache": {
-                    "description": "in percent",
-                    "type": "integer"
+                    "description": "in percent, rounded to hundredths",
+                    "type": "number"
                 },
                 "readerReadAHead": {
                     "description": "in percent, 5%-100%, [...S__X__E...] [S-E] not clean",

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -1588,8 +1588,8 @@
                     "type": "integer"
                 },
                 "preloadCache": {
-                    "description": "in percent",
-                    "type": "integer"
+                    "description": "in percent, rounded to hundredths",
+                    "type": "number"
                 },
                 "readerReadAHead": {
                     "description": "in percent, 5%-100%, [...S__X__E...] [S-E] not clean",

--- a/server/docs/swagger.yaml
+++ b/server/docs/swagger.yaml
@@ -211,8 +211,8 @@ definitions:
       peersListenPort:
         type: integer
       preloadCache:
-        description: in percent
-        type: integer
+        description: in percent, rounded to hundredths
+        type: number
       readerReadAHead:
         description: in percent, 5%-100%, [...S__X__E...] [S-E] not clean
         type: integer

--- a/server/settings/btsets.go
+++ b/server/settings/btsets.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/fs"
+	"math"
 	"path/filepath"
 	"strings"
 
@@ -25,9 +26,9 @@ type TMDBConfig struct {
 
 type BTSets struct {
 	// Cache
-	CacheSize       int64 // in byte, def 64 MB
-	ReaderReadAHead int   // in percent, 5%-100%, [...S__X__E...] [S-E] not clean
-	PreloadCache    int   // in percent
+	CacheSize       int64   // in byte, def 64 MB
+	ReaderReadAHead int     // in percent, 5%-100%, [...S__X__E...] [S-E] not clean
+	PreloadCache    float64 // in percent, rounded to hundredths
 
 	// Disk
 	UseDisk           bool
@@ -128,6 +129,7 @@ func SetBTSets(sets *BTSets) {
 	if sets.PreloadCache > 100 {
 		sets.PreloadCache = 100
 	}
+	sets.PreloadCache = math.Round(sets.PreloadCache*100) / 100
 
 	if sets.TorrentsSavePath == "" {
 		sets.UseDisk = false

--- a/server/tgbot/admin_preset.go
+++ b/server/tgbot/admin_preset.go
@@ -203,7 +203,7 @@ func applyPresetKV(s *settings.BTSets, args []string, uid int64) (bool, string) 
 				ok = true
 			}
 		case "preload":
-			if v := parseInt(val); v >= 0 && v <= 100 {
+			if v, valid := parseFloat(val); valid && v >= 0 && v <= 100 {
 				s.PreloadCache = v
 				ok = true
 			}

--- a/server/tgbot/admin_settings.go
+++ b/server/tgbot/admin_settings.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	tele "gopkg.in/telebot.v4"
@@ -57,13 +58,13 @@ func sendSettingsMenuText(c tele.Context, uid int64, page string) string {
 	case "2":
 		msg += " — " + tr(uid, "settings_page2")
 		msg += "\n\n"
-		msg += fmt.Sprintf("💾 %s: %d MB · Preload %d%% · ReadAhead %d%%\n", tr(uid, "settings_limits_cache"), s.CacheSize/(1024*1024), s.PreloadCache, s.ReaderReadAHead)
+		msg += fmt.Sprintf("💾 %s: %d MB · Preload %.2f%% · ReadAhead %d%%\n", tr(uid, "settings_limits_cache"), s.CacheSize/(1024*1024), s.PreloadCache, s.ReaderReadAHead)
 		msg += fmt.Sprintf("🔌 %s: %d · Port %s · Timeout %ds\n", tr(uid, "settings_limits_connections"), s.ConnectionsLimit, portStr(s.PeersListenPort), s.TorrentDisconnectTimeout)
 		msg += fmt.Sprintf("⬇️ %s: Down %s · Up %s · Retr %s\n", tr(uid, "settings_limits_speed"), rateStr(s.DownloadRateLimit), rateStr(s.UploadRateLimit), retrackersStr(s.RetrackersMode))
 	case "2a":
 		msg += " — " + tr(uid, "settings_page2") + " · " + tr(uid, "settings_limits_cache")
 		msg += "\n\n"
-		msg += fmt.Sprintf("Cache %d MB · Preload %d%% · ReadAhead %d%%", s.CacheSize/(1024*1024), s.PreloadCache, s.ReaderReadAHead)
+		msg += fmt.Sprintf("Cache %d MB · Preload %.2f%% · ReadAhead %d%%", s.CacheSize/(1024*1024), s.PreloadCache, s.ReaderReadAHead)
 	case "2b":
 		msg += " — " + tr(uid, "settings_page2") + " · " + tr(uid, "settings_limits_connections")
 		msg += "\n\n"
@@ -577,7 +578,7 @@ func settingsCallback(c tele.Context, action string) error {
 					sets.CacheSize = int64(v) * 1024 * 1024
 				}
 			case "preload":
-				if v := parseInt(value); v >= 0 && v <= 100 {
+				if v, ok := parseFloat(value); ok && v >= 0 && v <= 100 {
 					sets.PreloadCache = v
 				}
 			case "readahead":
@@ -650,4 +651,10 @@ func parseInt(s string) int {
 		}
 	}
 	return n
+}
+
+func parseFloat(s string) (float64, bool) {
+	s = strings.TrimSuffix(strings.TrimSpace(s), "%")
+	v, err := strconv.ParseFloat(strings.ReplaceAll(s, ",", "."), 64)
+	return v, err == nil
 }

--- a/web/src/components/Settings/PrimarySettingsComponent.jsx
+++ b/web/src/components/Settings/PrimarySettingsComponent.jsx
@@ -104,6 +104,8 @@ export default function PrimarySettingsComponent({
           sliderMax={100}
           inputMin={0}
           inputMax={100}
+          step={0.01}
+          onBlurCallback={value => setPreloadCachePercentage(Math.round(value * 100) / 100)}
         />
       </div>
 


### PR DESCRIPTION
## Description

  Allow PreloadCache to use fractional percentage values with precision up to two decimal places.

  ## Use case

  For large movies over 50 GB, users storing the cache on disk may configure a large cache so the entire movie can fit in it. Currently, the minimum preload value is effectively 1%. With a large disk cache, even 1% can represent a
  significant amount of data, resulting in unnecessarily long preloading before playback starts.

  Fractional values such as 0.1% or 0.25% allow users to keep a large disk cache while configuring a much smaller preload buffer and starting playback sooner.

  ## Changes

  - Changed PreloadCache to support fractional values.
  - Added rounding to two decimal places.
  - Added a 0.01 step to the web interface.
  - Updated Telegram settings and presets to parse and display fractional values.
  - Updated the Swagger schema accordingly.