### PR TITLE
Fix TrackTimecode API reset when marking files as viewed

### DIFF
--- a/server/torr/stream.go
+++ b/server/torr/stream.go
@@ -103,10 +103,18 @@ func (t *Torrent) Stream(fileID int, req *http.Request, resp http.ResponseWriter
 		}
 	}
 
-	// Mark as viewed
+	// Mark as viewed without resetting existing TimeCode
+	var timecode float64
+	for _, v := range sets.ListViewed(t.Hash().HexString()) {
+		if v.FileIndex == fileID {
+			timecode = v.TimeCode
+			break
+	    }
+	}
 	sets.SetViewed(&sets.Viewed{
 		Hash:      t.Hash().HexString(),
 		FileIndex: fileID,
+		TimeCode:  timecode,
 	})
 
 	// Set response headers


### PR DESCRIPTION
- Fix an issue where marking a file as viewed would reset its existing playback `TrackTimecode API`

The fix preserves the current `TimeCode` from the existing viewed entry and reuses it when updating the viewed state.

I’ve just adapted the “Add support for saving and restoring playback position in TorrServer via the TrackTimecode API” changes for the `TorrSpy` `Kodi` addon and `Lampa`, and everything is working well.

https://github.com/vadyur/script.service.torrspy/pull/5
https://github.com/yumata/lampa-source/pull/367
