### PR TITLE
Fix for #809: limit max number of shown pieces to 8192

### DIFF
--- a/web/src/components/DialogTorrentDetailsContent/TorrentCache/index.jsx
+++ b/web/src/components/DialogTorrentDetailsContent/TorrentCache/index.jsx
@@ -38,12 +38,12 @@ const TorrentCache = ({ cache, isMini, isSnakeDebugMode }) => {
   const pieceSizeWithGap = pieceSize + gapBetweenPieces
   const piecesInOneRow = Math.floor(canvasWidth / pieceSizeWithGap)
 
-  let shotCacheMap
+  let shortCacheMap
   if (isMini) {
     const preloadPiecesAmount = Math.round(cache.Capacity / cache.PiecesLength - 1)
-    shotCacheMap = getShortCacheMap({ cacheMap, preloadPiecesAmount, piecesInOneRow })
+    shortCacheMap = getShortCacheMap({ cacheMap, preloadPiecesAmount, piecesInOneRow })
   }
-  const source = isMini ? shotCacheMap : cacheMap
+  const source = isMini ? shortCacheMap : cacheMap
   const startingXPoint = Math.ceil((canvasWidth - pieceSizeWithGap * piecesInOneRow) / 2) // needed to center grid
   const height = Math.ceil(source.length / piecesInOneRow) * pieceSizeWithGap
 

--- a/web/src/components/DialogTorrentDetailsContent/TorrentCache/index.jsx
+++ b/web/src/components/DialogTorrentDetailsContent/TorrentCache/index.jsx
@@ -37,10 +37,12 @@ const TorrentCache = ({ cache, isMini, isSnakeDebugMode }) => {
 
   const pieceSizeWithGap = pieceSize + gapBetweenPieces
   const piecesInOneRow = Math.floor(canvasWidth / pieceSizeWithGap)
+  const maxShortCachePiecesAmount = 8192
 
   let shortCacheMap
   if (isMini) {
-    const preloadPiecesAmount = Math.round(cache.Capacity / cache.PiecesLength - 1)
+    const preloadPiecesAmount = Math.min(Math.round(cache.Capacity / cache.PiecesLength - 1),
+                                         maxShortCachePiecesAmount)
     shortCacheMap = getShortCacheMap({ cacheMap, preloadPiecesAmount, piecesInOneRow })
   }
   const source = isMini ? shortCacheMap : cacheMap


### PR DESCRIPTION
Fix for #809: limit max number of shown pieces to 8192. Issue usually appears with torrents with over 10k pieces, so 8192 should be good enough in all cases.