### PR TITLE
Return a JSON body when /torrents rejects a request

### DIFF
--- a/server/web/api/torrents.go
+++ b/server/web/api/torrents.go
@@ -31,6 +31,13 @@ type torrReqJS struct {
 	SaveToDB bool   `json:"save_to_db,omitempty"`
 }
 
+// abortWithJSONError aborts the request with a JSON body. gin's
+// AbortWithError only sets the status and records the error, leaving the
+// response empty, which breaks clients that parse the body as JSON.
+func abortWithJSONError(c *gin.Context, code int, err error) {
+	c.AbortWithStatusJSON(code, gin.H{"error": err.Error()})
+}
+
 // torrents godoc
 //
 //	@Summary		Handle torrents informations
@@ -49,10 +56,9 @@ func torrents(c *gin.Context) {
 	var req torrReqJS
 	err := c.ShouldBindJSON(&req)
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		abortWithJSONError(c, http.StatusBadRequest, err)
 		return
 	}
-	c.Status(http.StatusBadRequest)
 	switch req.Action {
 	case "add":
 		{
@@ -82,12 +88,17 @@ func torrents(c *gin.Context) {
 		{
 			wipeTorrents(c)
 		}
+	default:
+		{
+			abortWithJSONError(c, http.StatusBadRequest,
+				errors.Errorf("unknown action: %q", req.Action))
+		}
 	}
 }
 
 func addTorrent(req torrReqJS, c *gin.Context) {
 	if req.Link == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("link is empty"))
+		abortWithJSONError(c, http.StatusBadRequest, errors.New("link is empty"))
 		return
 	}
 
@@ -102,7 +113,7 @@ func addTorrent(req torrReqJS, c *gin.Context) {
 		torrSpec, torrsHash, err = utils.ParseTorrsHash(req.Link)
 		if err != nil {
 			log.TLogln("error parse torrshash:", err)
-			c.AbortWithError(http.StatusBadRequest, err)
+			abortWithJSONError(c, http.StatusBadRequest, err)
 			return
 		}
 		if req.Title == "" {
@@ -118,7 +129,7 @@ func addTorrent(req torrReqJS, c *gin.Context) {
 		torrSpec, err = utils.ParseLink(req.Link)
 		if err != nil {
 			log.TLogln("error parse link:", err)
-			c.AbortWithError(http.StatusBadRequest, err)
+			abortWithJSONError(c, http.StatusBadRequest, err)
 			return
 		}
 	}
@@ -126,7 +137,7 @@ func addTorrent(req torrReqJS, c *gin.Context) {
 	tor, err := torr.AddTorrent(torrSpec, req.Title, req.Poster, req.Data, req.Category)
 	if err != nil {
 		log.TLogln("error add torrent:", err)
-		c.AbortWithError(http.StatusInternalServerError, err)
+		abortWithJSONError(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -160,7 +171,7 @@ func addTorrent(req torrReqJS, c *gin.Context) {
 
 func getTorrent(req torrReqJS, c *gin.Context) {
 	if req.Hash == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("hash is empty"))
+		abortWithJSONError(c, http.StatusBadRequest, errors.New("hash is empty"))
 		return
 	}
 	tor := torr.GetTorrent(req.Hash)
@@ -175,7 +186,7 @@ func getTorrent(req torrReqJS, c *gin.Context) {
 
 func setTorrent(req torrReqJS, c *gin.Context) {
 	if req.Hash == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("hash is empty"))
+		abortWithJSONError(c, http.StatusBadRequest, errors.New("hash is empty"))
 		return
 	}
 	torr.SetTorrent(req.Hash, req.Title, req.Poster, req.Category, req.Data)
@@ -184,7 +195,7 @@ func setTorrent(req torrReqJS, c *gin.Context) {
 
 func remTorrent(req torrReqJS, c *gin.Context) {
 	if req.Hash == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("hash is empty"))
+		abortWithJSONError(c, http.StatusBadRequest, errors.New("hash is empty"))
 		return
 	}
 	torr.RemTorrent(req.Hash)
@@ -212,7 +223,7 @@ func listTorrents(c *gin.Context) {
 
 func dropTorrent(req torrReqJS, c *gin.Context) {
 	if req.Hash == "" {
-		c.AbortWithError(http.StatusBadRequest, errors.New("hash is empty"))
+		abortWithJSONError(c, http.StatusBadRequest, errors.New("hash is empty"))
 		return
 	}
 	torr.DropTorrent(req.Hash)

--- a/server/web/api/torrents_test.go
+++ b/server/web/api/torrents_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The /torrents handler is documented as `@Produce json`, but its failure
+// paths used to abort with an empty body, so any client calling .json() on
+// the response got a parse error instead of the reason it failed.
+func TestTorrentsRejectionsCarryJSONBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"malformed json", `{`},
+		{"wrong type on an optional key", `{"action":"add","link":"magnet:?xt=urn:btih:x","title":123}`},
+		{"unknown action", `{"action":"bogus"}`},
+		{"missing action", `{}`},
+		{"add without link", `{"action":"add"}`},
+		{"get without hash", `{"action":"get"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := gin.New()
+			router.POST("/torrents", torrents)
+
+			req := httptest.NewRequest(http.MethodPost, "/torrents", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+			if w.Body.Len() == 0 {
+				t.Fatal("response body is empty; clients parsing it as JSON fail")
+			}
+			var payload struct {
+				Error string `json:"error"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("body is not valid JSON (%v): %q", err, w.Body.String())
+			}
+			if payload.Error == "" {
+				t.Errorf("no error message in body: %q", w.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #569.

The `/torrents` handler is documented as `@Produce json`, but its failure paths call gin's `AbortWithError`, which sets the status and records the error without ever writing a body. A client that parses the response as JSON gets a syntax error on an empty string rather than the reason its request failed, which is the `JSON.parse: unexpected character at line 1 column 1` in the report.

The action switch also had no `default` branch. It leaned on a bare `c.Status(StatusBadRequest)` set before the switch, so an unknown or missing action likewise answered 400 with an empty body.

### Measured

Same requests against the current release image (`ghcr.io/yourok/torrserver:latest`, MatriX.144.1) and a build of this branch, as `status|bytes`:

| request | release | this branch |
| --- | --- | --- |
| `{"action":"add","link":"magnet:…","title":123}` | `400\|0` | `400\|93` |
| `{"action":"bogus"}` | `400\|0` | `400\|37` |
| `{}` | `400\|0` | `400\|32` |
| `{"action":"add"}` | `400\|0` | `400\|25` |
| `{"action":"rem"}` | `400\|0` | `400\|25` |
| `{"action":"list"}` | `200\|2` | `200\|2` |

Bodies now say what went wrong, for example:

```json
{"error":"json: cannot unmarshal number into Go struct field torrReqJS.title of type string"}
{"error":"unknown action: \"bogus\""}
```

Success paths are untouched: `list` is byte-identical, adding a magnet still returns the same status object, and the web UI loads and lists normally against the patched binary.

### Tests

`server/web/api/torrents_test.go` covers six rejection shapes and asserts each answers 400 with a non-empty, parseable JSON body. All six fail on master with `response body is empty` and pass with the change.

`go build ./...`, `gofmt` and `go test ./web/api/` are clean. `go vet` reports one pre-existing finding in `web/api/utils/link.go:74` that is present on clean master and untouched here.

### Left alone deliberately

The same `AbortWithError` pattern exists in eleven other files under `server/web/`, and `set`/`rem`/`drop`/`wipe` answer success with an empty `200`. Both are the same class of thing, but changing them is a repo-wide response-contract decision that felt like yours to make, and it would bury a small fix. Happy to follow up if you want it applied more widely.
