### PR TITLE
fix(torznab): populate Tracker field from <jackettindexer>

### DIFF
--- a/server/torznab/torznab.go
+++ b/server/torznab/torznab.go
@@ -31,6 +31,7 @@ type TorznabItem struct {
 	Description string             `xml:"description"`
 	PubDate     string             `xml:"pubDate"`
 	Size        int64              `xml:"size"`
+	Indexer     string             `xml:"jackettindexer"`
 	Enclosure   []TorznabEnclosure `xml:"enclosure"`
 	Attributes  []TorznabAttribute `xml:"attr"`
 }
@@ -111,6 +112,7 @@ func searchOne(host, key, query string) []*models.TorrentDetails {
 			Title:      item.Title,
 			Name:       item.Title, // Use Title as Name for now
 			Link:       item.Link,
+			Tracker:    item.Indexer,
 			CreateDate: parseDate(item.PubDate),
 		}
 


### PR DESCRIPTION
Fixes #822

`TorznabItem` had no field for the `<jackettindexer>` element that Jackett
returns in every `<item>`, so it was never parsed and `Tracker` was always
empty in the `/torznab/search/` response.

Adds the field and maps it to `models.TorrentDetails.Tracker`.
Torznab providers that don't emit this element are unaffected —
the field stays empty as before.

Verified against Jackett v0.24.2330 using the aggregate indexer.

Before:

```
$ curl -s "http://<server>:8090/torznab/search/?query=<query>" | grep -o '"Tracker":"[^"]*"'
"Tracker":""
"Tracker":""
```

After:

```
"Tracker":"RuTracker.org"
"Tracker":"Kinozal"
"Tracker":"seleZen"
```
