### PR TITLE
fix: avoid curl|sudo bash hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,26 @@ Run `TorrServer-windows-amd64.exe`.
 
 #### Linux
 
-Run in console
+**Interactive install** (download first — preferred):
 
 ```bash
-curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh -o installTorrServerLinux.sh && chmod 755 installTorrServerLinux.sh && sudo bash ./installTorrServerLinux.sh
+```
+
+Other interactive one-liners (avoid `curl | sudo bash`, which hangs on modern `sudo` with `use_pty`):
+
+```bash
+sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh)"
+```
+
+```bash
+sudo bash <(curl -fsSL https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh)
+```
+
+**Non-interactive** pipe is fine when there are no prompts:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh | sudo bash -s -- --install --silent
 ```
 
 The script supports interactive and non-interactive installation, configuration, updates, and removal. When running the script interactively, you can:
@@ -77,12 +93,6 @@ The script supports interactive and non-interactive installation, configuration,
 - **GStreamer build**: For releases 141.10+ on amd64/arm64, choose the gst build with transcoding support (or pass `--gst`)
 - **Reconfigure**: If TorrServer is already installed, you'll be prompted to reconfigure settings (port, auth, read-only mode, logging, BBR)
 - **Uninstall**: Type `Delete` (or `Удалить` in Russian) to uninstall TorrServer
-
-**Download first and set execute permissions:**
-
-```bash
-curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh -o installTorrServerLinux.sh && chmod 755 installTorrServerLinux.sh
-```
 
 **Command-line examples:**
 


### PR DESCRIPTION
## Summary

- Interactive `curl … | sudo bash` hangs after the language prompt on Ubuntu 26.04 (Resolute).
- Root cause is modern `sudo` running the command under a PTY (`use_pty`, on by default): script bytes and interactive `read </dev/tty` share the same terminal path, so prompts stop making progress.
- On Ubuntu 26 the default `sudo` is **sudo-rs** (`/usr/lib/cargo/bin/sudo`), which also enables `use_pty` by default and has known issues with piped stdin + TTY input. Classic `sudo.ws` remains available via `update-alternatives`.
- Update README install docs: prefer download-then-run; document safe interactive one-liners (`bash -c "$(curl …)"`, `bash <(curl …)`); keep `curl | sudo bash -s -- --install --silent` for non-interactive use.

## Problem

```bash
curl -s https://raw.githubusercontent.com/YouROK/TorrServer/master/installTorrServerLinux.sh | sudo bash
```

Shows the language prompt, accepts input visually, then hangs (no title banner / next prompt). Cancel works.

```bash
curl -s … -o installTorrServerLinux.sh && sudo bash ./installTorrServerLinux.sh
```

Works normally.

## Environment

- Ubuntu 26.04 (Resolute)
- `sudo -V` → `sudo-rs 0.2.13-0ubuntu1`
- `readlink -f $(command -v sudo)` → `/usr/lib/cargo/bin/sudo`
- `update-alternatives --display sudo` → sudo-rs priority 50 (default), `sudo.ws` priority 40

## Why it hangs

Since sudo 1.9.14 (and in sudo-rs by default), `use_pty` runs the command in a pseudo-terminal so a malicious child cannot inject into / retain the user’s real TTY ([sudo upgrade notes](https://www.sudo.ws/docs/upgrade/), [sudo-rs sudoers `use_pty`](https://github.com/trifectatechfoundation/sudo-rs/blob/main/docs/man/sudoers.5.md)).

With `curl | sudo bash`:

1. Script content is fed through sudo’s PTY path.
2. Installer prompts use `read </dev/tty` (same controlling PTY under `use_pty`).
3. Script delivery and interactive input contend → hang after the first prompt.

Related: [sudo-rs#1263](https://github.com/trifectatechfoundation/sudo-rs/issues/1263) (piping into sudo-rs), [sudo-project/sudo#344](https://github.com/sudo-project/sudo/issues/344) (stdin/PTY side effects).

The installer itself is fine when run from a file; the broken pattern is interactive `curl | sudo bash` under PTY-mode sudo.