### PR TITLE
feat(torznab): add Prowlarr indexer tracker support

### DIFF
--- a/server/torznab/torznab.go
+++ b/server/torznab/torznab.go
@@ -32,6 +32,7 @@ type TorznabItem struct {
 	PubDate     string             `xml:"pubDate"`
 	Size        int64              `xml:"size"`
 	Indexer     string             `xml:"jackettindexer"`
+	Prowlarr    string             `xml:"prowlarrindexer"`
 	Enclosure   []TorznabEnclosure `xml:"enclosure"`
 	Attributes  []TorznabAttribute `xml:"attr"`
 }
@@ -130,6 +131,9 @@ func searchOne(host, key, categories string, categoryType settings.CategoryType,
 
 	var results []*models.TorrentDetails
 	for _, item := range torznabResp.Channel.Items {
+		if item.Indexer == "" {
+			item.Indexer = item.Prowlarr
+		}
 		detail := &models.TorrentDetails{
 			Title:      item.Title,
 			Name:       item.Title, // Use Title as Name for now


### PR DESCRIPTION
Adds support for the `prowlarrindexer` field in Torznab search results.

Prowlarr returns the indexer name using:

```xml
<prowlarrindexer>Your Tracker</prowlarrindexer>
```

The indexer name is now used as the torrent tracker, with fallback support for both Jackett and Prowlarr.

## Test

```bash
curl -s "http://<server>:8090/torznab/search/?query=<query>" | grep -o '"Tracker":"[^"]*"'
```

Expected output:

```text
"Tracker":"Your Tracker"
```
