### PR TITLE
fix(torrstor): stop clearPriority from wiping a new reader's piece priorities

### DIFF
--- a/server/torr/storage/torrstor/cache.go
+++ b/server/torr/storage/torrstor/cache.go
@@ -82,6 +82,32 @@ func (c *Cache) Init(info *metainfo.Info, hash metainfo.Hash) {
 	for i := 0; i < c.pieceCount; i++ {
 		c.pieces[i] = NewPiece(i, c)
 	}
+
+	go c.priorityWatchdog()
+}
+
+// priorityWatchdog re-arms piece priorities while readers are active.
+//
+// setLoadPriority is only reached through the cache cleanup path, which is
+// driven by piece reads and writes (see mempiece.go and diskpiece.go). Should
+// priorities ever end up cleared while a reader still needs data, nothing is
+// downloaded, so no piece I/O happens, so cleanup never runs and the
+// priorities are never restored - the torrent stalls indefinitely with peers
+// connected. Re-arming them periodically breaks that cycle regardless of how
+// the priorities were lost.
+func (c *Cache) priorityWatchdog() {
+	for {
+		time.Sleep(5 * time.Second)
+		if c.isClosed.Load() {
+			return
+		}
+		if c.torrent == nil {
+			continue
+		}
+		if c.GetUseReaders() > 0 {
+			c.getRemPieces()
+		}
+	}
 }
 
 func (c *Cache) SetTorrent(torr *torrent.Torrent) {

--- a/server/torr/storage/torrstor/cache.go
+++ b/server/torr/storage/torrstor/cache.go
@@ -42,7 +42,11 @@ type Cache struct {
 	isRemove atomic.Bool
 	isClosed atomic.Bool
 	muRemove sync.Mutex
-	torrent  *torrent.Torrent
+	// muPrio serializes clearPriority and setLoadPriority so that the priority
+	// reset of a reader that has just closed cannot wipe the priorities a
+	// freshly created reader has already set.
+	muPrio  sync.Mutex
+	torrent *torrent.Torrent
 }
 
 func NewCache(capacity int64, storage *Storage) *Cache {
@@ -282,6 +286,8 @@ func (c *Cache) setLoadPriority(ranges []Range) {
 	if len(readers) == 0 || pieces == nil {
 		return
 	}
+	c.muPrio.Lock()
+	defer c.muPrio.Unlock()
 	for _, r := range readers {
 		if !r.isUse {
 			continue
@@ -379,7 +385,12 @@ func (c *Cache) clearPriority() {
 	if c.torrent == nil {
 		return
 	}
-	time.Sleep(time.Second)
+	// This used to sleep for a second before clearing priorities. A reader
+	// created during that window could have its PiecePriorityNow/Next/Readahead
+	// reset to None right after setLoadPriority had assigned them, starving the
+	// player. A mutex provides the same ordering without the race window.
+	c.muPrio.Lock()
+	defer c.muPrio.Unlock()
 	ranges := make([]Range, 0)
 	for _, r := range c.readersSnapshot() {
 		r.checkReader()


### PR DESCRIPTION
## Problem

A torrent can end up permanently stalled: `stat` stays `Torrent working`, peers remain connected, but `download_speed` is 0 and the reader position never advances. The player shows an endless spinner. The only recovery is dropping and re-adding the torrent, which rebuilds the cache.

Captured on a live server (Apple TV client, 512 MB RAM cache), sampled every 2 seconds:

```
20:48:05  readers=1  speed=0.00 MB/s  peers=7  seeds=6  reader_pos=6321   <- stuck
20:48:07  readers=2  speed=9.08 MB/s  peers=8  seeds=6  reader_pos=6324   <- a second reader appears, traffic resumes
20:48:23  readers=1  speed=0.00 MB/s  peers=9  seeds=7  reader_pos=6342   <- stuck again, stays stuck
```

## Mechanism

`CloseReader` starts `clearPriority` as a goroutine, and that function sleeps for a second before doing anything:

```go
func (c *Cache) CloseReader(r *Reader) {
	...
	go c.clearPriority()
}

func (c *Cache) clearPriority() {
	...
	time.Sleep(time.Second)
	ranges := ... // reader snapshot taken AFTER the sleep
	for id := range c.getPieces() {
		if len(ranges) > 0 {
			...
		} else {
			// no readers seen -> reset every piece to PiecePriorityNone
		}
	}
}
```

Players that issue many short Range requests create a new reader every couple of seconds — `Stream` sets `Connection: close`, so each Range request is a fresh TCP connection and a fresh reader. A reader therefore routinely appears inside that one-second window. If the sleeping goroutine wakes up at a moment when the previous reader is already unregistered and the new one is not yet visible, `ranges` is empty, the `else` branch is taken, and **every** piece is reset to `PiecePriorityNone` — including the priorities `setLoadPriority` has just assigned to the new reader.

The resulting state is self-sustaining. `setLoadPriority` is only reachable through `getRemPieces`, which is only called from `cleanPieces`, which is only triggered by piece I/O (`mempiece.go:25,54`, `diskpiece.go:72`). With every priority at `None` nothing is downloaded, so no piece I/O occurs, so cleanup never runs, so the priorities are never restored.

## Fix

**Commit 1** replaces the sleep with a mutex shared by `clearPriority` and `setLoadPriority`. The ordering guarantee is the same and the race window is gone.

**Commit 2** adds a per-cache ticker that re-arms priorities every 5 seconds while at least one reader is in use, so the cycle cannot persist even if priorities are lost some other way. It returns once the cache is closed, and the work it performs is what already runs on every reader close. Happy to drop this commit if you consider it redundant.

## Testing

- `gofmt` and `go vet` clean; `go test -race -count=2 ./server/torr/storage/torrstor/` passes.
- Built for `darwin/arm64` and deployed on the server where the stall was observed; streaming verified afterwards at 16.8 MB/s.
- **No deterministic reproducer.** The failure is timing dependent, and attempts to force it in a lab did not trigger it: a long sequential read never stalls, and 6 MB Range requests every 2 seconds against a ~180-peer swarm are masked by the swarm re-fetching faster than the reset hurts. Both patched and unpatched binaries delivered an identical 420/420 MB in those runs, so the change is at least regression-free, but the diagnosis rests on the code path above plus the live capture rather than on a repro script.

## Prior art

#739 identified the same `clearPriority` sleep race and proposed the same mutex approach as part of a larger change set. That PR is closed and unmerged; this one isolates the stall fix so it can be reviewed on its own.
