### PR TITLE
Add support for M3U file index by ID

### DIFF
--- a/server/web/api/m3u.go
+++ b/server/web/api/m3u.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -93,6 +94,7 @@ func allPlayList(c *gin.Context) {
 func playList(c *gin.Context) {
 	hash, _ := c.GetQuery("hash")
 	_, fromlast := c.GetQuery("fromlast")
+	index := c.Query("index")
 	if hash == "" {
 		c.AbortWithError(http.StatusBadRequest, errors.New("hash is empty"))
 		return
@@ -113,7 +115,7 @@ func playList(c *gin.Context) {
 	}
 
 	host := utils.GetScheme(c) + "://" + utils.GetHost(c)
-	list := getM3uList(tor.Status(), host, fromlast)
+	list := getM3uList(tor.Status(), host, fromlast, index)
 	list = "#EXTM3U\n" + list
 	name := strings.ReplaceAll(c.Param("fname"), `/`, "") // strip starting / from param
 	if name == "" {
@@ -139,10 +141,20 @@ func sendM3U(c *gin.Context, name, hash string, m3u string) {
 	http.ServeContent(c.Writer, c.Request, name, time.Now(), bytes.NewReader([]byte(m3u)))
 }
 
-func getM3uList(tor *state.TorrentStatus, host string, fromLast bool) string {
+func getM3uList(tor *state.TorrentStatus, host string, fromLast bool, startIndex string) string {
 	m3u := ""
 	from := 0
-	if fromLast {
+	if startIndex != "" {
+		id, err := strconv.Atoi(startIndex)
+		if err == nil {
+			for i, f := range tor.FileStats {
+				if f.Id == id {
+					from = i
+					break
+				}
+			}
+		}
+	} else if fromLast {
 		pos := searchLastPlayed(tor)
 		if pos != -1 {
 			from = pos

--- a/server/web/api/stream.go
+++ b/server/web/api/stream.go
@@ -189,7 +189,7 @@ func stream(c *gin.Context) {
 		} else if !strings.HasSuffix(strings.ToLower(name), ".m3u") && !strings.HasSuffix(strings.ToLower(name), ".m3u8") {
 			name += ".m3u"
 		}
-		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+utils2.GetHost(c), fromlast)
+		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+utils2.GetHost(c), fromlast, indexStr)
 		sendM3U(c, name, tor.Hash().HexString(), m3ulist)
 		return
 	} else
@@ -309,7 +309,7 @@ func streamNoAuth(c *gin.Context) {
 		} else if !strings.HasSuffix(strings.ToLower(name), ".m3u") && !strings.HasSuffix(strings.ToLower(name), ".m3u8") {
 			name += ".m3u"
 		}
-		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+utils2.GetHost(c), fromlast)
+		m3ulist := "#EXTM3U\n" + getM3uList(tor.Status(), utils2.GetScheme(c)+"://"+utils2.GetHost(c), fromlast, indexStr)
 		sendM3U(c, name, tor.Hash().HexString(), m3ulist)
 		return
 	} else


### PR DESCRIPTION
We recently added support for Kodi to interact with `m3u` via `ACTION_VIEW` on Android, the next official version of Kodi will include m3u support via `ACTION_VIEW.`

Generating playlists using the `m3u` index ID will help ensure compatibility and the correct sending of `m3u` playlists to Kodi.

https://github.com/xbmc/xbmc/pull/28661

Update playlist m3u generation to use torrent file IDs in stream URLs, improving compatibility with media players and external clients using indexed playback.

- The functionality has been tested and verified
When the stable version of Kodi 22 is released, I'll reopen these two pull requests. I don't want them to affect others who are using Kodi 21.3
- Added support for the `TorrServe` client: https://github.com/YouROK/TorrServe/pull/135
- Added support for the `Lampa` Android app: https://github.com/lampa-app/LAMPA/pull/68

I've also adapted a version of stable `Kodi 21.3 `with `m3u` support via the `ACTION_VIEW` intent.
For those interested, I'm attaching the stable version of `Kodi 21.3` here, which includes `m3u` support via the `ACTION_VIEW` intent.

Everything works the same way as on VIMU: click on an episode, and the playlist for the current episode opens in KODI.

Here you'll find the `TorrServe` client version compatible with `Kodi 21.3` build with `m3u` support via intent.
https://drive.google.com/drive/folders/1nU3RAdauS7VMxUVbjAQLNofliY5qoxwP?usp=sharing

PS: This build also support external subtitles from m3u `#EXTVLCOPT:input-slave=`, such as .srt and .ass. Kodi 22 will support them - I added this feature recently. https://github.com/YouROK/TorrServer/issues/40