### PR TITLE
fix(torrfs): sanitize path separators in torrent and category names

### DIFF
--- a/server/torrfs/categorydir.go
+++ b/server/torrfs/categorydir.go
@@ -14,9 +14,7 @@ type CategoryDir struct {
 }
 
 func NewCategoryDir(category string) *CategoryDir {
-	if category == "" {
-		category = "other"
-	}
+	category = categoryName(category)
 	d := &CategoryDir{
 		info: info{
 			name:  category,
@@ -29,6 +27,22 @@ func NewCategoryDir(category string) *CategoryDir {
 	return d
 }
 
+func categoryName(category string) string {
+	category = SanitizeName(category)
+	if category == "" {
+		return "other"
+	}
+	return category
+}
+
+func torrentName(t *torr.Torrent) string {
+	name := SanitizeName(t.Title)
+	if name == "" {
+		name = t.Hash().String()
+	}
+	return name
+}
+
 func (d *CategoryDir) Stat() (fs.FileInfo, error) {
 	return d.info, nil
 }
@@ -37,16 +51,14 @@ func (d *CategoryDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	nodes := []fs.DirEntry{}
 	torrs := torr.ListTorrent()
 	for _, t := range torrs {
-		if t.Category == "" {
-			t.Category = "other"
+		if categoryName(t.Category) != d.Name() {
+			continue
 		}
-		if t.Category == d.Name() {
-			if settings.BTsets.ShowFSActiveTorr && !t.GotInfo() {
-				continue
-			}
-			td := NewTorrDir(nil, t.Title, t)
-			nodes = append(nodes, td)
+		if settings.BTsets.ShowFSActiveTorr && !t.GotInfo() {
+			continue
 		}
+		td := NewTorrDir(nil, torrentName(t), t)
+		nodes = append(nodes, td)
 	}
 
 	return nodes, nil

--- a/server/torrfs/name.go
+++ b/server/torrfs/name.go
@@ -1,0 +1,27 @@
+package torrfs
+
+import (
+	"strings"
+)
+
+// SanitizeName makes a torrent/category name usable as a filesystem node name.
+func SanitizeName(name string) string {
+	name = strings.Map(func(r rune) rune {
+		switch {
+		case r == '/' || r == '\\':
+			return '_'
+		case r < 0x20 || r == 0x7f:
+			return -1
+		default:
+			return r
+		}
+	}, name)
+
+	name = strings.TrimSpace(name)
+
+	// "." and ".." are collapsed by path.Clean and break path resolution
+	if name == "" || name == "." || name == ".." {
+		return ""
+	}
+	return name
+}

--- a/server/torrfs/node.go
+++ b/server/torrfs/node.go
@@ -28,7 +28,7 @@ func Open(d INode, name string) (fs.File, error) {
 	}
 	arr := strings.Split(trimPath, "/")
 	if len(arr) == 0 {
-		return nil, fs.ErrNotExist
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 	}
 
 	dirs, _ := d.ReadDir(-1)
@@ -39,5 +39,5 @@ func Open(d INode, name string) (fs.File, error) {
 		}
 	}
 
-	return nil, fs.ErrNotExist
+	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 }

--- a/server/torrfs/rootdir.go
+++ b/server/torrfs/rootdir.go
@@ -48,18 +48,13 @@ func (d *RootDir) Stat() (fs.FileInfo, error) {
 
 func (d *RootDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	torrs := torr.ListTorrent()
-	cats := map[string]struct{}{}
 	nodes := map[string]INode{}
 
 	for _, torrent := range torrs {
-		cats[torrent.Category] = struct{}{}
-	}
-
-	for cat := range cats {
-		if cat == "" {
-			cat = "other"
+		cat := categoryName(torrent.Category)
+		if _, ok := nodes[cat]; !ok {
+			nodes[cat] = NewCategoryDir(cat)
 		}
-		nodes[cat] = NewCategoryDir(cat)
 	}
 
 	var entries []fs.DirEntry

--- a/server/torrfs/torrdir.go
+++ b/server/torrfs/torrdir.go
@@ -36,22 +36,25 @@ func NewTorrDir(parent INode, name string, torrent *torr.Torrent) *TorrDir {
 
 func (d *TorrDir) ReadDir(n int) ([]fs.DirEntry, error) {
 	if d.Torrent() == nil {
-		return nil, fs.ErrInvalid
+		return nil, &fs.PathError{Op: "readdir", Path: d.Name(), Err: fs.ErrInvalid}
 	}
 	// соединяемся с торрентом при чтении директории торрента
 	if !d.Torrent().GotInfo() {
 		hash := d.Torrent().Hash().String()
+		gotInfo := false
 		for i := 0; i < settings.BTsets.TorrentDisconnectTimeout*2; i++ {
 			tor := torr.GetTorrent(hash)
 			if tor.GotInfo() {
 				d.SetTorrent(tor)
+				gotInfo = true
 				break
 			}
 
 			time.Sleep(time.Millisecond * 500)
 		}
-		if d.Torrent() == nil {
-			return nil, fs.ErrNotExist
+		// without metadata the torrent file list is unavailable
+		if !gotInfo {
+			return nil, &fs.PathError{Op: "readdir", Path: d.Name(), Err: fs.ErrNotExist}
 		}
 	}
 

--- a/server/torrfs/torrfile.go
+++ b/server/torrfs/torrfile.go
@@ -45,7 +45,7 @@ func NewTorrFile(parent INode, name string, file *torrent.File) *TorrFile {
 func (f *TorrFile) Open(name string) (fs.File, error) {
 	r := f.Torrent().NewReader(f.file)
 	if r == nil {
-		return nil, fs.ErrInvalid
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
 	}
 	if sets.BTsets.ResponsiveMode {
 		r.SetResponsive()

--- a/server/torrfs/webdav/webdav.go
+++ b/server/torrfs/webdav/webdav.go
@@ -128,11 +128,11 @@ func (f *roFile) Read(p []byte) (int, error) {
 	defer f.mu.Unlock()
 
 	if f.f == nil {
-		return 0, fs.ErrClosed
+		return 0, &fs.PathError{Op: "read", Path: f.name, Err: fs.ErrClosed}
 	}
 	r, ok := f.f.(io.Reader)
 	if !ok {
-		return 0, fs.ErrInvalid
+		return 0, &fs.PathError{Op: "read", Path: f.name, Err: fs.ErrInvalid}
 	}
 	return r.Read(p)
 }
@@ -160,7 +160,7 @@ func (f *roFile) Readdir(count int) ([]os.FileInfo, error) {
 	defer f.mu.Unlock()
 
 	if f.f == nil {
-		return nil, fs.ErrClosed
+		return nil, &fs.PathError{Op: "readdir", Path: f.name, Err: fs.ErrClosed}
 	}
 
 	fi, err := fs.Stat(f.fsys, f.name)
@@ -168,7 +168,7 @@ func (f *roFile) Readdir(count int) ([]os.FileInfo, error) {
 		return nil, err
 	}
 	if !fi.IsDir() {
-		return nil, fs.ErrInvalid
+		return nil, &fs.PathError{Op: "readdir", Path: f.name, Err: fs.ErrInvalid}
 	}
 
 	if f.dirList == nil {


### PR DESCRIPTION
A slash in a torrent title leaked straight into the WebDAV/FUSE node name. WebDAV builds child paths with path.Join(dir, entry.Name()), so such a title became an extra nesting level that no longer resolved when walking the tree back. torrfs then returned a bare fs.ErrNotExist, and golang.org/x/net/webdav aborts the whole multistatus response with a 500 on any walk error that is not a *fs.PathError - so a single bad title broke PROPFIND for the entire category, and for the whole tree at Depth: infinity.

- add SanitizeName: replace / and \ with _, drop control characters and reject "." / ".." which path.Clean would collapse
- apply it to torrent titles and categories, falling back to the info hash when the title is empty
- wrap torrfs errors in *fs.PathError so an unresolvable path degrades to 404 instead of aborting the PROPFIND response
- replace the dead post-wait "d.Torrent() == nil" check with a gotInfo flag: d.torr is proven non-nil earlier and is only ever reassigned to a non-nil value, so on metadata timeout execution fell through to Torrent.Files(), which dereferences a nil slice pointer and panics